### PR TITLE
File upload for flutter web

### DIFF
--- a/lib/framework/data_context.dart
+++ b/lib/framework/data_context.dart
@@ -653,19 +653,21 @@ class FileData with Invokable {
 }
 
 class File {
-  File(this.name, this.ext, this.size, this.path);
+  File(this.name, this.ext, this.size, this.path, this.bytes);
 
   File.fromPlatformFile(PlatformFile file):
     name = file.name,
     ext = file.extension,
     size = file.size,
-    path = file.path;
+    path = kIsWeb ? null : file.path,
+    bytes = file.bytes;
 
 
   final String name;
   final int size;
   final String? ext;
   final String? path;
+  final Uint8List? bytes;
 
 
   Map<String, dynamic> toJson() {
@@ -674,6 +676,7 @@ class File {
       'extension': ext,
       'size': size,
       'path': path,
+      'bytes': bytes,
     };
   }
 } 

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -328,12 +328,12 @@ class ScreenController {
         final response = await UploadUtils.uploadFiles(
           action.uploadUrl!, 
           selectedFiles,
-          onDone: action.onComplete == null ? null : () => executeAction(context, action.onComplete!),
           onError: action.onError == null ? null : (error) => executeAction(context, action.onError!),
         );
         if (response == null || action.id == null || scopeManager == null) return;
         final fileData = scopeManager.dataContext.getContextById(action.id!) as FileData;
         fileData.setResponse(response);
+        if (action.onComplete != null) executeAction(context, action.onComplete!);
       });
     }
     else if (action is NavigateBack) {

--- a/lib/util/upload_utils.dart
+++ b/lib/util/upload_utils.dart
@@ -29,8 +29,16 @@ class UploadUtils {
     final multipartFiles = <http.MultipartFile>[];
   
     for (var file in files) {
-      if (file.path == null) continue;
-      final multipartFile = await http.MultipartFile.fromPath('files', file.path!);
+      http.MultipartFile? multipartFile;
+
+      if (file.path != null) {
+        multipartFile = await http.MultipartFile.fromPath('files', file.path!);
+      } else if ( file.bytes != null ) {
+        multipartFile = http.MultipartFile.fromBytes('files', file.bytes!, filename: file.name);
+      } else {
+        continue;
+      }
+
       multipartFiles.add(multipartFile);
     }
 

--- a/lib/util/upload_utils.dart
+++ b/lib/util/upload_utils.dart
@@ -48,7 +48,6 @@ class UploadUtils {
       final response = await request.send();
       
       if (response.statusCode >= 200 && response.statusCode <= 300) {
-        onDone?.call();
         final res = await http.Response.fromStream(response);
         return Response(res);
       } else {


### PR DESCRIPTION
Ticket: #243 
For flutter web, instead of using `file.path` we can use `file.bytes`. [reference](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)