### PR TITLE
#364 Throw language error for unsupported widget during build phase

### DIFF
--- a/lib/framework/widget/error_screen.dart
+++ b/lib/framework/widget/error_screen.dart
@@ -3,7 +3,7 @@ import 'package:ensemble/util/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 
-class ErrorScreen extends StatelessWidget {
+class ErrorScreen extends StatefulWidget {
   const ErrorScreen._init(this.errorText, {this.recovery, this.detailError});
 
   factory ErrorScreen(Object error, {Key? key}) {
@@ -21,16 +21,13 @@ class ErrorScreen extends StatelessWidget {
         detail.add(myError.detailError!);
       }
 
-      return ErrorScreen._init(
-        myError.error,
-        recovery: myError.recovery,
-        detailError: join(myError.detailError, stackTrace?.toString())
-      );
+      return ErrorScreen._init(myError.error,
+          recovery: myError.recovery,
+          detailError: join(myError.detailError, stackTrace?.toString()));
     } else if (myError is Error) {
-      return ErrorScreen._init(
-          myError.toString(),
-          detailError: join(myError.stackTrace?.toString(), stackTrace?.toString())
-      );
+      return ErrorScreen._init(myError.toString(),
+          detailError:
+              join(myError.stackTrace?.toString(), stackTrace?.toString()));
     }
     return ErrorScreen._init(
       "Unknown Error occurred.",
@@ -41,68 +38,6 @@ class ErrorScreen extends StatelessWidget {
   final String errorText;
   final String? recovery;
   final String? detailError;
-
-  @override
-  Widget build(BuildContext context) {
-    List<Widget> children = [];
-
-    // main error and graphics
-    children.add(Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Text(
-          Utils.randomize(["Oh Snap", "Uh Oh ..", "Foo Bar"]),
-          style: const TextStyle(fontSize: 28, color: Color(0xFFF7535A), fontWeight: FontWeight.w500)
-        ),
-        const Image(
-          image: AssetImage("assets/images/error.png", package: 'ensemble'),
-          width: 200
-        ),
-        const SizedBox(height: 16),
-        Text(
-          errorText + (recovery != null ? '\n$recovery' : ''),
-          textAlign: TextAlign.center,
-          style: const TextStyle(fontSize: 16, height: 1.4),
-        ),
-      ],
-    ));
-
-    // add detail
-    if (detailError != null && kDebugMode) {
-      children.add(Column(
-          children: [
-            const SizedBox(height: 30),
-            const Text(
-                'DETAILS',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)
-            ),
-            const SizedBox(height: 10),
-            Text(
-                detailError!,
-                textAlign: TextAlign.start,
-                style: const TextStyle(fontSize: 14, color: Colors.black87)
-            )
-          ]
-        )
-      );
-    }
-
-
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.only(left: 40, right: 40, top: 40),
-          child: SingleChildScrollView(
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: children
-            ),
-          )
-        )
-      )
-    );
-  }
 
   static String join(String? first, String? second) {
     List<String> list = [];
@@ -115,4 +50,101 @@ class ErrorScreen extends StatelessWidget {
     return list.join('\n');
   }
 
+  @override
+  State<ErrorScreen> createState() => _ErrorScreenState();
+}
+
+class _ErrorScreenState extends State<ErrorScreen> {
+  OverlayEntry? overlayEntry;
+  int currentPageIndex = 0;
+
+  void createErrorOverlay() {
+    // Remove the existing OverlayEntry.
+    removeErrorOverlay();
+
+    assert(overlayEntry == null);
+
+    List<Widget> children = [];
+
+    // main error and graphics
+    children.add(Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(Utils.randomize(["Oh Snap", "Uh Oh ..", "Foo Bar"]),
+            style: const TextStyle(
+                fontSize: 28,
+                color: Color(0xFFF7535A),
+                fontWeight: FontWeight.w500)),
+        const Image(
+            image: AssetImage("assets/images/error.png", package: 'ensemble'),
+            width: 200),
+        const SizedBox(height: 16),
+        Text(
+          widget.errorText +
+              (widget.recovery != null ? '\n${widget.recovery}' : ''),
+          textAlign: TextAlign.center,
+          style: const TextStyle(fontSize: 16, height: 1.4),
+        ),
+      ],
+    ));
+
+    // add detail
+    if (widget.detailError != null && kDebugMode) {
+      children.add(Column(children: [
+        const SizedBox(height: 30),
+        const Text('DETAILS',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+        const SizedBox(height: 10),
+        Text(widget.detailError!,
+            textAlign: TextAlign.start,
+            style: const TextStyle(fontSize: 14, color: Colors.black87))
+      ]));
+    }
+
+    overlayEntry = OverlayEntry(
+      // Create a new OverlayEntry.
+      builder: (BuildContext context) {
+        // Align is used to position the highlight overlay
+        // relative to the NavigationBar destination.
+        return Scaffold(
+          body: SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(left: 40, right: 40, top: 40),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: children)
+            )
+          )
+        );
+      },
+    );
+
+    // Add the OverlayEntry to the Overlay.
+    Overlay.of(context, debugRequiredFor: widget).insert(overlayEntry!);
+  }
+
+  // Remove the OverlayEntry.
+  void removeErrorOverlay() {
+    overlayEntry?.remove();
+    overlayEntry = null;
+  }
+
+  @override
+  void dispose() {
+    // Make sure to remove OverlayEntry when the widget is disposed.
+    removeErrorOverlay();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => createErrorOverlay());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
 }

--- a/lib/framework/widget/view_util.dart
+++ b/lib/framework/widget/view_util.dart
@@ -237,7 +237,7 @@ class ViewUtil {
       // processed, so wraps it in a CustomView widget
       return w;
     }
-    return const Text("Unsupported Widget");
+    throw LanguageError("Unsupported Widget: ${model.type}");
   }
 
   /// traverse the scope breath-first and propagate all data from the root down


### PR DESCRIPTION
Renders error screen as an overlay to avoid render constraints from parent widget when an error is caught during build phase