### PR TITLE
Changed indicator widget on top of carousel item

### DIFF
--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -54,6 +54,8 @@ class Carousel extends StatefulWidget
           _controller.indicatorHeight = Utils.optionalInt(h),
       'indicatorMargin': (value) =>
           _controller.indicatorMargin = Utils.getInsets(value),
+      'indicatorOffset': (value) =>
+          _controller.indicatorOffset = Utils.optionalDouble(value),
       'onItemChange': (action) => _controller.onItemChange =
           EnsembleAction.fromYaml(action, initiator: this),
       'indicatorWidget': (widget) => _controller.indicatorWidget = widget,
@@ -114,6 +116,7 @@ class MyController extends BoxController {
   int? indicatorWidth;
   int? indicatorHeight;
   EdgeInsets? indicatorMargin;
+  double? indicatorOffset;
 
   // Custom Widget
   dynamic indicatorWidget;
@@ -196,16 +199,25 @@ class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
         indicators.add(Opacity(child: getIndicator(false), opacity: 0));
       }
 
+      final double indicatorOffset = widget._controller.indicatorOffset ?? 0;
+      final bool isBottom =
+          widget._controller.indicatorPosition != IndicatorPosition.top;
+
       List<Widget> children = [
         carousel,
-        Row(mainAxisAlignment: MainAxisAlignment.center, children: indicators)
+        Positioned(
+          top: !isBottom ? indicatorOffset : null,
+          bottom: isBottom ? indicatorOffset : null,
+          left: 0,
+          right: 0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: indicators,
+          ),
+        )
       ];
 
-      carousel = Column(
-          children:
-              widget._controller.indicatorPosition == IndicatorPosition.top
-                  ? children.reversed.toList()
-                  : children);
+      carousel = Stack(clipBehavior: Clip.none, children: children);
     }
 
     return BoxWrapper(


### PR DESCRIPTION
Ticket: #477 
In this PR, I changed the indicator widget on top of the carousel item view and added an offset.

Sample YAML
```yaml

Carousel:
  styles:
    height: 240
    gap: 30
    indicatorMargin: 5
    indicatorOffset: -20 or 20
    indicatorType: circle
    indicatorPosition: bottom
    indicatorWidth: 6
    indicatorHeight: 6
  item-template:
    data: ${getHotels.body.hotels}
    name: hotel
    template:
      HotelCard:
        inputs:
          hotel: ${hotel}
```

Here, In the `indicatorOffset`, you can pass negative and positive values. A negative value will move the indicator out of the carousel item view.