### PR TITLE
Update BoxWrapper to support fallback backgroundImage

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -5749,6 +5749,10 @@
               "type": "string",
               "description": "The Image URL to fill the background"
             },
+            "fallback": {
+              "$ref": "#/$defs/Widget",
+              "description": "Return an inline widget or specify a custom widget to be rendered when the backgroundImage failed to load the image"
+            },
             "fit": {
               "type": "string",
               "description": "How to fit the image within our width/height or our parent (if dimension is not specified)",

--- a/lib/framework/model.dart
+++ b/lib/framework/model.dart
@@ -43,8 +43,10 @@ class BackgroundImage {
       image: imageProvider,
       fit: _fit,
       alignment: _alignment,
-      onError: (_, __) =>
-          fallbackWidget != null ? (_, __, ___) => fallbackWidget : null,
+      onError: (_, __) {
+        // TODO: onError doesn't have errorBuilder to set the fallback widget
+        // return fallbackWidget != null ? (_, __, ___) => fallbackWidget : null;
+      },
     );
   }
 

--- a/lib/framework/model.dart
+++ b/lib/framework/model.dart
@@ -28,11 +28,7 @@ class BackgroundImage {
   final Alignment _alignment;
   final dynamic _fallback;
 
-  DecorationImage getImageAsDecorated(ScopeManager? scopeManager) {
-    final Widget? fallbackWidget = _fallback != null
-        ? scopeManager?.buildWidgetFromDefinition(_fallback)
-        : null;
-
+  DecorationImage getImageAsDecorated() {
     ImageProvider imageProvider;
     if (Utils.isUrl(_source)) {
       imageProvider = NetworkImage(_source);
@@ -43,10 +39,6 @@ class BackgroundImage {
       image: imageProvider,
       fit: _fit,
       alignment: _alignment,
-      onError: (_, __) {
-        // TODO: onError doesn't have errorBuilder to set the fallback widget
-        // return fallbackWidget != null ? (_, __, ___) => fallbackWidget : null;
-      },
     );
   }
 

--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -56,48 +56,56 @@ class BoxWrapper extends StatelessWidget {
       clip = Clip.hardEdge;
     }
     ScopeManager? scopeManager = DataScopeWidget.getScope(context);
+    final Widget? backgroundImage =
+        boxController.backgroundImage?.getImageAsWidget(scopeManager);
 
     return Container(
-        width: ignoresDimension ? null : boxController.width?.toDouble(),
-        height: ignoresDimension ? null : boxController.height?.toDouble(),
-        margin: ignoresMargin ? null : boxController.margin,
-        padding: ignoresPadding ? null : boxController.padding,
-        clipBehavior: clip,
-        child: widget,
-        decoration: !boxController.hasBoxDecoration()
-            ? null
-            : BoxDecoration(
-                color: boxController.backgroundColor,
-                image: boxController.backgroundImage
-                    ?.getImageAsDecorated(scopeManager),
-                gradient: boxController.backgroundGradient,
-                border: !boxController.hasBorder()
-                    ? null
-                    : boxController.borderGradient != null
-                        ? GradientBoxBorder(
-                            gradient: boxController.borderGradient!,
-                            width: boxController.borderWidth?.toDouble() ??
-                                ThemeManager().getBorderThickness(context))
-                        : Border.all(
-                            color: boxController.borderColor ??
-                                ThemeManager().getBorderColor(context),
-                            width: boxController.borderWidth?.toDouble() ??
-                                ThemeManager().getBorderThickness(context)),
-                borderRadius: boxController.borderRadius?.getValue(),
-                boxShadow: !boxController.hasBoxShadow()
-                    ? null
-                    : <BoxShadow>[
-                        BoxShadow(
-                            color: boxController.shadowColor ??
-                                ThemeManager().getShadowColor(context),
-                            blurRadius:
-                                boxController.shadowRadius?.toDouble() ??
-                                    ThemeManager().getShadowRadius(context),
-                            offset: boxController.shadowOffset ??
-                                ThemeManager().getShadowOffset(context),
-                            blurStyle: boxController.shadowStyle ??
-                                ThemeManager().getShadowStyle(context))
-                      ]));
+      width: ignoresDimension ? null : boxController.width?.toDouble(),
+      height: ignoresDimension ? null : boxController.height?.toDouble(),
+      margin: ignoresMargin ? null : boxController.margin,
+      padding: ignoresPadding ? null : boxController.padding,
+      clipBehavior: clip,
+      decoration: !boxController.hasBoxDecoration()
+          ? null
+          : BoxDecoration(
+              color: boxController.backgroundColor,
+              gradient: boxController.backgroundGradient,
+              border: !boxController.hasBorder()
+                  ? null
+                  : boxController.borderGradient != null
+                      ? GradientBoxBorder(
+                          gradient: boxController.borderGradient!,
+                          width: boxController.borderWidth?.toDouble() ??
+                              ThemeManager().getBorderThickness(context))
+                      : Border.all(
+                          color: boxController.borderColor ??
+                              ThemeManager().getBorderColor(context),
+                          width: boxController.borderWidth?.toDouble() ??
+                              ThemeManager().getBorderThickness(context)),
+              borderRadius: boxController.borderRadius?.getValue(),
+              boxShadow: !boxController.hasBoxShadow()
+                  ? null
+                  : <BoxShadow>[
+                      BoxShadow(
+                          color: boxController.shadowColor ??
+                              ThemeManager().getShadowColor(context),
+                          blurRadius: boxController.shadowRadius?.toDouble() ??
+                              ThemeManager().getShadowRadius(context),
+                          offset: boxController.shadowOffset ??
+                              ThemeManager().getShadowOffset(context),
+                          blurStyle: boxController.shadowStyle ??
+                              ThemeManager().getShadowStyle(context))
+                    ],
+            ),
+      child: backgroundImage != null
+          ? Stack(
+              children: [
+                backgroundImage,
+                widget,
+              ],
+            )
+          : widget,
+    );
   }
 }
 

--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -100,7 +100,7 @@ class BoxWrapper extends StatelessWidget {
       child: backgroundImage != null
           ? Stack(
               children: [
-                backgroundImage,
+                Positioned.fill(child: backgroundImage),
                 widget,
               ],
             )


### PR DESCRIPTION
Ticket: [#798](https://github.com/EnsembleUI/ensemble/issues/798)

Removed image from the BoxDecoration and added the `backgroundImage` as a image widget inside the stack along with the child widget.