### PR TITLE
Warn the users when Input widgets are using inside Row without expanded

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1259,10 +1259,6 @@
                   "$ref": "#/$defs/typeColors",
                   "description": "The base border color for this input widget. This border color determines the look and feel of your input, while the other colors are overrides for different states. This property can be defined in the theme to apply to all Input widgets."
                 },
-                "enabledBorderColor": {
-                  "$ref": "#/$defs/typeColors",
-                  "description": "The border color for this input field if enabled. This property can be defined in the theme to apply to all Input widgets."
-                },
                 "disabledBorderColor": {
                   "$ref": "#/$defs/typeColors",
                   "description": "The border color when this input field is disabled. This property can be defined in the theme to apply to all Input widgets."

--- a/assets/schema/theme_schema.json
+++ b/assets/schema/theme_schema.json
@@ -127,10 +127,6 @@
           "$ref": "#/$defs/Color",
           "description": "The base border color for applicable input fields. This border color determines the look and feel of your inputs, while the other colors are overrides for different states."
         },
-        "enabledBorderColor": {
-          "$ref": "#/$defs/Color",
-          "description": "The override border color for enabled input fields."
-        },
         "disabledBorderColor": {
           "$ref": "#/$defs/Color",
           "description": "The border color when input fields are disabled."

--- a/lib/framework/theme/theme_loader.dart
+++ b/lib/framework/theme/theme_loader.dart
@@ -160,7 +160,6 @@ mixin ThemeLoader {
     int borderWidth = Utils.optionalInt(input?['borderWidth']) ?? 1;
 
     Color? borderColor = Utils.getColor(input?['borderColor']);
-    Color? enabledBorderColor = Utils.getColor(input?['enabledBorderColor']);
     Color? disabledBorderColor = Utils.getColor(input?['disabledBorderColor']);
     Color? errorBorderColor = Utils.getColor(input?['errorBorderColor']);
     Color? focusedBorderColor = Utils.getColor(input?['focusedBorderColor']);
@@ -175,7 +174,7 @@ mixin ThemeLoader {
           borderSide: BorderSide(
               color: borderColor ??
                   (colorScheme.brightness == Brightness.light
-                      ? Colors.black87
+                      ? Colors.black54
                       : Colors.white70),
               width: borderWidth.toDouble()));
 
@@ -183,12 +182,6 @@ mixin ThemeLoader {
         contentPadding: contentPadding ??
             const EdgeInsets.symmetric(vertical: 15, horizontal: 8),
         border: baseBorder,
-        enabledBorder: getInputBorder(
-                variant: variant,
-                borderColor: enabledBorderColor,
-                borderWidth: borderWidth,
-                borderRadius: borderRadius) ??
-            baseBorder,
         disabledBorder: getInputBorder(
             variant: variant,
             borderColor: disabledBorderColor,
@@ -224,12 +217,6 @@ mixin ThemeLoader {
         contentPadding: contentPadding ??
             const EdgeInsets.symmetric(vertical: 15, horizontal: 3),
         border: baseBorder,
-        enabledBorder: getInputBorder(
-                variant: variant,
-                borderColor: enabledBorderColor,
-                borderWidth: borderWidth,
-                borderRadius: borderRadius) ??
-            baseBorder,
         disabledBorder: getInputBorder(
             variant: variant,
             borderColor: disabledBorderColor,

--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -1,5 +1,6 @@
 /// This class contains common widgets for use with Ensemble widgets.
 
+import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/widget/input/form_helper.dart';
 import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble/framework/theme/theme_manager.dart';
@@ -97,30 +98,28 @@ class BoxWrapper extends StatelessWidget {
 /// the case where it is put inside a Row without expanded flag.
 class InputWrapper extends StatelessWidget {
   const InputWrapper(
-      {super.key, required this.widget, required this.controller});
+      {super.key, required this.type, required this.widget, required this.controller});
+  final String type;
   final Widget widget;
   final FormFieldController controller;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      int? maxWidth = controller.maxWidth;
 
       // inside a e.g. Row but not wrapping inside Expanded.
-      // This is the error condition we need to fix
+      // This is the error condition we need to advise the user
       if (!constraints.hasBoundedWidth && !controller.expanded) {
-        // this is our workaround for the layout error when the user use these
-        // input widgets (which stretch to their parent) inside a Row (which allow
-        // its child to have as much space as it wants) without using expanded flag.
-        // We'll cap their max width so the user can adjust it
-        // instead of seeing a blank screen
-        maxWidth ??= 700;
+        // throw Error when input widgets (which stretch to their parent) are
+        // inside a Row (which allow its child to have as much space as it wants)
+        // without using expanded flag.
+        throw LanguageError("${type} widget requires a width when used inside a parent like Row.", recovery: "Consider using 'expanded: true' on the ${type} to fill the parent's available width.");
       }
 
-      return maxWidth == null
+      return controller.maxWidth == null
           ? widget
           : ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: maxWidth.toDouble()),
+              constraints: BoxConstraints(maxWidth: controller.maxWidth!.toDouble()),
               child: widget);
     });
   }

--- a/lib/widget/input/dropdown.dart
+++ b/lib/widget/input/dropdown.dart
@@ -278,7 +278,10 @@ class SelectOneState extends FormFieldWidgetState<SelectOne> {
                 },
               ));
     }
-    return InputWrapper(widget: rtn, controller: widget._controller);
+    return InputWrapper(
+        type: Dropdown.type,
+        controller: widget._controller,
+        widget: rtn);
   }
 
   // ---------------------- Search From the List if [AUTOCOMPLETE] is true ---------------------------------

--- a/lib/widget/input/form_checkbox.dart
+++ b/lib/widget/input/form_checkbox.dart
@@ -116,6 +116,9 @@ class OnOffState extends FormFieldWidgetState<OnOffWidget> {
 
     // wraps around FormField to get all the form effects
     return InputWrapper(
+        type: widget.getType() == OnOffType.toggle
+            ? EnsembleSwitch.type
+            : EnsembleCheckbox.type,
         controller: widget._controller,
         widget: FormField<bool>(
             key: validatorKey,

--- a/lib/widget/input/form_date.dart
+++ b/lib/widget/input/form_date.dart
@@ -75,6 +75,7 @@ class DateState extends FormFieldWidgetState<Date> {
   @override
   Widget buildWidget(BuildContext context) {
     return InputWrapper(
+        type: Date.type,
         controller: widget.controller,
         widget: FormField<DateTime>(
             key: validatorKey,

--- a/lib/widget/input/form_textfield.dart
+++ b/lib/widget/input/form_textfield.dart
@@ -250,6 +250,7 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput> {
     }
 
     return InputWrapper(
+        type: TextInput.type,
         controller: widget._controller,
         widget: TextFormField(
             key: validatorKey,

--- a/lib/widget/input/form_time.dart
+++ b/lib/widget/input/form_time.dart
@@ -63,6 +63,7 @@ class TimeState extends FormFieldWidgetState<Time> {
   @override
   Widget buildWidget(BuildContext context) {
     return InputWrapper(
+        type: Time.type,
         controller: widget.controller,
         widget: FormField<DateTime>(
             key: validatorKey,


### PR DESCRIPTION
- We now throw an error when Input widgets (has no width) are inside a parent like Row (doesn't constrain its children's widths) since this is a Flutter layout issue. We asked them to either set a width or consider using 'expanded: true'.
- remove enabledBorderColor, which is redundant. Also tweak the default border color to lighter.