### PR TITLE
Specific wallet in connectWallet

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2190,6 +2190,10 @@
                   "type": "string",
                   "description": "Wallet connect project Id, get it from wallet connect dashboard"
                 },
+                "wallet": {
+                  "type": "string",
+                  "description": "Optional for Android, Required in IOS, when specified walletconnect will open and connect to specified wallet. e.g metamask, trust, rainbow..."
+                },
                 "onComplete": {
                   "$ref": "#/$defs/Action-payload",
                   "description": "Execute another Action upon successful upload of files"

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -453,6 +453,7 @@ class WalletConnectAction extends EnsembleAction {
     this.appIconUrl,
     this.onComplete,
     this.onError,
+    this.wallet,
   });
 
   String? id;
@@ -463,6 +464,7 @@ class WalletConnectAction extends EnsembleAction {
   String? appIconUrl;
   EnsembleAction? onComplete;
   EnsembleAction? onError;
+  String? wallet;
 
   factory WalletConnectAction.fromYaml({YamlMap? payload}) {
     if (payload == null ||
@@ -481,6 +483,7 @@ class WalletConnectAction extends EnsembleAction {
       appIconUrl: Utils.optionalString(payload['appMetaData']?['iconUrl']),
       onComplete: EnsembleAction.fromYaml(payload['onComplete']),
       onError: EnsembleAction.fromYaml(payload['onError']),
+      wallet: Utils.optionalString(payload['wallet']),
     );
   }
 }

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -473,7 +473,15 @@ class ScreenController {
             );
             return;
           }
-          launchUrlString(uri, mode: LaunchMode.externalApplication);
+
+          uri = action.wallet == null
+              ? uri
+              : '${action.wallet?.toLowerCase().trim()}://wc?uri=$uri';
+
+          launchUrlString(
+            uri,
+            mode: LaunchMode.externalApplication,
+          );
         });
       } on Exception catch (_) {
         if (action.onError != null) executeAction(context, action.onError!);


### PR DESCRIPTION
Ticket: #513

Ability to specify, specific wallet to connect. 

```yaml
Button:
  label: Connect to Metamask
  onTap:
    connectWallet:
      id: wallet
      wcProjectId: 77740b7e86cfcba224464923b8e115e3
      wallet: metamask #here specify wallet, like metamask, trust, rainbow..
      appMetaData:
        name: Ensemeble app
        description: Ensemble forever
        url: https://ensembleui.com/
        iconUrl: https://ensembleui.com/assets/images/logo.svg
      onComplete: |
        //@code

        address.text = wallet.addresses;
```

It's optional for android and web, but mandatory for IOS. Reason, android is designed to handle multiple applications subscribing to the same deep linking schema.