### PR TITLE
#305 Fixed binding listeners being removed when widget state is disposed

### DIFF
--- a/ensemble/integration_tests/default/API Bindings.yaml
+++ b/ensemble/integration_tests/default/API Bindings.yaml
@@ -1,0 +1,54 @@
+View:
+  styles:
+    useSafeArea: true
+  onLoad:
+    action: invokeAPI
+    name: getPeople
+
+  Column:
+    children:
+      - Text:
+          text: count ${getPeople.body.results.length}
+      - CustomWidget:
+          inputs:
+            people: ${getPeople.body.results}
+            borderColor: black
+
+CustomWidget:
+  inputs: [people, borderColor]
+  Column:
+    styles:
+      # https://github.com/EnsembleUI/ensemble/issues/305 borderColor makes the Column recreate the child Text.
+      borderColor: ${borderColor}
+    children:
+      - Text:
+          text: "First person: ${people[0].name.first}"
+
+API:
+  getPeople:
+    uri: https://randomuser.me/api/?results=2
+    method: GET
+    onResponse: |-
+      //@code
+      // we need consistent output, so hardcode the result
+      response.body = {
+        "results": [
+          {
+            "gender": "female",
+            "name": {
+              "title": "Miss",
+              "first": "Rachel",
+              "last": "Miles"
+            }
+          },
+          {
+            "gender": "male",
+            "name": {
+              "title": "Mr",
+              "first": "Peter",
+              "last": "Parker"
+            }
+          }
+        ]
+      }
+      

--- a/ensemble/integration_tests/default/Widget Bindings.yaml
+++ b/ensemble/integration_tests/default/Widget Bindings.yaml
@@ -1,0 +1,37 @@
+View:
+  title: Home
+  Column:
+    styles: { mainAxis: center }
+    children:
+      # input
+      - TextInput:
+          id: myInput
+          value: first
+      # button to take focus away from TextInput
+      - Button:
+          label: Just a button
+
+      # outputs
+      - Text:
+          text: ${myInput.value}
+      - Custom:
+          inputs:
+            txt: ${myInput.value}
+
+
+Custom:
+  inputs: [txt]
+  Column:
+    children:
+      - Text:
+          text: "Custom Widget: ${txt}"
+      - Custom2:
+          inputs:
+            text: ${txt}
+
+
+
+Custom2:
+  inputs: [text]
+  Text:
+    text: "Custom Custom Widget: ${text}"

--- a/integration_test/defaultapp_test.dart
+++ b/integration_test/defaultapp_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:ensemble/widget/button.dart';
+import 'package:ensemble/widget/form_textfield.dart';
+import 'package:ensemble/widget/text.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import '../integration_test/framework/main.dart' as testApp;
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+
+  group('Default App Tests', () {
+
+    /// test that binding to a TextInput works properly in the same scope
+    /// and also in a custom widget's scope
+    testWidgets("Bindings to widget's value", (tester) async {
+      testApp.initTestApp(definition: 'Widget Bindings');
+      await tester.pumpAndSettle();
+
+      // TextInput has initial value of 'first'
+      // so first make sure our EnsembleText is correctly bind to that
+      Finder text = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('first')
+      );
+      expect(text, findsOneWidget);
+
+      // Custom Widget's text should also bind to the same value
+      Finder customText = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('Custom Widget: first')
+      );
+      expect(customText, findsOneWidget);
+
+      // nested Custom Widget also bind correctly
+      Finder customCustomText = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('Custom Custom Widget: first')
+      );
+      expect(customCustomText, findsOneWidget);
+
+      // now put the cursor inside TextInput and changes its value
+      Finder textInput = find.byType(TextInput);
+      await tester.enterText(textInput, 'second');
+      // just tap somewhere so TextInput's focus out is fired
+      await tester.tap(find.byType(Button));
+      await tester.pumpAndSettle();
+
+      // confirm the text now says second
+      text = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('second')
+      );
+      expect(text, findsOneWidget);
+
+      // and custom widget's text also updates
+      customText = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('Custom Widget: second')
+      );
+      expect(customText, findsOneWidget);
+
+      // also nested custom widget
+      customCustomText = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('Custom Custom Widget: second')
+      );
+      expect(customCustomText, findsOneWidget);
+    });
+
+    /// test bindings to API is working properly
+    testWidgets('API Binding', (tester) async {
+      testApp.initTestApp(definition: 'API Bindings');
+      await tester.pumpAndSettle();
+
+      // before the API loads
+      Finder count = find.descendant(
+        of: find.byType(EnsembleText),
+        matching: find.text('count ')
+      );
+      expect(count, findsOneWidget);
+
+      Finder person = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('First person: ')
+      );
+      expect(person, findsOneWidget);
+
+      // after API loads
+      await tester.pump(const Duration(seconds: 2));
+
+      // data should reflected
+      count = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('count 2')
+      );
+      expect(count, findsOneWidget);
+
+      person = find.descendant(
+          of: find.byType(EnsembleText),
+          matching: find.text('First person: Rachel')
+      );
+      expect(person, findsOneWidget);
+
+    });
+
+
+  });
+
+
+
+
+}

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -22,9 +22,6 @@ class EnsembleApp extends StatefulWidget {
     // initialize once
     GetStorage.init();
     Device().initDeviceInfo();
-    ErrorWidget.builder = (FlutterErrorDetails errorDetails) {
-      return ErrorScreen(errorDetails);
-    };
   }
 
   final ScreenPayload? screenPayload;

