### PR TITLE
Add resizeView style for page and device.viewInsetBottom

### DIFF
--- a/lib/framework/device.dart
+++ b/lib/framework/device.dart
@@ -37,6 +37,7 @@ class Device
       "height": () => screenHeight,
       "safeAreaTop": () => safeAreaTop,
       "safeAreaBottom": () => safeAreaBottom,
+      "viewInsetBottom": () => viewInsetBottom,
 
       // Misc Info
       "platform": () => DeviceInfoCapability.platform,
@@ -63,7 +64,8 @@ mixin MediaQueryCapability {
     if (isPreview) {
       return MediaQuery.of(Utils.globalAppKey.currentContext!);
     }
-    return data ??= MediaQuery.of(Utils.globalAppKey.currentContext!);
+    data = MediaQuery.of(Utils.globalAppKey.currentContext!);
+    return data!;
   }
 
   int get screenWidth {
@@ -80,6 +82,10 @@ mixin MediaQueryCapability {
 
   int get safeAreaBottom {
     return _getData().padding.bottom.toInt();
+  }
+
+  int get viewInsetBottom {
+    return _getData().viewInsets.bottom.toInt();
   }
 }
 

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -314,10 +314,12 @@ class PageState extends State<Page> {
       );
     }
 
+    bool? resizeView = widget._pageModel.pageStyles?['resizeView'] ?? false;
+
     Widget rtn = DataScopeWidget(
       scopeManager: _scopeManager,
       child: Scaffold(
-          resizeToAvoidBottomInset: false,
+          resizeToAvoidBottomInset: resizeView,
           // slight optimization, if body background is set, let's paint
           // the entire screen including the Safe Area
           backgroundColor: backgroundColor,


### PR DESCRIPTION
Ticket: #623 
In this PR, I added the following

1. `resizeView` boolean property for the page styles, you can enable or disable it. If enabled, the view will be automatically adjusted by moving the view or input field on top of the keyboard without obscuring it.
2. `device.viewInsetBottom` which provides the keyboard height