### PR TITLE
Add clear, focus and unfocus methods and few more style properties to ConfirmationInput widget

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -995,7 +995,7 @@
         }
       ]
     },
-    "Confirmation-payload": {
+    "ConfirmationInput-payload": {
       "type": "object",
       "properties": {
         "length": {
@@ -1023,78 +1023,83 @@
               "properties": {
                 "textStyle": {
                   "$ref": "#/$defs/TextStyle"
+                },
+                "fieldType": {
+                  "type": "string",
+                  "description": "How the input field should be displayed",
+                  "enum": [
+                    "default",
+                    "underline",
+                    "rounded",
+                    "custom"
+                  ]
+                },
+                "inputType": {
+                  "type": "string",
+                  "description": "Pick a predefined input type",
+                  "enum": [
+                    "default",
+                    "email",
+                    "phone",
+                    "ipAddress",
+                    "number",
+                    "text",
+                    "url",
+                    "datetime"
+                  ]
+                },
+                "length": {
+                  "type": "integer",
+                  "description": "The length of the Confirmation Input Field (default is 4)"
+                },
+                "fieldWidth": {
+                  "type": "integer",
+                  "description": "The width of the text field"
+                },
+                "fieldHeight": {
+                  "type": "integer",
+                  "description": "The height of the text field"
+                },
+                "gap": {
+                  "type": "integer",
+                  "description": "Horizontal gap to insert between the children (default is 10)"
+                },
+                "autoComplete": {
+                  "type": "boolean",
+                  "description": "If it is True, then it will trigger onComplete when the user specified length and has typed the full length, False will trigger onComplete when the user hit Enter. Defaults (True)"
+                },
+                "enableCursor": {
+                  "type": "boolean",
+                  "description": "If the button is inside a Form and upon on tap, it will execute the form's onSubmit action if this property is TRUE"
+                },
+                "defaultFieldBorderColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the border color for inactive/unfocused state of text field"
+                },
+                "activeFieldBorderColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the border color for active/focused state of text field"
+                },
+                "filledFieldBorderColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the border color for filled state of text field"
+                },
+                "defaultFieldBackgroundColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the background Color for inactive/unfocused state of text field"
+                },
+                "activeFieldBackgroundColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the ackground Color for active/focused state of text field"
+                },
+                "filledFieldBackgroundColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the ackground Color for filled field state of text field"
+                },
+                "cursorColor": {
+                  "$ref": "#/$defs/typeColors",
+                  "description": "Set the color for the cursor"
                 }
-              },
-              "fieldType": {
-                "type": "string",
-                "description": "How the input field should be displayed",
-                "enum": [
-                  "default",
-                  "underline",
-                  "rounded"
-                ]
-              },
-              "inputType": {
-                "type": "string",
-                "description": "Pick a predefined input type",
-                "enum": [
-                  "default",
-                  "email",
-                  "phone",
-                  "ipAddress",
-                  "number",
-                  "text",
-                  "url",
-                  "datetime"
-                ]
-              },
-              "fieldWidth": {
-                "type": "integer",
-                "description": "The width of the text field"
-              },
-              "fieldHeight": {
-                "type": "integer",
-                "description": "The height of the text field"
-              },
-              "gap": {
-                "type": "integer",
-                "description": "Horizontal gap to insert between the children (default is 10)"
-              },
-              "autoComplete": {
-                "type": "boolean",
-                "description": "If it is True, then it will trigger onComplete when the user specified length and has typed the full length, False will trigger onComplete when the user hit Enter. Defaults (True)"
-              },
-              "enableCursor": {
-                "type": "boolean",
-                "description": "If the button is inside a Form and upon on tap, it will execute the form's onSubmit action if this property is TRUE"
-              },
-              "defaultFieldBorderColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the border color for inactive/unfocused state of text field"
-              },
-              "activeFieldBorderColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the border color for active/focused state of text field"
-              },
-              "filledFieldBorderColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the border color for filled state of text field"
-              },
-              "defaultFieldBackgroundColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the background Color for inactive/unfocused state of text field"
-              },
-              "activeFieldBackgroundColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the ackground Color for active/focused state of text field"
-              },
-              "filledFieldBackgroundColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the ackground Color for filled field state of text field"
-              },
-              "cursorColor": {
-                "$ref": "#/$defs/typeColors",
-                "description": "Set the color for the cursor"
               }
             }
           ]
