### PR TITLE
Fixed gap issue in item-template of flex widgets

### DIFF
--- a/lib/layout/box/box_utils.dart
+++ b/lib/layout/box/box_utils.dart
@@ -42,9 +42,15 @@ class BoxUtils {
 
   static bool _checkVisibleChild(Widget child) {
     Widget view = child;
-    if (view is DataScopeWidget && view.child is CustomView) {
-      final CustomView customView = view.child as CustomView;
-      view = customView.childWidget;
+    if (view is DataScopeWidget) {
+      if (view.child is CustomView) {
+        // Custom Widgets
+        final CustomView customView = view.child as CustomView;
+        view = customView.childWidget;
+      } else {
+        // Native Widgets like Button, Text
+        view = view.child;
+      }
     }
 
     final isWidgetController =


### PR DESCRIPTION
Ticket: #427 
Fixed the gap issue in `item-template` of flex widgets

<details>
  <summary>Sample YAML Code</summary>

  ### YAML Code
  ```yaml
View:
  styles:
    useSafeArea: true
    scrollableView: true
    backgroundImage:
      source: https://firebasestorage.googleapis.com/v0/b/ensemble-web-studio.appspot.com/o/demo_apps%2Fkitchen-sink%2Fbeach_sunset.jpg?alt=media&token=a197bdb1-7b8f-479a-9fee-722ec7857c97

  onLoad:
    invokeAPI:
      name: getHotels

  Column:
    styles:
      padding: 15 24
      gap: 36
    children:
      - Column:
          styles:
            padding: 15 24
            gap: 8
          children:
            - Button:
                label: Log In
            - Button:
                label: Sign In
            - Button:
                label: Logout

      - Column:
          styles:
            padding: 15 24
            gap: 30
          item-template:
            data: ${getHotels.body.hotels}
            name: hotel
            template:
              Button:
                label: ${hotel.name}

API:
  getHotels:
    inputs: [location, from, to]
    authorization: none
    uri: "https://dc7ghx6kqg.execute-api.us-west-1.amazonaws.com/dev/hotels/search"
    method: "POST"
    parameters:
      city: ${location}
      fromDate: ${from}
      toDate: ${to}

  ```
</details>

<img src="https://user-images.githubusercontent.com/12869588/231676950-f7fedf91-6e17-486f-a148-cbfbd66fb08f.png" width="350" />

