### PR TITLE
Add text field input mask

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -773,6 +773,10 @@
                 "datetime"
               ]
             },
+            "mask": {
+              "type": "string",
+              "description": "It formats the input by a given mask. Ex: +# (###) ###-##-##"
+            },
             "keyboardAction": {
               "$ref": "#/$defs/keyboardAction"
             },

--- a/lib/util/input_formatter.dart
+++ b/lib/util/input_formatter.dart
@@ -1,14 +1,23 @@
 import 'package:flutter/services.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 class InputFormatter {
-  static List<TextInputFormatter> getFormatter(String? inputType) {
-    if (inputType == null) return [];
-
+  static List<TextInputFormatter> getFormatter(
+      String? inputType, String? mask) {
     switch (inputType) {
       case 'number':
-        return [FilteringTextInputFormatter.digitsOnly];
+        return [
+          FilteringTextInputFormatter.digitsOnly,
+          if (mask != null)
+            MaskTextInputFormatter(
+                mask: mask, type: MaskAutoCompletionType.eager)
+        ];
       default:
-        return [];
+        return [
+          if (mask != null)
+            MaskTextInputFormatter(
+                mask: mask, type: MaskAutoCompletionType.eager)
+        ];
     }
   }
 }

--- a/lib/widget/input/form_textfield.dart
+++ b/lib/widget/input/form_textfield.dart
@@ -18,6 +18,7 @@ import 'package:email_validator/email_validator.dart';
 import 'package:ensemble/framework/model.dart' as model;
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:form_validator/form_validator.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 /// TextInput
 class TextInput extends BaseTextInput {
@@ -32,6 +33,7 @@ class TextInput extends BaseTextInput {
       'obscureText': (obscure) =>
           _controller.obscureText = Utils.optionalBool(obscure),
       'inputType': (type) => _controller.inputType = Utils.optionalString(type),
+      'mask': (type) => _controller.mask = Utils.optionalString(type),
     });
     return setters;
   }
@@ -181,6 +183,7 @@ class TextInputController extends FormFieldController {
 
   model.InputValidator? validator;
   String? inputType;
+  String? mask;
   int maxLines = 1;
   TextStyle? textStyle;
   TextStyle? hintStyle;
@@ -363,8 +366,8 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
           },
           textInputAction: widget._controller.keyboardAction,
           keyboardType: widget.keyboardType,
-          inputFormatters:
-              InputFormatter.getFormatter(widget._controller.inputType),
+          inputFormatters: InputFormatter.getFormatter(
+              widget._controller.inputType, widget._controller.mask),
           maxLines: widget._controller.maxLines,
           obscureText: isObscureOrPlainText(),
           enableSuggestions: !widget.isPassword(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   event_bus: ^2.0.0
   flutter_layout_grid: ^2.0.3
   email_validator: ^2.0.1
+  mask_text_input_formatter: ^2.5.0
   form_validator: ^2.1.1
   flutter_svg: ^2.0.7
   qr_flutter: ^4.1.0


### PR DESCRIPTION
Ticket: #629 

**Sample EDL**
`#` match to the number and `A` to the letter

```yaml
View:
  header:
    title: MaskTextInput

  styles:
    scrollableView: true

  body:
    Column:
      styles:
        gap: 16
        padding: 30
      children:
        - TextInput:
            label: Example 1
            hintText: "Ex: +2 (312) 234-56-89"
            mask: "+# (###) ###-##-##"
            inputType: number
            required: true

        - TextInput:
            label: Example 2
            hintText: "Ex: 11/12/2020"
            mask: "##/##/####"
            inputType: text
            required: true

        - TextInput:
            label: Example 3
            hintText: "Ex: 1234.SBCWEF/25AB"
            mask: "####.AAAAAA/##AA"
            inputType: text
            required: true

```