### PR TITLE
Defer building the child widgets to the parent's build()

### DIFF
--- a/lib/framework/widget/has_children.dart
+++ b/lib/framework/widget/has_children.dart
@@ -1,0 +1,28 @@
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/view/data_scope_widget.dart';
+import 'package:ensemble/framework/widget/widget.dart';
+import 'package:ensemble/page_model.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter/cupertino.dart';
+
+mixin HasChildren<W extends HasController> on WidgetState<W> {
+
+  List<Widget> buildChildren(List<WidgetModel> models) {
+    if (scopeManager != null) {
+      return models.map((model) => scopeManager!.buildWidget(model)).toList();
+    }
+
+    BuildContext _context = context;
+    ScopeManager? _scopeManager = DataScopeWidget.getScope(context);
+
+    return [];
+  }
+
+  Widget buildChild(WidgetModel model) {
+    if (scopeManager == null) {
+      throw RuntimeError("scopeManager is null while building its child");
+    }
+    return scopeManager!.buildWidget(model);
+  }
+}


### PR DESCRIPTION
Previously we created a widget outside, then pass it to the parent to add it to the parent tree. This is a problem on rebuild since the widget's context (created outside) is different, which cause the State to rebuild but retain the StatefulWidget. This was missed until we put the code in to remove a widget's binding listeners on dispose(). Since the key to remove the listener is the StatefulWidget, which stays the same while we have multiple States.

With this change, the StatefulWidget and the State are always in lock step. They are still created more often than necessary, but that's another optimization for another day.