### PR TITLE
Navigate to flutter screen

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2909,6 +2909,10 @@
                   "type": "string",
                   "description": "Enter the Name or ID of your Screen"
                 },
+                "external": {
+                  "type": "boolean",
+                  "description": "(Default false) Specify if screen is externally provided or not. If set true the screen is expected from external source."
+                },
                 "inputs": {
                   "type": "object",
                   "description": "Specify the key/value pairs to pass into the next Screen",

--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -26,6 +26,9 @@ import 'html_shim.dart' if (dart.library.html) 'dart:html' show window;
 import 'framework/theme/theme_loader.dart';
 import 'layout/ensemble_page_route.dart';
 
+typedef CustomBuilder = Widget Function(
+    BuildContext context, Map<String, dynamic>? args);
+
 /// Singleton Controller
 class Ensemble {
   static final Ensemble _instance = Ensemble._internal();
@@ -36,9 +39,14 @@ class Ensemble {
 
   late FirebaseApp ensembleFirebaseApp;
   static final Map<String, dynamic> externalDataContext = {};
+  Map<String, CustomBuilder> externalScreenWidgets = {};
 
   static final RouteObserver<PageRoute> routeObserver =
       RouteObserver<PageRoute>();
+
+  void setExternalScreenWidgets(Map<String, CustomBuilder> widgets) {
+    externalScreenWidgets = widgets;
+  }
 
   /// initialize all the singleton/managers. Note that this function can be
   /// called multiple times since it's being called inside a widget.
@@ -243,6 +251,7 @@ class Ensemble {
     String? screenName,
     bool? asModal,
     Map<String, dynamic>? pageArgs,
+    bool isExternal = false,
   }) {
     PageType pageType = asModal == true ? PageType.modal : PageType.regular;
 
@@ -251,7 +260,8 @@ class Ensemble {
             screenId: screenId,
             screenName: screenName,
             pageType: pageType,
-            arguments: pageArgs));
+            arguments: pageArgs,
+            isExternal: isExternal));
 
     Map<String, dynamic>? transition =
         Theme.of(context).extension<EnsembleThemeExtension>()?.transitions;

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -114,7 +114,8 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       super.inputs,
       super.options,
       this.onNavigateBack,
-      super.transition})
+      super.transition,
+      super.isExternal})
       : super(asModal: false);
   EnsembleAction? onNavigateBack;
 
@@ -131,6 +132,7 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       options: Utils.getMap(payload['options']),
       onNavigateBack: EnsembleAction.fromYaml(payload['onNavigateBack']),
       transition: Utils.getMap(payload['transition']),
+      isExternal: Utils.getBool(payload['external'], fallback: false),
     );
   }
 
@@ -173,12 +175,14 @@ abstract class BaseNavigateScreenAction extends EnsembleAction {
       required this.asModal,
       this.transition,
       super.inputs,
-      this.options});
+      this.options,
+      this.isExternal = false});
 
   String screenName;
   bool asModal;
   Map<String, dynamic>? transition;
   final Map<String, dynamic>? options;
+  final bool isExternal;
 }
 
 class PlaidLinkAction extends EnsembleAction {

--- a/lib/framework/menu.dart
+++ b/lib/framework/menu.dart
@@ -70,6 +70,7 @@ abstract class Menu {
                   Utils.optionalString(item['floatingAlignment']) ?? 'center',
               floatingMargin: Utils.optionalInt(item['floatingMargin']),
               onTap: item['onTap'],
+              isExternal: Utils.getBool(item['isExternal'], fallback: false),
             ),
           );
           customIconModel = null; // Resetting custom icon model
@@ -191,6 +192,7 @@ class MenuItem {
     this.floatingAlignment = 'center',
     this.floatingMargin,
     this.onTap,
+    required this.isExternal,
   });
 
   final String? label;
