### PR TITLE
Fixed button padding, gradient and onTap issue

### DIFF
--- a/lib/widget/button.dart
+++ b/lib/widget/button.dart
@@ -125,7 +125,9 @@ class ButtonState extends WidgetState<Button> {
     if (isOutlineButton) {
       rtn = BoxWrapper(
         boxController: widget.controller,
-        widget: OutlinedButton(
+        ignoresPadding: true,
+        ignoresMargin: true,
+        widget: TextButton(
             onPressed: isEnabled() ? () => onPressed(context) : null,
             style: getButtonStyle(context, isOutlineButton),
             child: labelLayout),
@@ -133,6 +135,8 @@ class ButtonState extends WidgetState<Button> {
     } else {
       rtn = BoxWrapper(
         boxController: widget.controller,
+        ignoresPadding: true,
+        ignoresMargin: true,
         widget: FilledButton(
             onPressed: isEnabled() ? () => onPressed(context) : null,
             style: getButtonStyle(context, isOutlineButton),
@@ -175,6 +179,12 @@ class ButtonState extends WidgetState<Button> {
           side: widget._controller.borderGradient != null
               ? BorderSide.none
               : borderSide);
+    } else {
+      if (isOutlineButton) {
+        border = const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.zero),
+        );
+      }
     }
 
     // we need to get the button shape from borderRadius, borderColor & borderThickness
@@ -184,7 +194,9 @@ class ButtonState extends WidgetState<Button> {
     return ThemeManager().getButtonStyle(
         isOutline: isOutlineButton,
         color: widget._controller.color,
-        backgroundColor: widget._controller.backgroundColor,
+        backgroundColor: widget._controller.backgroundGradient == null
+            ? widget._controller.backgroundColor
+            : Colors.transparent,
         border: border,
         buttonHeight: widget._controller.buttonHeight?.toDouble(),
         buttonWidth: widget._controller.buttonWidth?.toDouble(),


### PR DESCRIPTION
Ticket: [#450](https://github.com/EnsembleUI/ensemble/issues/450)
In this PR, I fixed some Button Issues
    1. Gradient is not filled for the entire button. It applied only to the BoxWrapper
    2. onTap is not called in the padding area of the button
    3. Outline button has an extra border by default. It will display two borders on the button
    
Issue Video:

<img src="https://user-images.githubusercontent.com/12869588/236215579-988c489c-d077-402e-bed0-6624da2adf6c.mp4" alt="Watch the video" width="300">

Sample YAML:
```yaml

View:
  title: Home

  body:
    Column:
      styles:
        crossAxis: center
      children:
        - Button:
            styles:
              backgroundColor: blue
              backgroundGradient:
                colors:
                  - amber
                  - blue
                start: bottomRight
                end: topLeft
              padding: 20 60
              margin: 10 10
              fontSize: 20

            label: Filled
            onTap: |
              //@code
              console.log("filled button tapped");
        - Button:
            styles:
              outline: true
              color: green
              borderColor: red
              borderRadius: 5
              borderWidth: 3
              padding: 20 20
              margin: 30 10
              fontSize: 20

            label: Outline
            onTap: |
              //@code
              console.log("outline button tapped");

        - Button:
            styles:
              backgroundColor: blue
              borderRadius: 55
              padding: 20 60
              margin: 10 10
              fontSize: 20

            label: Filled
            onTap: |
              //@code
              console.log("filled button tapped");

```