### PR TITLE
Fix DateInput, Checkbox, Switch alignment/styling issues

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -756,6 +756,10 @@
             "lastDate": {
               "type": "string",
               "description": "The last selectable date in the calendar. Use format YYYY-MM-DD"
+            },
+            "showCalendarIcon": {
+              "type": "boolean",
+              "description": "Whether we should show (default) or hide the calendar icon. Selecting the text will still open the calendar picker"
             }
           }
         }

--- a/lib/widget/form_checkbox.dart
+++ b/lib/widget/form_checkbox.dart
@@ -101,18 +101,28 @@ class OnOffState extends FormFieldWidgetState<OnOffWidget> {
     // add leading/trailing text + the actual widget
     List<Widget> children = [];
     if (widget._controller.leadingText != null) {
-      children.add(Text(widget._controller.leadingText!));
+      children.add(
+        Flexible(
+          child: Text(
+            widget._controller.leadingText!,
+            style: formFieldTextStyle,
+          )
+        )
+      );
     }
-    children.add(widget.getType() == OnOffType.toggle ?
-        Switch(
-          value: widget._controller.value,
-          onChanged: isEnabled() ? (value) => onToggle(value) : null) :
-        Checkbox(
-          value: widget._controller.value,
-          onChanged: isEnabled() ? (bool? value) => onToggle(value ?? false) : null)
+    children.add(widget.getType() == OnOffType.toggle
+        ? aSwitch
+        : aCheckbox
     );
     if (widget._controller.trailingText != null) {
-      children.add(Text(widget._controller.trailingText!));
+      children.add(
+        Expanded(
+          child: Text(
+            widget._controller.trailingText!,
+            style: formFieldTextStyle,
+          )
+        )
+      );
     }
 
     // wraps around FormField to get all the form effects
@@ -126,7 +136,9 @@ class OnOffState extends FormFieldWidgetState<OnOffWidget> {
       },
       builder: (FormFieldState<bool> field) {
         return InputDecorator(
+
             decoration: inputDecoration.copyWith(
+              contentPadding: EdgeInsets.zero,
               border: InputBorder.none,
               enabledBorder: InputBorder.none,
               disabledBorder: InputBorder.none,
@@ -139,6 +151,26 @@ class OnOffState extends FormFieldWidgetState<OnOffWidget> {
 
         );
       }
+    );
+  }
+
+  /// we adjust the hit area of the checkbox here. 40px is smaller than the default (48px)
+  /// but it seem to be reasonable for touch device, plus the alignment inside
+  /// form is much better (align well with the rest of the input widgets)
+  Widget get aCheckbox {
+    return SizedBox(
+        width: 40,
+        height: 40,
+        child: Checkbox(
+            value: widget._controller.value,
+            onChanged: isEnabled() ? (bool? value) => onToggle(value ?? false) : null
+        )
+    );
+  }
+  Widget get aSwitch {
+    return Switch(
+      value: widget._controller.value,
+      onChanged: isEnabled() ? (value) => onToggle(value) : null
     );
   }
 }

--- a/lib/widget/form_date.dart
+++ b/lib/widget/form_date.dart
@@ -40,6 +40,7 @@ class Date extends StatefulWidget with Invokable, HasController<DateController, 
       'initialValue': (value) => _controller.value ??= Utils.getDate(value),
       'firstDate': (value) => _controller.firstDate = Utils.getDate(value),
       'lastDate': (value) => _controller.lastDate = Utils.getDate(value),
+      'showCalendarIcon': (shouldShow) => _controller.showCalendarIcon = Utils.optionalBool(shouldShow),
       'onChange': (definition) => _controller.onChange = Utils.getAction(definition, initiator: this)
     };
   }
@@ -54,6 +55,7 @@ class DateController extends FormFieldController {
   DateTime? firstDate;
   DateTime? lastDate;
 
+  bool? showCalendarIcon;
   EnsembleAction? onChange;
 
 }
@@ -79,21 +81,14 @@ class DateState extends FormFieldWidgetState<Date> {
       builder: (FormFieldState<DateTime> field) {
         return InputDecorator(
           decoration: inputDecoration.copyWith(
-            border: InputBorder.none,
-            enabledBorder: InputBorder.none,
-            disabledBorder: InputBorder.none,
-            focusedBorder: InputBorder.none,
-            errorText: field.errorText
+            errorText: field.errorText,
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              InkWell(
-                child: nowBuildWidget(),
-                onTap: isEnabled() ? () => _selectDate(context) : null
-              )
-            ]
-          )
+          child: InkWell(
+              child: nowBuildWidget(),
+              onTap: isEnabled() ? () => _selectDate(context) : null
+            )
+
+
         );
       }
     );
