### PR TITLE
Changed border styling of data grid view

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1187,6 +1187,104 @@
         }
       ]
     },
+    "DataGrid-payload": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DataRow-Templated-payload"
+        },
+        {
+          "properties": {
+            "children": {
+                "$ref": "#/$defs/DataRow"
+            },
+            "styles": {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/baseStyles"
+                },
+                {
+                  "$ref": "#/$defs/boxLayoutStyles"
+                }
+              ]
+            },
+            "headingTextStyle": {
+              "type": "object",
+              "description": "Set the text style for the heading text",
+              "$ref": "#/$defs/TextStyle"
+            },
+            "dataTextStyle": {
+              "type": "object",
+              "description": "Set the text style for the data item text",
+              "$ref": "#/$defs/TextStyle"
+            },
+            "horizontalMargin": {
+              "type": "integer",
+              "description": "The leading and trailing gap for the DataGrid view.",
+              "minimum": 0
+            },
+            "dataRowHeight": {
+              "type": "integer",
+              "description": "Set the height of the data row item.",
+              "minimum": 0
+            },
+            "headingRowHeight": {
+              "type": "integer",
+              "description": "Set the height of the heading row item.",
+              "minimum": 0
+            },
+            "columnSpacing": {
+              "type": "number",
+              "description": "Set the padding for the column.",
+              "minimum": 0
+            },
+            "borderRadius": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The border radius for this DataGrid. This property can be defined in the theme to apply to all Input widgets."
+            },
+            "borderWidth": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The border width for this DataGrid. This property can be defined in the theme to apply to all Input widgets."
+            },
+            "borderColor": {
+              "$ref": "#/$defs/typeColors",
+              "description": "Set the color of the border."
+            }
+          }
+        }
+      ]
+    },
+    "DataRow-Templated-payload": {
+      "type": "object",
+      "properties": {
+        "item-template": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "string",
+              "description": "Bind to an array of data from an API response or a variable"
+            },
+            "name": {
+              "type": "string",
+              "description": "Set the name to reference as you iterate through the array of data"
+            },
+            "template": {
+              "$ref": "#/$defs/DataRow",
+              "description": "The data row widget to render for each item"
+            }
+          }
+        }
+      }
+    },
+    "DataRow": {
+      "type": "array",
+      "description": "List of widgets",
+      "items": {
+        "$ref": "#/$defs/Widget"
+      }
+    },
     "Stack-payload": {
       "type": "object",
       "properties": {

--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1205,18 +1205,20 @@
                 },
                 {
                   "$ref": "#/$defs/boxLayoutStyles"
+                },
+                {
+                  "headingTextStyle": {
+                    "type": "object",
+                    "description": "Set the text style for the heading text",
+                    "$ref": "#/$defs/TextStyle"
+                  },
+                  "dataTextStyle": {
+                    "type": "object",
+                    "description": "Set the text style for the data item text",
+                    "$ref": "#/$defs/TextStyle"
+                  }
                 }
               ]
-            },
-            "headingTextStyle": {
-              "type": "object",
-              "description": "Set the text style for the heading text",
-              "$ref": "#/$defs/TextStyle"
-            },
-            "dataTextStyle": {
-              "type": "object",
-              "description": "Set the text style for the data item text",
-              "$ref": "#/$defs/TextStyle"
             },
             "horizontalMargin": {
               "type": "integer",
@@ -1237,20 +1239,6 @@
               "type": "number",
               "description": "Set the padding for the column.",
               "minimum": 0
-            },
-            "borderRadius": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "The border radius for this DataGrid. This property can be defined in the theme to apply to all Input widgets."
-            },
-            "borderWidth": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "The border width for this DataGrid. This property can be defined in the theme to apply to all Input widgets."
-            },
-            "borderColor": {
-              "$ref": "#/$defs/typeColors",
-              "description": "Set the color of the border."
             }
           }
         }

--- a/lib/layout/data_grid.dart
+++ b/lib/layout/data_grid.dart
@@ -62,14 +62,6 @@ class DataGrid extends StatefulWidget
       'DataColumns': (List cols) {
         this.cols = cols;
       },
-      'headingTextStyle': (Map styles) {
-        controller.headingTextController = TextController();
-        TextUtils.setStyles(styles, controller.headingTextController!);
-      },
-      'dataTextStyle': (Map styles) {
-        controller.dataTextController = TextController();
-        TextUtils.setStyles(styles, controller.dataTextController!);
-      },
       'horizontalMargin': (val) =>
           controller.horizontalMargin = Utils.optionalDouble(val),
       'dataRowHeight': (val) =>
@@ -80,11 +72,6 @@ class DataGrid extends StatefulWidget
           controller.columnSpacing = Utils.optionalDouble(val),
       'dividerThickness': (val) =>
           controller.dividerThickness = Utils.optionalDouble(val),
-      'borderColor': (value) => controller.borderColor = Utils.getColor(value),
-      'borderWidth': (value) =>
-          controller.borderWidth = Utils.optionalDouble(value),
-      'borderRadius': (value) =>
-          controller.borderRadius = Utils.optionalDouble(value),
     };
   }
 }
@@ -155,7 +142,7 @@ class EnsembleDataRowState extends State<EnsembleDataRow> {
   }
 }
 