--- a/lib/framework/scope.dart
+++ b/lib/framework/scope.dart
@@ -53,6 +53,18 @@ class ScopeManager extends IsScopeManager with ViewBuilder, PageBindingManager {
   /// call when the screen is being disposed
   /// TODO: consolidate listeners, location, eventBus, ...
   void dispose() {
+    // clear out all event listeners
+    eventBus.destroy();
+
+    // cancel all timers bound to Invokable
+    pageData._timerMap.forEach((_, timer) {
+      timer.cancel();
+    });
+    // cancel all standalone timers
+    for (var timer in pageData._timers) {
+      timer.cancel();
+    }
+
     // cancel the screen's location listener
     pageData.locationListener?.cancel();
   }
@@ -452,21 +464,6 @@ mixin PageBindingManager on IsScopeManager {
   void dispatch(ModelChangeEvent event) {
     //log("EventBus ${eventBus.hashCode} firing $event");
     eventBus.fire(event);
-  }
-
-  /// upon widget being disposed, we need to remove all listeners associated with it
-  void disposeWidget(Invokable widget) {
-    // remove all listeners associated with this Invokable
-    if (listenerMap[widget] != null) {
-      for (StreamSubscription listener in listenerMap[widget]!.values) {
-        listener.cancel();
-      }
-      //log("Binding : Disposing ${widget}(${widget.id ?? ''}). Removing ${listenerMap[widget]!.length} listeners");
-      listenerMap.remove(widget);
-    }
-    // remove all Timers associated with this Invokable
-    removeTimerByWidget(widget);
-
   }
 
   /// unique but repeatable hash (within the same session) of the provided keys

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -526,7 +526,6 @@ class PageState extends State<Page>{
     //log('Disposing View ${widget.hashCode}');
     _scopeManager.dispose();
     //_scopeManager.debugListenerMap();
-    _scopeManager.eventBus.destroy();
     super.dispose();
   }
 

--- a/lib/framework/widget/widget.dart
+++ b/lib/framework/widget/widget.dart
@@ -51,15 +51,6 @@ abstract class WidgetState<W extends HasController> extends BaseWidgetState<W> {
     _scopeManager = DataScopeWidget.getScope(context);
   }
 
-  // notify our ScopeManager that the widget is being disposed
-  @override
-  void dispose() {
-    if (widget is Invokable) {
-      _scopeManager?.disposeWidget(widget as Invokable);
-    }
-    super.dispose();
-  }
-
   @override
   void changeState() {
     super.changeState();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^1.0.0
 
 flutter:
@@ -89,6 +91,10 @@ flutter:
 
   assets:
     - assets/images/
+
+    # integration tests (TODO - exclude from build)
+    - ensemble/integration_tests/
+    - ensemble/integration_tests/default/
 
   fonts:
     # semi-custom fonts

--- a/test/invokable_test.dart
+++ b/test/invokable_test.dart
@@ -21,7 +21,7 @@ void main() {
       'skills': 'flying',
       'superhero': true,
       'first_name': 'Peter',
-      'last-name': 'Parker',
+      'lastName': 'Parker',
       'has_power_since': 1654841398,
       'power_for_hire': 6400.12,
       'date_1': 'Thu, 16 Jun 2022 17:01:08 GMT-0700',
@@ -79,12 +79,12 @@ void main() {
   test('Parsing expressions', () {
     // empty context returns original
     DataContext context = DataContext(buildContext: MockBuildContext(), initialMap: {});
-    expect(context.eval(r'${blah}'), null);
-    expect(context.eval(r'${result.name}'), null);
+    expect(context.eval(r'${blah}'), '');
+    expect(context.eval(r'${result.name}'), '');
 
     context = getBaseContext();
     expect(context.eval(r'${result.first_name}'), 'Peter');
-    expect(context.eval(r'${result.last-name}'), 'Parker');
+    expect(context.eval(r'${result.lastName}'), 'Parker');
     expect(context.eval(r'${result.name}'), 'Peter Parker');
 
     expect(context.eval('hello'), 'hello');
@@ -106,11 +106,11 @@ void main() {
   test("Widget getters", () {
     DataContext context = getDataAndWidgetContext();
     
-    //expect(context.eval(r'$(myText.text) there $(result.name)'), 'Hello there Peter Parker');
+    expect(context.eval(r'${myText.text} there ${result.name}'), 'Hello there Peter Parker');
     //expect(context.eval(r'$(myTextField.value)'), 'Ronald');
 
     // invalid getter
-    expect(context.eval(r'${myTextField.what}'), null);
+    expect(context.eval(r'${myTextField.what}'), '');
   });
 
   /*test("Container getters", () {


### PR DESCRIPTION
Widgets from our YAML is being re-used for optimization. This creates a situation where multiple State objects can be created for the same Widget. This is normally OK, except we try to remove the binding listeners when a widget state is disposed (which is a problem when the old State is removed, but the widget remains with its other States).

The solution is to only remove all binding listeners when the Page is disposed (e.g. navigating away), since these YAML widgets are always alive as long as the page exists.

Also added integration tests for Binding.



For more information, see https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html. Copied snippet below:
```
The framework calls [createState](https://api.flutter.dev/flutter/widgets/StatefulWidget/createState.html) whenever it inflates a [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html), which means that multiple [State](https://api.flutter.dev/flutter/widgets/State-class.html) objects might be associated with the same [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) if that widget has been inserted into the tree in multiple places. Similarly, if a [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) is removed from the tree and later inserted in to the tree again, the framework will call [createState](https://api.flutter.dev/flutter/widgets/StatefulWidget/createState.html) again to create a fresh [State](https://api.flutter.dev/flutter/widgets/State-class.html) object, simplifying the lifecycle of [State](https://api.flutter.dev/flutter/widgets/State-class.html) objects.
```