### PR TITLE
Add few input types, input formatter and update validator

### DIFF
--- a/lib/util/input_formatter.dart
+++ b/lib/util/input_formatter.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/services.dart';
+
+class InputFormatter {
+  static List<TextInputFormatter> getFormatter(String? inputType) {
+    if (inputType == null) return [];
+
+    switch (inputType) {
+      case 'number':
+        return [FilteringTextInputFormatter.digitsOnly];
+      default:
+        return [];
+    }
+  }
+}

--- a/lib/widget/input/form_textfield.dart
+++ b/lib/widget/input/form_textfield.dart
@@ -6,6 +6,7 @@ import 'package:ensemble/framework/theme/theme_manager.dart';
 import 'package:ensemble/framework/widget/icon.dart' as framework;
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/input_formatter.dart';
 import 'package:ensemble/util/input_validator.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/widget/input/form_helper.dart';
@@ -47,6 +48,14 @@ class TextInput extends BaseTextInput {
       return TextInputType.emailAddress;
     } else if (_controller.inputType == InputType.phone.name) {
       return TextInputType.phone;
+    } else if (_controller.inputType == InputType.number.name) {
+      return TextInputType.number;
+    } else if (_controller.inputType == InputType.text.name) {
+      return TextInputType.text;
+    } else if (_controller.inputType == InputType.url.name) {
+      return TextInputType.url;
+    } else if (_controller.inputType == InputType.datetime.name) {
+      return TextInputType.datetime;
     }
     return null;
   }
@@ -297,29 +306,8 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
                       'ensemble.input.required', 'This field is required')
                   : null;
             }
-            // only applicable for TextInput
-            if (!widget.isPassword() && value != null) {
-              if (widget._controller.inputType == InputType.email.name) {
-                if (!EmailValidator.validate(value)) {
-                  return Utils.translateWithFallback(
-                      'ensemble.input.validation.invalidEmailType',
-                      'Please enter a valid email address');
-                }
-              } else if (widget._controller.inputType ==
-                  InputType.ipAddress.name) {
-                if (!InputValidator.ipAddress(value)) {
-                  return Utils.translateWithFallback(
-                      'ensemble.input.validation.invalidIPAddressType',
-                      'Please enter a valid IP Address');
-                }
-              } else if (widget._controller.inputType == InputType.phone.name) {
-                if (!InputValidator.phone(value)) {
-                  return Utils.translateWithFallback(
-                      'ensemble.input.validation.invalidPhoneType',
-                      "Please enter a valid Phone Number");
-                }
-              }
-            }
+
+            // First we're using the validator to validate the TextInput Field
             if (widget._controller.validator != null) {
               ValidationBuilder? builder;
               if (widget._controller.validator?.minLength != null) {
@@ -346,10 +334,37 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
                 return builder.build().call(value);
               }
             }
+
+            // If validator is null, we can use our own validation based on the InputType
+            //only applicable for TextInput
+            if (!widget.isPassword()) {
+              if (widget._controller.inputType == InputType.email.name) {
+                if (!EmailValidator.validate(value)) {
+                  return Utils.translateWithFallback(
+                      'ensemble.input.validation.invalidEmailType',
+                      'Please enter a valid email address');
+                }
+              } else if (widget._controller.inputType ==
+                  InputType.ipAddress.name) {
+                if (!InputValidator.ipAddress(value)) {
+                  return Utils.translateWithFallback(
+                      'ensemble.input.validation.invalidIPAddressType',
+                      'Please enter a valid IP Address');
+                }
+              } else if (widget._controller.inputType == InputType.phone.name) {
+                if (!InputValidator.phone(value)) {
+                  return Utils.translateWithFallback(
+                      'ensemble.input.validation.invalidPhoneType',
+                      "Please enter a valid Phone Number");
+                }
+              }
+            }
             return null;
           },
           textInputAction: widget._controller.keyboardAction,
           keyboardType: widget.keyboardType,
+          inputFormatters:
+              InputFormatter.getFormatter(widget._controller.inputType),
           maxLines: widget._controller.maxLines,
           obscureText: isObscureOrPlainText(),
           enableSuggestions: !widget.isPassword(),
@@ -397,4 +412,4 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
   }
 }
 
-enum InputType { email, phone, ipAddress }
+enum InputType { email, phone, ipAddress, number, text, url, datetime }


### PR DESCRIPTION
Ticket: #669

In this PR, I updated the following things
1. Added input types like `number`, `text`, `url`, `datetime`
2. Added `InputFormatter` for `digits` (Now user can't copy and paste any characters or symbols if we set the input formatters, currently I added it only for digits)
3. Changed the validation logic. The user passed validator will take the first precedence instead of our default validation.

We have the following TextInputType by default in Flutter
1. `number` - It doesn’t have any symbols but only numbers
2. `phone` - It has numbers and symbols (For ex: +, *, #)
4. `emailAddress` - Characters with @ symbol
5. `text, name, streetAddress, visiblePassword` - Only characters (Both types are the same keyboard layout)
6. `url` - It has dot, forward slash, .com with characters keyboard layout
7. `datetime` - It has number with more symbols

Here 4th point, it looks the same keyboard layout for those text input types. So I added only the text instead of others like name, streetAddress, visiblePassword