@@ -3967,6 +3972,18 @@
             "PasswordInput": {
               "$ref": "#/$defs/PasswordInput-payload",
               "description": "Kitchen Sink Example: https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screen/218fa244-f0cd-4d17-91e6-7c099bbedede#"
+            }
+          }
+        },
+        {
+          "title": "ConfirmationInput",
+          "required": [
+            "ConfirmationInput"
+          ],
+          "properties": {
+            "ConfirmationInput": {
+              "$ref": "#/$defs/ConfirmationInput-payload",
+              "description": "Kitchen Sink Example: https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screen/iCOvav6CcioH46LR6wYF"
             }
           }
         },

--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1007,6 +1007,18 @@
                   "datetime"
                 ]
               },
+              "fieldWidth": {
+                "type": "integer",
+                "description": "The width of the text field"
+              },
+              "fieldHeight": {
+                "type": "integer",
+                "description": "The height of the text field"
+              },
+              "gap": {
+                "type": "integer",
+                "description": "Horizontal gap to insert between the children (default is 10)"
+              },
               "autoComplete": {
                 "type": "boolean",
                 "description": "If it is True, then it will trigger onComplete when the user specified length and has typed the full length, False will trigger onComplete when the user hit Enter. Defaults (True)"

--- a/lib/widget/confirmation_input.dart
+++ b/lib/widget/confirmation_input.dart
@@ -39,11 +39,12 @@ class ConfirmationInput extends StatefulWidget
           _controller.enableCursor = Utils.getBool(newValue, fallback: true),
       'length': (newValue) =>
           _controller.length = Utils.getInt(newValue, fallback: 4),
-      'width': (value) => _controller.fieldWidth = Utils.optionalDouble(value),
-      'height': (value) =>
+      'fieldWidth': (value) =>
+          _controller.fieldWidth = Utils.optionalDouble(value),
+      'fieldHeight': (value) =>
           _controller.fieldHeight = Utils.optionalDouble(value),
-      'padding': (value) =>
-          _controller.fieldPadding = Utils.getDouble(value, fallback: 10.0),
+      'gap': (value) =>
+          _controller.fieldGap = Utils.getDouble(value, fallback: 10.0),
       'borderRadius': (value) =>
           _controller.fieldBorderRadius = Utils.getDouble(value, fallback: 2.0),
       'borderWidth': (value) =>
@@ -111,7 +112,7 @@ class ConfirmationInputController extends FormInputController {
   String? inputType;
   double? fieldWidth;
   double? fieldHeight;
-  double? fieldPadding;
+  double? fieldGap;
   double? fieldBorderRadius;
   double? fieldBorderWidth;
   Color? defaultFieldBorderColor;
@@ -170,7 +171,7 @@ class ConfirmationInputState extends framework.WidgetState<ConfirmationInput>
             controller.filledFieldBackgroundColor ?? Colors.transparent,
         filledFieldBorderColor:
             controller.filledFieldBorderColor ?? Colors.transparent,
-        fieldPadding: controller.fieldPadding ?? 10.0,
+        fieldPadding: controller.fieldGap ?? 10.0,
         fieldBorderRadius: controller.fieldBorderRadius ?? 2.0,
         fieldBorderWidth: controller.fieldBorderWidth ?? 2.0,
       ),

--- a/lib/widget/confirmation_input.dart
+++ b/lib/widget/confirmation_input.dart
@@ -102,8 +102,7 @@ class ConfirmationInput extends StatefulWidget
   }
 }
 
