### PR TITLE
add checkPermission action for checking notification status

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -3390,6 +3390,40 @@
               }
             }
           }
+        },
+        {
+          "title": "CheckPermission",
+          "type": "object",
+          "required": [
+            "checkPermission"
+          ],
+          "properties": {
+            "checkPermission": {
+              "type": "object",
+              "description": "Check for user permissions for certain device capabilities",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["notification"]
+                },
+                "onAuthorized": {
+                  "$ref": "#/$defs/Action-payload",
+                  "description": "Execute an Action if this permission was authorized by the user."
+                },
+                "onDenied": {
+                  "$ref": "#/$defs/Action-payload",
+                  "description": "Execute an Action if this permission was denied by the user."
+                },
+                "onNotDetermined": {
+                  "$ref": "#/$defs/Action-payload",
+                  "description": "Execute an Action if we can't determine the permission's status. Note that this state is not applicable on Android."
+                }
+              }
+            }
+          }
         }
       ]
     },

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -1,6 +1,7 @@
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
+import 'package:ensemble/framework/permissions_manager.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
@@ -679,6 +680,28 @@ class ShowNotificationAction extends EnsembleAction {
   }
 }
 
+class CheckPermission extends EnsembleAction {
+  CheckPermission({required dynamic type, this.onAuthorized, this.onDenied, this.onNotDetermined}) : _type = type;
+  final dynamic _type;
+  final EnsembleAction? onAuthorized;
+  final EnsembleAction? onDenied;
+  final EnsembleAction? onNotDetermined;
+  
+  Permission? getType(DataContext dataContext) => Permission.values.from(dataContext.eval(_type));
+  
+  factory CheckPermission.fromYaml({YamlMap? payload}) {
+    if (payload == null || payload['type'] == null) {
+      throw ConfigError('checkPermission requires a type.');
+    }
+    return CheckPermission(
+      type: payload['type'],
+      onAuthorized: EnsembleAction.fromYaml(payload['onAuthorized']),
+      onDenied: EnsembleAction.fromYaml(payload['onDenied']),
+      onNotDetermined: EnsembleAction.fromYaml(payload['onNotDetermined']),
+    );
+  }
+}
+
 enum ActionType {
   invokeAPI,
   navigateScreen,
@@ -704,6 +727,7 @@ enum ActionType {
   copyToClipboard,
   openPlaidLink,
   getPhoneContacts,
+  checkPermission
 }
 
 enum ToastType { success, error, warning, info }
@@ -802,6 +826,8 @@ abstract class EnsembleAction {
     } else if (actionType == ActionType.getPhoneContacts) {
       return PhoneContactAction.fromYaml(
           initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.checkPermission) {
+      return CheckPermission.fromYaml(payload: payload);
     }
     throw LanguageError("Invalid action.",
         recovery: "Make sure to use one of Ensemble-provided actions.");

--- a/lib/framework/permissions_manager.dart
+++ b/lib/framework/permissions_manager.dart
@@ -1,0 +1,37 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+class PermissionsManager {
+  static final PermissionsManager _instance = PermissionsManager._internal();
+  PermissionsManager._internal();
+  factory PermissionsManager() {
+    return _instance;
+  }
+
+  Future<bool?> hasPermission(Permission type) async {
+    bool? status;
+    if (type == Permission.notification) {
+      var settings = await FirebaseMessaging.instance.getNotificationSettings();
+      switch (settings.authorizationStatus) {
+        case AuthorizationStatus.authorized:
+        case AuthorizationStatus.provisional:
+          status = true;
+          break;
+        case AuthorizationStatus.denied:
+          status = false;
+          break;
+        case AuthorizationStatus.notDetermined:
+        default:
+          status = null;
+          break;
+      }
+    }
+    return Future.value(status);
+  }
+
+
+
+}
+
+enum Permission {
+  notification,
+}

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -16,6 +16,7 @@ import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/permissions_manager.dart';
 import 'package:ensemble/framework/stub/camera_manager.dart';
 import 'package:ensemble/framework/stub/contacts_manager.dart';
 import 'package:ensemble/framework/stub/file_manager.dart';
@@ -560,6 +561,25 @@ class ScreenController {
       }
     } else if (action is AuthorizeOAuthAction) {
       // TODO
+    } else if (action is CheckPermission) {
+      Permission? type = action.getType(dataContext);
+      if (type == null) {
+        throw RuntimeError('checkPermission requires a type.');
+      }
+      bool? result = await PermissionsManager().hasPermission(type);
+      if (result == true) {
+        if (action.onAuthorized != null) {
+          executeAction(context, action.onAuthorized!);
+        }
+      } else if (result == false) {
+        if (action.onDenied != null) {
+          executeAction(context, action.onDenied!);
+        }
+      } else {
+        if (action.onNotDetermined != null) {
+          executeAction(context, action.onNotDetermined!);
+        }
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
   dart_jsonwebtoken: ^2.8.2
   flutter_dotenv: ^5.1.0
   get_it: ^7.6.0
+  firebase_messaging: ^14.6.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Note that we use 2 packages for notification: flutter_local_notifications and firebase_messaging. The former is not capable to checking permission reliably across platforms, while the latter has not been officially merged in by @snehmehta . Hence here i'm directly import firebase_messaging. Both of these libraries should be moved to its own module.