### PR TITLE
Open App settings

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2668,6 +2668,41 @@
           }
         },
         {
+          "title": "Open App Settings",
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string",
+              "description": "To open the app settings with the targets",
+              "enum": [
+                "settings",
+                "notification",
+                "subscriptions",
+                "accessibility",
+                "alarm",
+                "apn",
+                "batteryOptimization",
+                "bluetooth",
+                "dataRoaming",
+                "date",
+                "developer",
+                "device",
+                "display",
+                "hotspot",
+                "internalStorage",
+                "location",
+                "lockAndPassword",
+                "nfc",
+                "security",
+                "sound",
+                "vpn",
+                "wifi",
+                "wireless"
+              ]
+            }
+          }
+        },
+        {
           "title": "Invoke API",
           "type": "object",
           "required": [

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -1,3 +1,4 @@
+import 'package:app_settings/app_settings.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
@@ -244,36 +245,27 @@ class PlaidLinkAction extends EnsembleAction {
   }
 }
 
-class PhoneContactAction extends EnsembleAction {
-  PhoneContactAction({
+class AppSettingAction extends EnsembleAction {
+  AppSettingAction({
     super.initiator,
-    this.id,
-    this.onSuccess,
-    this.onError,
+    required this.target,
   });
 
-  final String? id;
-  final EnsembleAction? onSuccess;
-  final EnsembleAction? onError;
+  final String target;
 
-  EnsembleAction? getOnSuccess(DataContext dataContext) =>
-      dataContext.eval(onSuccess);
+  AppSettingsType getTarget(dataContext) =>
+      AppSettingsType.values.from(dataContext.eval(target)) ??
+      AppSettingsType.settings;
 
-  EnsembleAction? getOnError(DataContext dataContext) =>
-      dataContext.eval(onError);
-
-  factory PhoneContactAction.fromYaml(
-      {Invokable? initiator, YamlMap? payload}) {
-    if (payload == null) {
+  factory AppSettingAction.fromYaml({Invokable? initiator, YamlMap? payload}) {
+    if (payload == null || payload['target'] == null) {
       throw LanguageError(
-          "${ActionType.getPhoneContacts.name} action requires payload");
+          "${ActionType.openAppSettings.name} action requires the app settings target");
     }
 
-    return PhoneContactAction(
+    return AppSettingAction(
       initiator: initiator,
-      id: Utils.optionalString(payload['id']),
-      onSuccess: EnsembleAction.fromYaml(payload['onSuccess']),
-      onError: EnsembleAction.fromYaml(payload['onError']),
+      target: Utils.getString(payload['target'], fallback: ''),
     );
   }
 }
@@ -703,7 +695,7 @@ enum ActionType {
   showNotification,
   copyToClipboard,
   openPlaidLink,
-  getPhoneContacts,
+  openAppSettings,
 }
 
 enum ToastType { success, error, warning, info }
@@ -799,9 +791,8 @@ abstract class EnsembleAction {
       return CopyToClipboardAction.fromYaml(payload: payload);
     } else if (actionType == ActionType.openPlaidLink) {
       return PlaidLinkAction.fromYaml(initiator: initiator, payload: payload);
-    } else if (actionType == ActionType.getPhoneContacts) {
-      return PhoneContactAction.fromYaml(
-          initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.openAppSettings) {
+      return AppSettingAction.fromYaml(initiator: initiator, payload: payload);
     }
     throw LanguageError("Invalid action.",
         recovery: "Make sure to use one of Ensemble-provided actions.");

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -259,14 +259,9 @@ class AppSettingAction extends EnsembleAction {
       AppSettingsType.settings;
 
   factory AppSettingAction.fromYaml({Invokable? initiator, YamlMap? payload}) {
-    if (payload == null || payload['target'] == null) {
-      throw LanguageError(
-          "${ActionType.openAppSettings.name} action requires the app settings target");
-    }
-
     return AppSettingAction(
       initiator: initiator,
-      target: Utils.getString(payload['target'], fallback: ''),
+      target: Utils.getString(payload?['target'], fallback: 'settings'),
     );
   }
 }

--- a/lib/framework/device.dart
+++ b/lib/framework/device.dart
@@ -20,8 +20,7 @@ class Device
         Invokable,
         MediaQueryCapability,
         LocationCapability,
-        DeviceInfoCapability,
-        AppSetting {
+        DeviceInfoCapability {
   static final Device _instance = Device._internal();
   Device._internal();
   factory Device() {
@@ -48,12 +47,20 @@ class Device
 
   @override
   Map<String, Function> methods() {
-    return {};
+    return {
+      'openAppSettings': (target) => openAppSettings(target),
+    };
   }
 
   @override
   Map<String, Function> setters() {
     return {};
+  }
+
+  void openAppSettings(String target) {
+    final settingType =
+        AppSettingsType.values.from(target) ?? AppSettingsType.settings;
+    AppSettings.openAppSettings(type: settingType);
   }
 }
 
@@ -241,31 +248,6 @@ class Location with Invokable {
           (distance > 1 ? ' miles' : ' mile');
     }
     return '';
-  }
-}
-
-class AppSetting with Invokable {
-  @override
-  Map<String, Function> getters() {
-    return {};
-  }
-
-  @override
-  Map<String, Function> setters() {
-    return {};
-  }
-
-  @override
-  Map<String, Function> methods() {
-    return {
-      'openAppSettings': openAppSettings,
-    };
-  }
-
-  void openAppSettings(String type) {
-    final settingType =
-        AppSettingsType.values.from(type) ?? AppSettingsType.settings;
-    AppSettings.openAppSettings(type: settingType);
   }
 }
 

--- a/lib/framework/device.dart
+++ b/lib/framework/device.dart
@@ -2,7 +2,9 @@ import 'dart:core';
 import 'dart:io';
 import 'dart:developer';
 
+import 'package:app_settings/app_settings.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/storage_manager.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
@@ -18,7 +20,8 @@ class Device
         Invokable,
         MediaQueryCapability,
         LocationCapability,
-        DeviceInfoCapability {
+        DeviceInfoCapability,
+        AppSetting {
   static final Device _instance = Device._internal();
   Device._internal();
   factory Device() {
@@ -238,6 +241,31 @@ class Location with Invokable {
           (distance > 1 ? ' miles' : ' mile');
     }
     return '';
+  }
+}
+
+class AppSetting with Invokable {
+  @override
+  Map<String, Function> getters() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> setters() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> methods() {
+    return {
+      'openAppSettings': openAppSettings,
+    };
+  }
+
+  void openAppSettings(String type) {
+    final settingType =
+        AppSettingsType.values.from(type) ?? AppSettingsType.settings;
+    AppSettings.openAppSettings(type: settingType);
   }
 }
 

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 import 'dart:math' show Random;
 import 'dart:ui';
 
+import 'package:app_settings/app_settings.dart';
 import 'package:ensemble/action/InvokeAPIController.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/ensemble_app.dart';
@@ -17,7 +18,6 @@ import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/stub/camera_manager.dart';
-import 'package:ensemble/framework/stub/contacts_manager.dart';
 import 'package:ensemble/framework/stub/file_manager.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/stub/plaid_link_manager.dart';
@@ -236,6 +236,9 @@ class ScreenController {
         throw RuntimeError(
             "openPlaidLink action requires the plaid's link_token.");
       }
+    } else if (action is AppSettingAction) {
+      final settingType = action.getTarget(dataContext);
+      AppSettings.openAppSettings(type: settingType);
     } else if (action is PhoneContactAction) {
       GetIt.I<ContactManager>().getPhoneContacts((contacts) {
         if (action.getOnSuccess(dataContext) != null) {

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -19,6 +19,7 @@ import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/permissions_manager.dart';
 import 'package:ensemble/framework/stub/camera_manager.dart';
+import 'package:ensemble/framework/stub/contacts_manager.dart';
 import 'package:ensemble/framework/stub/file_manager.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/stub/plaid_link_manager.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,6 +91,7 @@ dependencies:
   dart_jsonwebtoken: ^2.8.2
   flutter_dotenv: ^5.1.0
   get_it: ^7.6.0
+  app_settings: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Ticket: #709 

In this PR, I added the functionality for opening the app settings. You can do it in two ways
1. Invoke it using `openAppSettings` ensemble action with the target
2. Using `device.openAppSettings()` with target from Javascript

**Both platforms supported targets**
1. settings
2. notification

**iOS supported targets**
1. subscriptions

**Android supported targets**
1. accessibility
2. alarm
4. apn
5. batteryOptimization
6. bluetooth
7. dataRoaming
8. date
9. developer
10. device
11. display
12. hotspot
13. internalStorage
14. location
15. lockAndPassword
16. nfc
17. security
18. sound
19. vpn
20. wifi
21. wireless

YAML
```yaml
View:
  header:
    title: App Settings
  styles:
    scrollableView: false
  body:
    Column:
      styles:
        gap: 24
        padding: 24
        mainAxis: start
        crossAxis: center
      children:
        - Button:
            label: Open Settings
            onTap:
              openAppSettings:
                target: wifi

        - Button:
            label: Open Settings via JS
            onTap:
              executeCode:
                body: |
                  //@code
                  device.openAppSettings("location");

```