@@ -136,17 +131,18 @@ class DateState extends FormFieldWidgetState<Date> {
 
 
   Widget nowBuildWidget() {
-    Widget rtn = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        const Icon(Icons.calendar_month_rounded, color: Colors.black54),
-        const SizedBox(width: 5),
-        Text(
-          selectedValue,
-          style: TextStyle(fontSize: widget._controller.fontSize?.toDouble())
-        )
-      ],
-    );
+    Widget rtn = Text(selectedValue, style: formFieldTextStyle);
+    if (widget._controller.showCalendarIcon != false) {
+      rtn = Row(
+        children: [
+          Expanded(
+            child: rtn
+          ),
+          Icon(Icons.calendar_month_rounded, color: formFieldTextStyle.color?.withOpacity(.5)),
+        ]
+      );
+    }
+
     if (!isEnabled()) {
       rtn = Opacity(
         opacity: .5,

--- a/lib/widget/form_helper.dart
+++ b/lib/widget/form_helper.dart
@@ -80,7 +80,6 @@ abstract class FormFieldWidgetState<W extends HasController>
       FormFieldController myController = widget
           .controller as FormFieldController;
       return InputDecoration(
-          contentPadding: const EdgeInsets.only(left: 10),
           floatingLabelBehavior: FloatingLabelBehavior.always,
           labelText: shouldShowLabel() ? myController.label : null,
           hintText: myController.hintText,
@@ -117,5 +116,18 @@ abstract class FormFieldWidgetState<W extends HasController>
       return formState.widget.shouldFormFieldShowLabel;
     }
     return true;
+  }
+
+  /// return the TextStyle for a form field (TextField, ....)
+  TextStyle get formFieldTextStyle {
+    // MaterialSpec - titleMedium maps to FormField textStyle
+    TextStyle textStyle = Theme.of(context).textTheme.titleMedium ?? const TextStyle();
+    if (widget.controller is FormFieldController) {
+      return textStyle.copyWith(
+        fontSize: (widget.controller as FormFieldController).fontSize?.toDouble()
+        // TODO: expose color, ... for all form fields here
+      );
+    }
+    return textStyle;
   }
 }

--- a/test/widget/checkbox_switch_test.dart
+++ b/test/widget/checkbox_switch_test.dart
@@ -1,0 +1,62 @@
+import 'package:ensemble/widget/form_checkbox.dart';
+import 'package:ensemble/widget/form_date.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import 'test_utils.dart';
+
+/// Tests for Checkbox and Switch widget
+void main() {
+  testWidgets("checkbox", (tester) async {
+    EnsembleCheckbox widget = EnsembleCheckbox();
+    widget.setProperty('leadingText', 'hello');
+    widget.setProperty('trailingText', 'there');
+
+    await tester.pumpWidget(TestUtils.wrapTestWidget(widget));
+    Finder checkboxFinder = find.byType(Checkbox);
+
+    // make sure leading/trailing text are shown properly
+    expect(find.text('hello'), findsOneWidget);
+    expect(find.text('there'), findsOneWidget);
+    expect(find.byType(Text), findsNWidgets(2));
+    expect(checkboxFinder, findsOneWidget);
+
+    // checkbox should start out unchecked
+    Checkbox checkbox = tester.firstWidget(checkboxFinder);
+    expect(checkbox.value, false);
+
+    // tap and confirm the checkbox is now checked
+    await tester.tap(checkboxFinder);
+    await tester.pump();
+    checkbox = tester.firstWidget(checkboxFinder);    // need to get the widget's new reference or it won't work
+    expect(checkbox.value, true);
+  });
+
+  testWidgets("switch", (tester) async {
+    EnsembleSwitch widget = EnsembleSwitch();
+    widget.setProperty('value', true);
+    widget.setProperty('trailingText', 'hello');
+
+    await tester.pumpWidget(TestUtils.wrapTestWidget(widget));
+    Finder switchFinder = find.byType(Switch);
+
+    // should only find 1 instance of Text which is the trailing text
+    expect(find.text('hello'), findsOneWidget);
+    expect(find.byType(Text), findsOneWidget);
+    expect(switchFinder, findsOneWidget);
+
+    // initially switch is ON
+    Switch aSwitch = tester.firstWidget(switchFinder);
+    expect(aSwitch.value, true);
+
+    // tap and confirm switch is now OFF
+    await tester.tap(switchFinder);
+    await tester.pump();
+    aSwitch = tester.firstWidget(switchFinder);
+    expect(aSwitch.value, false);
+  });
+
+
+
+}


### PR DESCRIPTION
- DateInput, Checkbox and Switch now properly use the global styles.
- DateInput can hide its calendar icon
- Checkbox / Switch text now properly wrap.
- Add Checkbox/Switch widget tests.