@@ -205,4 +207,5 @@ class MenuItem {
   final String floatingAlignment;
   final int? floatingMargin;
   final dynamic onTap;
+  final bool isExternal;
 }

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -641,7 +641,7 @@ class PageState extends State<Page>
   }
 
   void selectNavigationIndex(BuildContext context, MenuItem menuItem) {
-    ScreenController().navigateToScreen(context, screenName: menuItem.page);
+    ScreenController().navigateToScreen(context, screenName: menuItem.page, isExternal: menuItem.isExternal);
   }
 
   Widget? _buildFooter(ScopeManager scopeManager, SinglePageModel pageModel) {

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -641,7 +641,8 @@ class PageState extends State<Page>
   }
 
   void selectNavigationIndex(BuildContext context, MenuItem menuItem) {
-    ScreenController().navigateToScreen(context, screenName: menuItem.page, isExternal: menuItem.isExternal);
+    ScreenController().navigateToScreen(context,
+        screenName: menuItem.page, isExternal: menuItem.isExternal);
   }
 
   Widget? _buildFooter(ScopeManager scopeManager, SinglePageModel pageModel) {

--- a/lib/framework/view/page_group.dart
+++ b/lib/framework/view/page_group.dart
@@ -98,10 +98,12 @@ class PageGroupState extends State<PageGroup> with MediaQueryCapability {
     for (int i = 0; i < widget.menu.menuItems.length; i++) {
       MenuItem menuItem = widget.menu.menuItems[i];
       pageWidgets.add(ScreenController().getScreen(
-          key: UniqueKey(),
-          // ensure each screen is different for Flutter not to optimize
-          screenName: menuItem.page,
-          pageArgs: widget.pageArgs));
+        key: UniqueKey(),
+        // ensure each screen is different for Flutter not to optimize
+        screenName: menuItem.page,
+        pageArgs: widget.pageArgs,
+        isExternal: menuItem.isExternal,
+      ));
       dynamic selected = _scopeManager.dataContext.eval(menuItem.selected);
       if (selected == true || selected == 'true') {
         selectedPage = i;

--- a/lib/framework/widget/screen.dart
+++ b/lib/framework/widget/screen.dart
@@ -166,11 +166,16 @@ class ExternalScreen extends StatelessWidget {
     return screen ??
         Scaffold(
           body: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 32.0, vertical: 64.0),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 32.0, vertical: 64.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                IconButton(onPressed: () {Navigator.pop(context);}, icon: const Icon(Icons.arrow_back_ios)),
+                IconButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    icon: const Icon(Icons.arrow_back_ios)),
                 const SizedBox(height: 32),
                 const Text(
                   'External Screen',

--- a/lib/page_model.dart
+++ b/lib/page_model.dart
@@ -364,7 +364,7 @@ class AppProvider {
 /// payload to pass to the Screen
 class ScreenPayload {
   ScreenPayload(
-      {this.screenId, this.screenName, this.arguments, this.pageType});
+      {this.screenId, this.screenName, this.arguments, this.pageType, this.isExternal = false});
 
   // screen ID is optional as the App always have a default screen
   String? screenId;
@@ -375,6 +375,9 @@ class ScreenPayload {
   Map<String, dynamic>? arguments;
 
   PageType? pageType;
+
+  // check if screen is externally provided. i.e not ensemble screen.
+  bool isExternal;
 }
 
 /// rendering options for the screenc

--- a/lib/page_model.dart
+++ b/lib/page_model.dart
@@ -364,7 +364,11 @@ class AppProvider {
 /// payload to pass to the Screen
 class ScreenPayload {
   ScreenPayload(
-      {this.screenId, this.screenName, this.arguments, this.pageType, this.isExternal = false});
+      {this.screenId,
+      this.screenName,
+      this.arguments,
+      this.pageType,
+      this.isExternal = false});
 
   // screen ID is optional as the App always have a default screen
   String? screenId;

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -167,12 +167,14 @@ class ScreenController {
       }
 
       PageRouteBuilder routeBuilder = navigateToScreen(
-          providedDataContext.buildContext,
-          screenName: dataContext.eval(action.screenName),
-          asModal: action.asModal,
-          routeOption: routeOption,
-          pageArgs: nextArgs,
-          transition: action.transition);
+        providedDataContext.buildContext,
+        screenName: dataContext.eval(action.screenName),
+        asModal: action.asModal,
+        routeOption: routeOption,
+        pageArgs: nextArgs,
+        transition: action.transition,
+        isExternal: action.isExternal,
+      );
 
       // listen for data returned on popped
       if (scopeManager == null) {
@@ -993,14 +995,17 @@ class ScreenController {
     RouteOption? routeOption,
     Map<String, dynamic>? pageArgs,
     Map<String, dynamic>? transition,
+    bool isExternal = false,
   }) {
     PageType pageType = asModal == true ? PageType.modal : PageType.regular;
 
     Widget screenWidget = getScreen(
-        screenId: screenId,
-        screenName: screenName,
-        asModal: asModal,
-        pageArgs: pageArgs);
+      screenId: screenId,
+      screenName: screenName,
+      asModal: asModal,
+      pageArgs: pageArgs,
+      isExternal: isExternal,
+    );
 
     Map<String, dynamic>? defaultTransitionOptions =
         Theme.of(context).extension<EnsembleThemeExtension>()?.transitions ??
@@ -1042,6 +1047,7 @@ class ScreenController {
     String? screenName,
     bool? asModal,
     Map<String, dynamic>? pageArgs,
+    required bool isExternal,
   }) {
     PageType pageType = asModal == true ? PageType.modal : PageType.regular;
     return Screen(
@@ -1053,6 +1059,7 @@ class ScreenController {
         screenName: screenName,
         pageType: pageType,
         arguments: pageArgs,
+        isExternal: isExternal,
       ),
     );
   }


### PR DESCRIPTION
Ticket: #440 

EDL remains the same i.e pass the screen name.

Only configuration needs to be done on flutter side that is pass custom widgets along with name.
Example:
```dart
void main() async {
  WidgetsFlutterBinding.ensureInitialized();

  // (optional) pre-initialize asynchronously so Ensemble is ready
  // when your app switches to Ensemble screens. Add `await` before
  // this statement if your first page is an Ensemble's page.
  Ensemble().initialize();

  /// (optional) set map of custom flutter widget that can be called from ensemble
  Ensemble().setCustomFlutterWidgets(
    {
      'testScreen': (context, args) =>
          TestScreen(name: args?['name'] ?? 'Hello'),
    },
  );
  runApp(const MyApp());
}
```

EDL to navigate to `TestScreen` will be no different, 

```yaml
- Button:
    label: Test Screen
    onTap:
      navigateModalScreen:
        name: testScreen
        inputs:
          name: PageName

```