### PR TITLE
Refactor saveToKeychain method

### DIFF
--- a/lib/framework/data_context.dart
+++ b/lib/framework/data_context.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:io' as io;
 import 'dart:ui';
@@ -362,14 +363,16 @@ class NativeInvokable with Invokable {
     return {};
   }
 
-  Future<void> saveToKeychain(String key, String value) async {
+  Future<void> saveToKeychain(String key, dynamic value) async {
     if (defaultTargetPlatform != TargetPlatform.iOS) {
       return;
     }
     try {
+      final data = jsonEncode(value);
+      final json = {'key': key, 'data': data};
       const platform = MethodChannel('com.ensembleui.dev/safari-extension');
-      final _ = await platform
-          .invokeMethod(ActionType.saveToKeychain.name, {key: value});
+      final _ =
+          await platform.invokeMethod(ActionType.saveToKeychain.name, json);
     } on PlatformException catch (e) {
       throw LanguageError(
           'Failed to invoke ensemble.saveToKeychain. Reason: ${e.toString()}');


### PR DESCRIPTION
Ticket: #746

From **Ensemble**
```yaml
Button:
  label: SaveToKeychain
  onTap:
    executeCode:
      body: |
        //@code
        ensemble.saveToKeychain("flutter", {"name": "Vinoth"})
        console.log("saveToKeychain called");
```

In **AppDelegate.swift**
![Screenshot 2023-08-23 at 3 00 47 PM (2)](https://github.com/EnsembleUI/ensemble/assets/12869588/b69afcc9-85a5-4739-9367-b06195dad304)
