### PR TITLE
Add text input field focus and unfocus

### DIFF
--- a/lib/widget/input/dropdown.dart
+++ b/lib/widget/input/dropdown.dart
@@ -6,6 +6,7 @@ import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/widget/helpers/widgets.dart';
 import 'package:ensemble/widget/input/form_helper.dart';
+import 'package:ensemble/widget/input/form_textfield.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -72,6 +73,8 @@ abstract class SelectOne extends StatefulWidget
   @override
   Map<String, Function> methods() {
     return {
+      'focus': () => _controller.inputFieldAction?.focusInputField(),
+      'unfocus': () => _controller.inputFieldAction?.unfocusInputField(),
       'itemsFromString': (dynamic strValues, [dynamic delimiter = ',']) {
         setItemsFromString(strValues, delimiter);
       }
@@ -167,7 +170,13 @@ abstract class SelectOne extends StatefulWidget
 
 enum SelectOneType { dropdown }
 
+mixin SelectOneInputFieldAction on FormFieldWidgetState<SelectOne> {
+  void focusInputField();
+  void unfocusInputField();
+}
+
 class SelectOneController extends FormFieldController {
+  SelectOneInputFieldAction? inputFieldAction;
   List<SelectOneItem>? items;
 
   // this is our value but it can be in an invalid state.
@@ -180,8 +189,11 @@ class SelectOneController extends FormFieldController {
   framework.EnsembleAction? onChange;
 }
 
-class SelectOneState extends FormFieldWidgetState<SelectOne> {
-  final focusNode = FocusNode();
+class SelectOneState extends FormFieldWidgetState<SelectOne>
+    with SelectOneInputFieldAction {
+  FocusNode focusNode = FocusNode();
+  TextEditingController textEditingController = TextEditingController();
+
   @override
   void initState() {
     // validate on blur
@@ -191,6 +203,18 @@ class SelectOneState extends FormFieldWidgetState<SelectOne> {
       }
     });*/
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.controller.inputFieldAction = this;
+  }
+
+  @override
+  void didUpdateWidget(covariant SelectOne oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget.controller.inputFieldAction = this;
   }
 
   @override
@@ -246,22 +270,25 @@ class SelectOneState extends FormFieldWidgetState<SelectOne> {
     } else {
       rtn = LayoutBuilder(
           builder: (context, constraints) => RawAutocomplete<SelectOneItem>(
+                focusNode: focusNode,
+                textEditingController: textEditingController,
                 optionsBuilder: (TextEditingValue textEditingValue) =>
                     buildAutoCompleteOptions(textEditingValue),
                 displayStringForOption: (SelectOneItem option) =>
                     option.label ?? option.value,
                 fieldViewBuilder: (BuildContext context,
-                        TextEditingController fieldTextEditingController,
-                        FocusNode fieldFocusNode,
-                        VoidCallback onFieldSubmitted) =>
-                    TextField(
-                        enabled: isEnabled(),
-                        showCursor: true,
-                        style: const TextStyle(
-                            color: Colors.black, fontWeight: FontWeight.w500),
-                        controller: fieldTextEditingController,
-                        focusNode: fieldFocusNode,
-                        decoration: inputDecoration),
+                    TextEditingController fieldTextEditingController,
+                    FocusNode fieldFocusNode,
+                    VoidCallback onFieldSubmitted) {
+                  return TextField(
+                      enabled: isEnabled(),
+                      showCursor: true,
+                      style: const TextStyle(
+                          color: Colors.black, fontWeight: FontWeight.w500),
+                      controller: fieldTextEditingController,
+                      focusNode: fieldFocusNode,
+                      decoration: inputDecoration);
+                },
                 onSelected: (SelectOneItem selection) {
                   onSelectionChanged(selection.value);
                   if (kDebugMode) {
@@ -418,6 +445,20 @@ class SelectOneState extends FormFieldWidgetState<SelectOne> {
       return (i.abs() - 10).abs().toDouble();
     } else {
       return (i + 10).toDouble();
+    }
+  }
+
+  @override
+  void focusInputField() {
+    if (!focusNode.hasFocus) {
+      focusNode.requestFocus();
+    }
+  }
+
+  @override
+  void unfocusInputField() {
+    if (focusNode.hasFocus) {
+      focusNode.unfocus();
     }
   }
 }

--- a/lib/widget/input/form_textfield.dart
+++ b/lib/widget/input/form_textfield.dart
@@ -81,6 +81,7 @@ abstract class BaseTextInput extends StatefulWidget
   // textController manages 'value', while _controller manages the rest
   final TextEditingController textController = TextEditingController();
   final TextInputController _controller = TextInputController();
+
   @override
   TextInputController get controller => _controller;
 
@@ -117,7 +118,10 @@ abstract class BaseTextInput extends StatefulWidget
 
   @override
   Map<String, Function> methods() {
-    return {};
+    return {
+      'focus': () => _controller.inputFieldAction?.focusInputField(),
+      'unfocus': () => _controller.inputFieldAction?.unfocusInputField(),
+    };
   }
 
   TextInputAction? _getKeyboardAction(dynamic value) {
@@ -145,8 +149,14 @@ abstract class BaseTextInput extends StatefulWidget
   TextInputType? get keyboardType;
 }
 
+mixin TextInputFieldAction on FormFieldWidgetState<BaseTextInput> {
+  void focusInputField();
+  void unfocusInputField();
+}
+
 /// controller for both TextField and Password
 class TextInputController extends FormFieldController {
+  TextInputFieldAction? inputFieldAction;
   EnsembleAction? onChange;
   EnsembleAction? onKeyPress;
   TextInputAction? keyboardAction;
@@ -167,7 +177,8 @@ class TextInputController extends FormFieldController {
   TextStyle? hintStyle;
 }
 
-class TextInputState extends FormFieldWidgetState<BaseTextInput> {
+class TextInputState extends FormFieldWidgetState<BaseTextInput>
+    with TextInputFieldAction {
   final focusNode = FocusNode();
 
   // for this widget we will implement onChange if the text changes AND:
@@ -221,6 +232,18 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput> {
       }
     });
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.controller.inputFieldAction = this;
+  }
+
+  @override
+  void didUpdateWidget(covariant BaseTextInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget.controller.inputFieldAction = this;
   }
 
   @override
@@ -357,6 +380,20 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput> {
                 ),
           decoration: decoration,
         ));
+  }
+
+  @override
+  void focusInputField() {
+    if (!focusNode.hasFocus) {
+      focusNode.requestFocus();
+    }
+  }
+
+  @override
+  void unfocusInputField() {
+    if (focusNode.hasFocus) {
+      focusNode.unfocus();
+    }
   }
 }
 


### PR DESCRIPTION
Ticket: #624 
In this PR, I added focus and unfocus functionality for the text input field. You can invoke the keyboard action (focus & unfocus) like below

```
textInputFieldId.focus();
textInputFieldId.unfocus();
```

![TextField Focus Gif](https://github.com/EnsembleUI/ensemble/assets/12869588/74cee507-f94b-4522-b908-9d518691dd33)


