### PR TITLE
Add support for custom widgets from Runtime

### DIFF
--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -27,6 +27,10 @@ class Ensemble {
     return _instance;
   }
 
+  void notifyAppBundleChanges() {
+    _config?.updateAppBundle();
+  }
+
   /// the configuration required to run an App
   EnsembleConfig? _config;
 
@@ -248,6 +252,10 @@ class EnsembleConfig {
     return ThemeManager().getAppTheme(appBundle?.theme);
   }
 
+  YamlMap? getCustomWidgets() {
+    return appBundle?.widgets;
+  }
+
   FlutterI18nDelegate getI18NDelegate() {
     return definitionProvider.getI18NDelegate();
   }
@@ -262,9 +270,10 @@ class I18nProps {
 }
 
 class AppBundle {
-  AppBundle({this.theme});
+  AppBundle({this.theme, this.widgets});
 
-  YamlMap? theme;
+  YamlMap? theme; // theme
+  YamlMap? widgets; // custom widgets
 }
 
 /// store the App's account info (e.g. access token for maps)

--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -252,8 +252,9 @@ class EnsembleConfig {
     return ThemeManager().getAppTheme(appBundle?.theme);
   }
 
-  YamlMap? getCustomWidgets() {
-    return appBundle?.widgets;
+  /// retrieve the global widgets/codes/APIs
+  YamlMap? getResources() {
+    return appBundle?.resources;
   }
 
   FlutterI18nDelegate getI18NDelegate() {
@@ -270,10 +271,10 @@ class I18nProps {
 }
 
 class AppBundle {
-  AppBundle({this.theme, this.widgets});
+  AppBundle({this.theme, this.resources});
 
   YamlMap? theme; // theme
-  YamlMap? widgets; // custom widgets
+  YamlMap? resources; // globally available widgets/codes/APIs
 }
 
 /// store the App's account info (e.g. access token for maps)

--- a/lib/ensemble_provider.dart
+++ b/lib/ensemble_provider.dart
@@ -123,11 +123,11 @@ class AppModel {
       DocumentSnapshot<Map<String, dynamic>> doc, bool isModified) async {
     // adjust the theme and home screen
     if (doc.data()?['isRoot'] == true) {
-      if (doc.data()?['type'] == 'screen') {
+      if (doc.data()?['type'] == ArtifactType.screen.name) {
         homeMapping = doc.id;
-      } else if (doc.data()?['type'] == 'theme') {
+      } else if (doc.data()?['type'] == ArtifactType.theme.name) {
         themeMapping = doc.id;
-      } else if (doc.data()?['type'] == 'config') {
+      } else if (doc.data()?['type'] == ArtifactType.config.name) {
         // environment variable
         Map<String, dynamic>? envVariables;
         dynamic env = doc.data()!['envVariables'];
@@ -143,7 +143,11 @@ class AppModel {
 
       // mark the app bundle as dirty
       if (isModified &&
-          ['theme', 'config', 'widgets'].contains(doc.data()!['type'])) {
+          [
+            ArtifactType.theme.name,
+            ArtifactType.config.name,
+            ArtifactType.resources.name
+          ].contains(doc.data()!['type'])) {
         log("Changed Artifact: " + doc.data()!['type']);
         Ensemble().notifyAppBundleChanges();
       }
@@ -251,7 +255,7 @@ class AppModel {
         .get();
     for (var doc in snapshot.docs) {
       await updateArtifact(doc, false);
-      if (doc.data()['type'] == 'theme') {
+      if (doc.data()['type'] == ArtifactType.theme.name) {
         themeMapping = doc.id;
       } else if (doc.data()['type'] == 'screen' && homeMapping == null) {
         homeMapping = doc.id;
@@ -259,6 +263,6 @@ class AppModel {
     }
     return AppBundle(
         theme: themeMapping != null ? artifactCache[themeMapping] : null,
-        widgets: artifactCache['widgets']);
+        resources: artifactCache[ArtifactType.resources.name]);
   }
 }

--- a/lib/host_cache_provider.dart
+++ b/lib/host_cache_provider.dart
@@ -40,10 +40,9 @@ class HostCachedEnsembleProvider extends EnsembleDefinitionProvider {
         (theme ??= hostCache.getString(appModel.themeMapping!)) != null) {
       return AppBundle(
           theme: loadYaml(theme!),
-          resources: appModel.artifactCache[ArtifactType.resources.name]);
+          resources: await appModel.getCombinedResources());
     } else {
-      return AppBundle(
-          resources: appModel.artifactCache[ArtifactType.resources.name]);
+      return AppBundle(resources: await appModel.getCombinedResources());
     }
   }
 

--- a/lib/host_cache_provider.dart
+++ b/lib/host_cache_provider.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/ensemble_provider.dart';
 import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:yaml/yaml.dart';
 
@@ -37,9 +38,12 @@ class HostCachedEnsembleProvider extends EnsembleDefinitionProvider {
     String? theme;
     if (appModel.themeMapping != null &&
         (theme ??= hostCache.getString(appModel.themeMapping!)) != null) {
-      return AppBundle(theme: loadYaml(theme!));
+      return AppBundle(
+          theme: loadYaml(theme!),
+          resources: appModel.artifactCache[ArtifactType.resources.name]);
     } else {
-      return AppBundle();
+      return AppBundle(
+          resources: appModel.artifactCache[ArtifactType.resources.name]);
     }
   }
 

--- a/lib/host_cache_provider.dart
+++ b/lib/host_cache_provider.dart
@@ -27,7 +27,7 @@ class HostCachedEnsembleProvider extends EnsembleDefinitionProvider {
   @override
   Future<AppBundle> getAppBundle({bool? bypassCache = false}) async {
     // Populate cache from remote if first time or explicitly asked
-    if (bypassCache == true || appModel.contentCache.isEmpty) {
+    if (bypassCache == true || appModel.artifactCache.isEmpty) {
       AppBundle updatedBundle = await appModel.getAppBundle();
       _syncArtifactsToHostCache();
       return updatedBundle;
@@ -66,7 +66,7 @@ class HostCachedEnsembleProvider extends EnsembleDefinitionProvider {
   }
 
   _syncArtifactsToHostCache() {
-    appModel.contentCache.forEach((key, value) {
+    appModel.artifactCache.forEach((key, value) {
       hostCache.setString(key, json.encode(value));
     });
   }

--- a/lib/page_model.dart
+++ b/lib/page_model.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 import 'dart:ui';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/data_context.dart';
@@ -74,6 +75,17 @@ abstract class PageModel {
   /// Create a map of Ensemble's custom widgets so WidgetModel can reference them
   Map<String, dynamic> _buildCustomViewDefinitions(YamlMap docMap) {
     Map<String, dynamic> subViewDefinitions = {};
+
+    // first get the custom widgets from Global
+    YamlMap? globalWidgets = Ensemble().getConfig()?.getCustomWidgets();
+    globalWidgets?.forEach((key, value) {
+      if (value != null) {
+        subViewDefinitions[key] = value;
+      }
+    });
+
+    // then add custom widgets on the page. They will
+    // override global scope if the name is duplicate
     docMap.forEach((key, value) {
       if (!_reservedTokens.contains(key)) {
         if (value != null) {

--- a/lib/page_model.dart
+++ b/lib/page_model.dart
@@ -77,8 +77,8 @@ abstract class PageModel {
     Map<String, dynamic> subViewDefinitions = {};
 
     // first get the custom widgets from Global
-    YamlMap? globalWidgets = Ensemble().getConfig()?.getCustomWidgets();
-    globalWidgets?.forEach((key, value) {
+    YamlMap? globalWidgets = Ensemble().getConfig()?.getResources();
+    globalWidgets?['Widgets']?.forEach((key, value) {
       if (value != null) {
         subViewDefinitions[key] = value;
       }

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -13,6 +13,13 @@ import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart' as foundation;
 import 'package:firebase_core/firebase_core.dart';
 
+enum ArtifactType {
+  screen,
+  theme,
+  resources, // global widgets/codes/APIs/
+  config // app config
+}
+
 abstract class DefinitionProvider {
   static Map<String, dynamic> cache = {};
   final I18nProps i18nProps;

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -20,6 +20,9 @@ enum ArtifactType {
   config // app config
 }
 
+// the root entries of the Resource artifact
+enum ResourceArtifactEntry { Widgets, Code, API }
+
 abstract class DefinitionProvider {
   static Map<String, dynamic> cache = {};
   final I18nProps i18nProps;


### PR DESCRIPTION
Support widgets defined at the app level, as well as imported apps (currently hardcode to just 8PghcmhtGkWiWffmhDDl)
At runtime we'll fetch artifact 'resources', which has the following signature:
```
Widgets:
  customWidget1:
    inputs: ..
    body: ...
 anotherCustomWidget:
  body: ...
  
// for later  
Code:
API:
```
We then iterate through each imported apps (current just 1 app 8PghcmhtGkWiWffmhDDl) and add the custom widgets with namespace to the resources)