### PR TITLE
Ability to override field name

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1513,6 +1513,14 @@
                 "$ref": "#/$defs/Action-payload",
                 "description": "Execute an Action when uploader fails with error(s)"
               },
+              "inputs": {
+                "type": "array",
+                "description": "Define the list of input names that upload API accepts"
+              },
+              "fieldName" : {
+                "type": "string",
+                "description": "Field name that your server is expecting (default files)"
+              },
               "options": {
                 "type": "object",
                 "properties": {

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -195,7 +195,7 @@ class FileUploadAction extends EnsembleAction {
     this.onComplete,
     this.onError,
     required this.uploadApi,
-    this.fieldName,
+    required this.fieldName,
     this.maxFileSize,
     this.overMaxFileSizeMessage,
   }) : super(inputs: inputs);
@@ -207,7 +207,7 @@ class FileUploadAction extends EnsembleAction {
   EnsembleAction? onComplete;
   EnsembleAction? onError;
   String uploadApi;
-  String? fieldName;
+  String fieldName;
   double? maxFileSize;
   String? overMaxFileSizeMessage;
 }

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -195,6 +195,7 @@ class FileUploadAction extends EnsembleAction {
     this.onComplete,
     this.onError,
     required this.uploadApi,
+    this.fieldName,
     this.maxFileSize,
     this.overMaxFileSizeMessage,
   }) : super(inputs: inputs);
@@ -206,6 +207,7 @@ class FileUploadAction extends EnsembleAction {
   EnsembleAction? onComplete;
   EnsembleAction? onError;
   String uploadApi;
+  String? fieldName;
   double? maxFileSize;
   String? overMaxFileSizeMessage;
 }

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -362,6 +362,7 @@ class ScreenController {
           dataContext,
           selectedFiles,
           onError: action.onError == null ? null : (error) => executeAction(context, action.onError!),
+          fieldName: action.fieldName,
         );
         if (response == null || action.id == null || scopeManager == null) return;
         final fileData = scopeManager.dataContext.getContextById(action.id!) as FileData;

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -358,11 +358,11 @@ class ScreenController {
           }
         }
         final response = await UploadUtils.uploadFiles(
-          apiDefinition, 
-          dataContext,
-          selectedFiles,
-          onError: action.onError == null ? null : (error) => executeAction(context, action.onError!),
+          api: apiDefinition, 
+          eContext: dataContext,
+          files: selectedFiles,
           fieldName: action.fieldName,
+          onError: action.onError == null ? null : (error) => executeAction(context, action.onError!),
         );
         if (response == null || action.id == null || scopeManager == null) return;
         final fileData = scopeManager.dataContext.getContextById(action.id!) as FileData;

--- a/lib/util/upload_utils.dart
+++ b/lib/util/upload_utils.dart
@@ -10,15 +10,14 @@ typedef OnErrorCallback = void Function(dynamic error);
 
 class UploadUtils {
   
-  static Future<Response?> uploadFiles(
-      YamlMap api, 
-      DataContext eContext,
-      List<File> files, 
-      {
-        ProgressCallback? progressCallback,
-        OnDoneCallback? onDone,
-        OnErrorCallback? onError,
-        String? fieldName,
+  static Future<Response?> uploadFiles({
+      required YamlMap api,
+      required DataContext eContext,
+      required List<File> files,
+      required String fieldName,
+      ProgressCallback? progressCallback,
+      OnDoneCallback? onDone,
+      OnErrorCallback? onError,
       }
     ) async {
 
@@ -49,9 +48,9 @@ class UploadUtils {
       http.MultipartFile? multipartFile;
 
       if (file.path != null) {
-        multipartFile = await http.MultipartFile.fromPath(fieldName ?? 'files', file.path!);
+        multipartFile = await http.MultipartFile.fromPath(fieldName, file.path!);
       } else if ( file.bytes != null ) {
-        multipartFile = http.MultipartFile.fromBytes(fieldName ?? 'files', file.bytes!, filename: file.name);
+        multipartFile = http.MultipartFile.fromBytes(fieldName, file.bytes!, filename: file.name);
       } else {
         continue;
       }

--- a/lib/util/upload_utils.dart
+++ b/lib/util/upload_utils.dart
@@ -18,6 +18,7 @@ class UploadUtils {
         ProgressCallback? progressCallback,
         OnDoneCallback? onDone,
         OnErrorCallback? onError,
+        String? fieldName,
       }
     ) async {
 
@@ -48,9 +49,9 @@ class UploadUtils {
       http.MultipartFile? multipartFile;
 
       if (file.path != null) {
-        multipartFile = await http.MultipartFile.fromPath('files', file.path!);
+        multipartFile = await http.MultipartFile.fromPath(fieldName ?? 'files', file.path!);
       } else if ( file.bytes != null ) {
-        multipartFile = http.MultipartFile.fromBytes('files', file.bytes!, filename: file.name);
+        multipartFile = http.MultipartFile.fromBytes(fieldName ?? 'files', file.bytes!, filename: file.name);
       } else {
         continue;
       }

--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -316,6 +316,7 @@ class Utils {
             onError: Utils.getAction(payload['onError']),
             uploadApi: payload['uploadApi'],
             inputs: inputs,
+            fieldName: Utils.optionalString(payload['fieldName']),
             maxFileSize: Utils.optionalDouble(payload['options']?['maxFileSize']),
             overMaxFileSizeMessage: Utils.optionalString(payload['options']?['overMaxFileSizeMessage']),
          );

--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -316,7 +316,7 @@ class Utils {
             onError: Utils.getAction(payload['onError']),
             uploadApi: payload['uploadApi'],
             inputs: inputs,
-            fieldName: Utils.optionalString(payload['fieldName']),
+            fieldName: Utils.getString(payload['fieldName'], fallback: 'files'),
             maxFileSize: Utils.optionalDouble(payload['options']?['maxFileSize']),
             overMaxFileSizeMessage: Utils.optionalString(payload['options']?['overMaxFileSizeMessage']),
          );


### PR DESCRIPTION
Added new property to uploadFiles fieldName, so users can override default field name in multipart/form-data from 'files' to whatever their servers are expecting.