### PR TITLE
Fixed carousel padding issue

### DIFF
--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -211,6 +211,7 @@ class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
     return BoxWrapper(
       widget: carousel,
       boxController: widget._controller,
+      ignoresPadding: true,
       ignoresDimension:
           true, // width/height shouldn't be apply in the container
     );
@@ -241,8 +242,8 @@ class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
     // wrap each child inside Container to add padding and gap
     double gap =
         widget._controller.gap?.toDouble() ?? MyController.defaultItemGap;
-    double leadingGap = widget._controller.leadingGap?.toDouble() ?? gap / 2;
-    double trailingGap = widget._controller.trailingGap?.toDouble() ?? gap / 2;
+    double leadingGap = widget._controller.leadingGap?.toDouble() ?? 0;
+    double trailingGap = widget._controller.trailingGap?.toDouble() ?? 0;
     List<Widget> items = [];
     for (int i = 0; i < children.length; i++) {
       Widget child = children[i];


### PR DESCRIPTION
Ticket: #465
In this PR, I fixed the padding issue and also removed the default padding for the leading and trailing items.

`gap: 10` -> It adds the gap between the children. Default value is 10
`leadingGap: 10` -> It adds the gap at the start of the first item. Default value is 0
`trailingGap: 10` -> It adds the gap at the end of the last item. Default value is 0