### PR TITLE
#368 Make content selectable by default

### DIFF
--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -88,7 +88,8 @@ class EnsembleAppState extends State<EnsembleApp> {
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate
       ],
-      home: Scaffold(
+      home: SelectionArea(
+          child: Scaffold(
         // this outer scaffold is where the background image would be (if
         // specified). We do not want it to resize on keyboard popping up.
         // The Page's Scaffold can handle the resizing.
@@ -99,7 +100,7 @@ class EnsembleAppState extends State<EnsembleApp> {
               AppProvider(definitionProvider: config.definitionProvider),
           screenPayload: widget.screenPayload,
         ),
-      ),
+      )),
       // TODO: this case translation issue on hot loading. Address this for RTL support
       //builder: (context, widget) => FlutterI18n.rootAppBuilder().call(context, widget)
     );

--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -98,7 +98,10 @@ class BoxWrapper extends StatelessWidget {
 /// the case where it is put inside a Row without expanded flag.
 class InputWrapper extends StatelessWidget {
   const InputWrapper(
-      {super.key, required this.type, required this.widget, required this.controller});
+      {super.key,
+      required this.type,
+      required this.widget,
+      required this.controller});
   final String type;
   final Widget widget;
   final FormFieldController controller;
@@ -106,20 +109,23 @@ class InputWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-
       // inside a e.g. Row but not wrapping inside Expanded.
       // This is the error condition we need to advise the user
       if (!constraints.hasBoundedWidth && !controller.expanded) {
         // throw Error when input widgets (which stretch to their parent) are
         // inside a Row (which allow its child to have as much space as it wants)
         // without using expanded flag.
-        throw LanguageError("${type} widget requires a width when used inside a parent like Row.", recovery: "Consider using 'expanded: true' on the ${type} to fill the parent's available width.");
+        throw LanguageError(
+            "${type} widget requires a width when used inside a parent like Row.",
+            recovery:
+                "Consider using 'expanded: true' on the ${type} to fill the parent's available width.");
       }
 
       return controller.maxWidth == null
           ? widget
           : ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: controller.maxWidth!.toDouble()),
+              constraints:
+                  BoxConstraints(maxWidth: controller.maxWidth!.toDouble()),
               child: widget);
     });
   }

--- a/lib/widget/input/dropdown.dart
+++ b/lib/widget/input/dropdown.dart
@@ -279,9 +279,7 @@ class SelectOneState extends FormFieldWidgetState<SelectOne> {
               ));
     }
     return InputWrapper(
-        type: Dropdown.type,
-        controller: widget._controller,
-        widget: rtn);
+        type: Dropdown.type, controller: widget._controller, widget: rtn);
   }
 
   // ---------------------- Search From the List if [AUTOCOMPLETE] is true ---------------------------------


### PR DESCRIPTION
Leverages new SelectionArea utility widget from flutter to enable selection across all screens in Ensemble https://api.flutter.dev/flutter/material/SelectionArea-class.html