### PR TITLE
Ensure the singleton managers' initialization is run at most once

### DIFF
--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -7,6 +7,8 @@ import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/secrets.dart';
+import 'package:ensemble/framework/storage_manager.dart';
 import 'package:ensemble/framework/stub/oauth_controller.dart';
 import 'package:ensemble/framework/theme/theme_manager.dart';
 import 'package:ensemble/page_model.dart';
@@ -34,6 +36,32 @@ class Ensemble {
 
   late FirebaseApp ensembleFirebaseApp;
   static final Map<String, dynamic> externalDataContext = {};
+
+
+  /// initialize all the singleton/managers. Note that this function can be
+  /// called multiple times since it's being called inside a widget.
+  /// The actual code block to initialize the managers is guaranteed to run
+  /// at most once.
+  Completer<void>? _completer;
+  Future<void> initManagers() async {
+    // if currently pending or completed, wait till it finishes and do nothing.
+    if (_completer != null) {
+      return _completer!.future;
+    }
+
+    _completer = Completer<void>();
+    try {
+      // this code block is guaranteed to run at most once
+      await StorageManager().init();
+      await SecretsStore().initialize();
+      Device().initDeviceInfo();
+      _completer!.complete();
+    } catch (error) {
+      _completer!.completeError(error);
+    }
+  }
+
+
 
   void notifyAppBundleChanges() {
     _config?.updateAppBundle();

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:ui';
+import 'dart:async';
 
 import 'package:device_preview/device_preview.dart';
 import 'package:ensemble/ensemble.dart';
@@ -95,13 +96,20 @@ class EnsembleApp extends StatefulWidget {
 }
 
 class EnsembleAppState extends State<EnsembleApp> {
+  late Future<EnsembleConfig> config;
+  @override
+  void initState() {
+    super.initState();
+    config = initApp();
+    if (!kIsWeb) {
+      Workmanager().initialize(callbackDispatcher, isInDebugMode: false);
+    }
+  }
+
   /// initialize our App with the the passed in config or
   /// read from our ensemble-config file.
   Future<EnsembleConfig> initApp() async {
-    await SecretsStore().initialize();
-    Device().initDeviceInfo();
-
-    await StorageManager().init();
+    await Ensemble().initManagers();
     StorageManager().setIsPreview(widget.isPreview);
 
     // use the config if passed in
@@ -118,16 +126,6 @@ class EnsembleAppState extends State<EnsembleApp> {
     // else init from config file
     else {
       return Ensemble().initialize();
-    }
-  }
-
-  late Future<EnsembleConfig> config;
-  @override
-  void initState() {
-    super.initState();
-    config = initApp();
-    if (!kIsWeb) {
-      Workmanager().initialize(callbackDispatcher, isInDebugMode: false);
     }
   }
 


### PR DESCRIPTION
I need the ability to run a code block exactly once, even if this code block is inside a widget that can be rebuilt at anytime. Reasons are uniquely to us:
1. don't want to put it inside main(). Customers should be able to simply use EnsembleApp as a widget with zero other setup.
2. Root-level widget EnsembleApp can be rebuilt multiple times - since EnsembleLive relies on a brand new EnsembleApp() with unique key every time for cache busting. Plus customers can recreate this widget any time.