### PR TITLE
Fix toast message expression issue

### DIFF
--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -340,7 +340,22 @@ class ScreenController {
       if (scopeManager != null && action.widget != null) {
         customToastBody = scopeManager.buildWidgetFromDefinition(action.widget);
       }
-      ToastController().showToast(context, action, customToastBody);
+
+      final toastMessage = dataContext.eval(action.message);
+      final modifiedToastAction = ShowToastAction(
+        message: toastMessage,
+        initiator: action.initiator,
+        type: action.type,
+        title: action.title,
+        widget: action.widget,
+        dismissible: action.dismissible,
+        alignment: action.alignment,
+        duration: action.duration,
+        styles: action.styles,
+      );
+
+      ToastController()
+          .showToast(context, modifiedToastAction, customToastBody);
     } else if (action is OpenUrlAction) {
       dynamic value = dataContext.eval(action.url);
       value ??= '';


### PR DESCRIPTION
The following code is not working properly. It is fixed now, the expression is evaluated now.

```yaml
showToast:
  message: ${textInput.value + " copied!"}
  options:
    dismissable: true
    type: success
    duration: 3
```
<img src="https://github.com/EnsembleUI/ensemble/assets/12869588/3d9c3b4b-688a-4ff6-92a4-014dde646f8b" width="350" />