-class ConfirmationInputController extends BoxController {
-  TextInputFieldAction? inputFieldAction;
+class ConfirmationInputController extends FormInputController {
   String? text;
   late int length;
   bool? autoComplete;
@@ -130,14 +129,8 @@ class ConfirmationInputController extends BoxController {
   set textStyle(TextStyleComposite style) => _textStyle = style;
 }
 
-mixin TextInputFieldAction on framework.WidgetState<ConfirmationInput> {
-  void focusInputField();
-  void unfocusInputField();
-  void clear();
-}
-
 class ConfirmationInputState extends framework.WidgetState<ConfirmationInput>
-    with TextInputFieldAction {
+    with InputFieldAction {
   final _otpPinFieldController = GlobalKey<OtpPinFieldState>();
 
   @override

--- a/lib/widget/confirmation_input.dart
+++ b/lib/widget/confirmation_input.dart
@@ -39,6 +39,15 @@ class ConfirmationInput extends StatefulWidget
           _controller.enableCursor = Utils.getBool(newValue, fallback: true),
       'length': (newValue) =>
           _controller.length = Utils.getInt(newValue, fallback: 4),
+      'width': (value) => _controller.fieldWidth = Utils.optionalDouble(value),
+      'height': (value) =>
+          _controller.fieldHeight = Utils.optionalDouble(value),
+      'padding': (value) =>
+          _controller.fieldPadding = Utils.getDouble(value, fallback: 10.0),
+      'borderRadius': (value) =>
+          _controller.fieldBorderRadius = Utils.getDouble(value, fallback: 2.0),
+      'borderWidth': (value) =>
+          _controller.fieldBorderWidth = Utils.getDouble(value, fallback: 2.0),
       'textStyle': (style) => _controller.textStyle =
           Utils.getTextStyleAsComposite(_controller, style: style),
       'defaultFieldBorderColor': (newValue) =>
@@ -64,7 +73,11 @@ class ConfirmationInput extends StatefulWidget
 
   @override
   Map<String, Function> methods() {
-    return {};
+    return {
+      'clear': () => controller.inputFieldAction?.clear(),
+      'focus': () => controller.inputFieldAction?.focusInputField(),
+      'unfocus': () => controller.inputFieldAction?.unfocusInputField(),
+    };
   }
 
   @override
@@ -90,12 +103,18 @@ class ConfirmationInput extends StatefulWidget
 }
 
 class ConfirmationInputController extends BoxController {
+  TextInputFieldAction? inputFieldAction;
   String? text;
   late int length;
   bool? autoComplete;
   bool? enableCursor;
   String? fieldType;
   String? inputType;
+  double? fieldWidth;
+  double? fieldHeight;
+  double? fieldPadding;
+  double? fieldBorderRadius;
+  double? fieldBorderWidth;
   Color? defaultFieldBorderColor;
   Color? activeFieldBorderColor;
   Color? defaultFieldBackgroundColor;
@@ -111,7 +130,28 @@ class ConfirmationInputController extends BoxController {
   set textStyle(TextStyleComposite style) => _textStyle = style;
 }
 
-class ConfirmationInputState extends framework.WidgetState<ConfirmationInput> {
+mixin TextInputFieldAction on framework.WidgetState<ConfirmationInput> {
+  void focusInputField();
+  void unfocusInputField();
+  void clear();
+}
+
+class ConfirmationInputState extends framework.WidgetState<ConfirmationInput>
+    with TextInputFieldAction {
+  final _otpPinFieldController = GlobalKey<OtpPinFieldState>();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    widget.controller.inputFieldAction = this;
+  }
+
+  @override
+  void didUpdateWidget(covariant ConfirmationInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget.controller.inputFieldAction = this;
+  }
+
   @override
   Widget buildWidget(BuildContext context) {
     return BoxWrapper(
@@ -122,6 +162,7 @@ class ConfirmationInputState extends framework.WidgetState<ConfirmationInput> {
 
   Widget buildTextInput(ConfirmationInputController controller) {
     return OtpPinField(
+      key: _otpPinFieldController,
       otpPinFieldStyle: OtpPinFieldStyle(
         textStyle: controller.textStyle.getTextStyle(),
         defaultFieldBorderColor:
@@ -136,7 +177,12 @@ class ConfirmationInputState extends framework.WidgetState<ConfirmationInput> {
             controller.filledFieldBackgroundColor ?? Colors.transparent,
         filledFieldBorderColor:
             controller.filledFieldBorderColor ?? Colors.transparent,
+        fieldPadding: controller.fieldPadding ?? 10.0,
+        fieldBorderRadius: controller.fieldBorderRadius ?? 2.0,
+        fieldBorderWidth: controller.fieldBorderWidth ?? 2.0,
       ),
+      fieldHeight: widget.controller.fieldHeight ?? 50,
+      fieldWidth: widget.controller.fieldWidth ?? 50,
       maxLength: controller.length,
       keyboardType: widget.keyboardType,
       otpPinFieldDecoration: controller.fieldType?.otpPinField ??
@@ -161,13 +207,30 @@ class ConfirmationInputState extends framework.WidgetState<ConfirmationInput> {
       ScreenController().executeAction(context, widget._controller.onComplete!);
     }
   }
+
+  @override
+  void clear() {
+    _otpPinFieldController.currentState?.clearOtp();
+  }
+
+  @override
+  void focusInputField() {
+    _otpPinFieldController.currentState?.hasFocus = true;
+    _otpPinFieldController.currentState?.focusNode.requestFocus();
+  }
+
+  @override
+  void unfocusInputField() {
+    _otpPinFieldController.currentState?.hasFocus = false;
+    _otpPinFieldController.currentState?.focusNode.unfocus();
+  }
 }
 
 extension FieldTypeOtpValue on String {
   OtpPinFieldDecoration get otpPinField {
     switch (this) {
-      case 'default':
-        return OtpPinFieldDecoration.defaultPinBoxDecoration;
+      case 'custom':
+        return OtpPinFieldDecoration.custom;
       case 'rounded':
         return OtpPinFieldDecoration.roundedPinBoxDecoration;
       case 'underline':

--- a/lib/widget/confirmation_input.dart
+++ b/lib/widget/confirmation_input.dart
@@ -103,7 +103,8 @@ class ConfirmationInput extends StatefulWidget
   }
 }
 
-class ConfirmationInputController extends FormInputController {
+class ConfirmationInputController extends BoxController {
+  InputFieldAction? inputFieldAction;
   String? text;
   late int length;
   bool? autoComplete;
@@ -128,6 +129,12 @@ class ConfirmationInputController extends FormInputController {
   TextStyleComposite? _textStyle;
   TextStyleComposite get textStyle => _textStyle ??= TextStyleComposite(this);
   set textStyle(TextStyleComposite style) => _textStyle = style;
+}
+
+mixin InputFieldAction on framework.WidgetState<ConfirmationInput> {
+  void focusInputField();
+  void unfocusInputField();
+  void clear();
 }
 
 class ConfirmationInputState extends framework.WidgetState<ConfirmationInput>

--- a/lib/widget/helpers/controllers.dart
+++ b/lib/widget/helpers/controllers.dart
@@ -263,3 +263,24 @@ class BoxController extends WidgetController {
       shadowRadius != null ||
       shadowStyle != null;
 }
+
+mixin InputFieldAction<T extends StatefulWidget> on State<T> {
+  void focusInputField();
+  void unfocusInputField();
+  void clear();
+}
+
+class FormInputController extends BoxController {
+  InputFieldAction? inputFieldAction;
+
+  @override
+  Map<String, Function> getBaseMethods() {
+    Map<String, Function> methods = super.getBaseMethods();
+    methods.addAll({
+      'clear': () => inputFieldAction?.clear(),
+      'focus': () => inputFieldAction?.focusInputField(),
+      'unfocus': () => inputFieldAction?.unfocusInputField(),
+    });
+    return methods;
+  }
+}

--- a/lib/widget/helpers/controllers.dart
+++ b/lib/widget/helpers/controllers.dart
@@ -263,24 +263,3 @@ class BoxController extends WidgetController {
       shadowRadius != null ||
       shadowStyle != null;
 }
-
-mixin InputFieldAction<T extends StatefulWidget> on State<T> {
-  void focusInputField();
-  void unfocusInputField();
-  void clear();
-}
-
-class FormInputController extends BoxController {
-  InputFieldAction? inputFieldAction;
-
-  @override
-  Map<String, Function> getBaseMethods() {
-    Map<String, Function> methods = super.getBaseMethods();
-    methods.addAll({
-      'clear': () => inputFieldAction?.clear(),
-      'focus': () => inputFieldAction?.focusInputField(),
-      'unfocus': () => inputFieldAction?.unfocusInputField(),
-    });
-    return methods;
-  }
-}


### PR DESCRIPTION
In this PR, I added a few properties and methods for the **ConfirmationInput** widget

**Style Properties:**
1. fieldHeight
2. fieldWidth
3. gap
4. borderRadius
5. borderWidth
6. Added custom type for field

NOTE: 4th and 5th properties will work only if you've `fieldType` as `custom`

**Methods:**
1. clear
2. focus
3. unfocus