-class DataGridController extends WidgetController {
+class DataGridController extends BoxController {
   List<Widget>? children;
   double? horizontalMargin;
   TextController? headingTextController;
@@ -164,9 +151,22 @@ class DataGridController extends WidgetController {
   double? columnSpacing;
   TextController? dataTextController;
   double? dividerThickness;
-  Color? borderColor;
-  double? borderRadius;
-  double? borderWidth;
+
+  @override
+  Map<String, Function> getBaseSetters() {
+    Map<String, Function> setters = super.getBaseSetters();
+    setters.addAll({
+      'headingText': (Map styles) {
+        headingTextController = TextController();
+        TextUtils.setStyles(styles, headingTextController!);
+      },
+      'dataText': (Map styles) {
+        dataTextController = TextController();
+        TextUtils.setStyles(styles, dataTextController!);
+      },
+    });
+    return setters;
+  }
 }
 
 class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
@@ -303,9 +303,9 @@ class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
       dividerThickness: widget.controller.dividerThickness,
       border: TableBorder.all(
         color: widget.controller.borderColor ?? Colors.black,
-        width: widget.controller.borderWidth ?? 1.0,
+        width: widget.controller.borderWidth?.toDouble() ?? 1.0,
         borderRadius:
-            BorderRadius.circular(widget.controller.borderRadius ?? 0.0),
+            widget.controller.borderRadius?.getValue() ?? BorderRadius.zero,
       ),
     );
     return SingleChildScrollView(

--- a/lib/layout/data_grid.dart
+++ b/lib/layout/data_grid.dart
@@ -80,20 +80,11 @@ class DataGrid extends StatefulWidget
           controller.columnSpacing = Utils.optionalDouble(val),
       'dividerThickness': (val) =>
           controller.dividerThickness = Utils.optionalDouble(val),
-      'border': (Map val) {
-        if (val.isNotEmpty) {
-          BorderRadius borderRadius = BorderRadius.zero;
-          if (val['borderRadius'] != null) {
-            borderRadius = BorderRadius.circular(
-                Utils.getDouble(val['borderRadius'], fallback: 0.0));
-          }
-          controller.border = TableBorder.all(
-            width: Utils.getDouble(val['width'], fallback: 1.0),
-            color: Utils.getColor(val['color']) ?? const Color(0xFF000000),
-            borderRadius: borderRadius,
-          );
-        }
-      },
+      'borderColor': (value) => controller.borderColor = Utils.getColor(value),
+      'borderWidth': (value) =>
+          controller.borderWidth = Utils.optionalDouble(value),
+      'borderRadius': (value) =>
+          controller.borderRadius = Utils.optionalDouble(value),
     };
   }
 }
@@ -173,7 +164,9 @@ class DataGridController extends WidgetController {
   double? columnSpacing;
   TextController? dataTextController;
   double? dividerThickness;
-  TableBorder border = const TableBorder();
+  Color? borderColor;
+  double? borderRadius;
+  double? borderWidth;
 }
 
 class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
@@ -308,7 +301,12 @@ class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
       dataTextStyle: dataTextStyle,
       columnSpacing: widget.controller.columnSpacing,
       dividerThickness: widget.controller.dividerThickness,
-      border: widget.controller.border,
+      border: TableBorder.all(
+        color: widget.controller.borderColor ?? Colors.black,
+        width: widget.controller.borderWidth ?? 1.0,
+        borderRadius:
+            BorderRadius.circular(widget.controller.borderRadius ?? 0.0),
+      ),
     );
     return SingleChildScrollView(
         scrollDirection: Axis.vertical,

--- a/lib/layout/data_grid.dart
+++ b/lib/layout/data_grid.dart
@@ -81,27 +81,18 @@ class DataGrid extends StatefulWidget
       'dividerThickness': (val) =>
           controller.dividerThickness = Utils.optionalDouble(val),
       'border': (Map val) {
-        Map<String, dynamic> map = {};
-        val.forEach((key, value) {
-          if (value is Map) {
-            Color color = Utils.getColor(value['color']) ?? Colors.black;
-            double width = Utils.getDouble(value['width'], fallback: 1.0);
-            map[key] = BorderSide(color: color, width: width);
-          } else if (key == 'borderRadius') {
-            double? radius = Utils.optionalDouble(value);
-            map[key] = (radius == null)
-                ? BorderRadius.zero
-                : BorderRadius.circular(radius);
+        if (val.isNotEmpty) {
+          BorderRadius borderRadius = BorderRadius.zero;
+          if (val['borderRadius'] != null) {
+            borderRadius = BorderRadius.circular(
+                Utils.getDouble(val['borderRadius'], fallback: 0.0));
           }
-        });
-        controller.border = TableBorder(
-            top: map['top'] ?? BorderSide.none,
-            right: map['right'] ?? BorderSide.none,
-            bottom: map['bottom'] ?? BorderSide.none,
-            left: map['left'] ?? BorderSide.none,
-            horizontalInside: map['horizontalInside'] ?? BorderSide.none,
-            verticalInside: map['verticalInside'] ?? BorderSide.none,
-            borderRadius: map['borderRadius'] ?? BorderRadius.zero);
+          controller.border = TableBorder.all(
+            width: Utils.getDouble(val['width'], fallback: 1.0),
+            color: Utils.getColor(val['color']) ?? const Color(0xFF000000),
+            borderRadius: borderRadius,
+          );
+        }
       },
     };
   }


### PR DESCRIPTION
Fixes: #494 #512 
In this PR, I changed the border styling of grid view it's because of an issue in the borderRadius of TableBorder default constructor. Now it's changed it `TableBorder.all` named constructors with `color`, `width` and `borderRadius` only.

**Sample YAML**
```yaml
DataGrid:
  border:
    borderRadius: 30
    color: red
    width: 4
```