### PR TITLE
Defer building the child widgets to the parent's build()

### DIFF
--- a/lib/framework/scope.dart
+++ b/lib/framework/scope.dart
@@ -422,6 +422,10 @@ mixin PageBindingManager on IsScopeManager {
   /// remove all the binding listeners that this widget is listening to.
   /// Call this when a widget is disposed
   void removeBindingListeners(Invokable destinationWidget) {
+    // int? count = listenerMap[destinationWidget]?.values.length;
+    // if (count != null) {
+    //   log("Removing ${count} binding listeners for (${destinationWidget.runtimeType} - ${destinationWidget.hashCode})");
+    // }
     listenerMap[destinationWidget]?.values.forEach((e) => e.cancel());
   }
 

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -250,16 +250,11 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
   }
 
   Widget? _buildCustomIcon(MenuItem item, {bool isActive = false}) {
-    Widget? iconWidget;
     dynamic customWidgetModel =
         isActive ? item.customActiveWidget : item.customWidget;
     if (customWidgetModel != null) {
-      final child = widget.scopeManager.buildWidget(customWidgetModel!);
-      final dataScopeWidget = child as DataScopeWidget;
-      final customWidget = dataScopeWidget.child as CustomView;
-      iconWidget = customWidget.childWidget;
+      return widget.scopeManager.buildWidget(customWidgetModel!);
     }
-    return iconWidget;
   }
 }
 

--- a/lib/framework/widget/custom_view.dart
+++ b/lib/framework/widget/custom_view.dart
@@ -24,8 +24,10 @@ class CustomView extends StatelessWidget with Invokable {
   Widget build(BuildContext context) {
     // execute onLoad once if applicable
     if (viewBehavior.onLoad != null && !onLoadExecuted) {
-      ScreenController().executeAction(context, viewBehavior.onLoad!);
       onLoadExecuted = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ScreenController().executeAction(context, viewBehavior.onLoad!);
+      });
     }
     return childWidget;
   }

--- a/lib/framework/widget/view_util.dart
+++ b/lib/framework/widget/view_util.dart
@@ -235,12 +235,15 @@ class ViewUtil {
       if (w is UpdatableContainer) {
         List<Widget>? children;
         if (model.children != null) {
-          children = [];
-          for (WidgetModel model in model.children!) {
-            //children.add(buildBareWidget(ScopeNode(currentScope), model, modelMap));
-            children.add(buildBareWidget(scopeNode, model, modelMap));
-          }
-          modelMap[model]!.children = children;
+          // children = [];
+          // for (WidgetModel model in model.children!) {
+          //   //children.add(buildBareWidget(ScopeNode(currentScope), model, modelMap));
+          //   children.add(buildBareWidget(scopeNode, model, modelMap));
+          // }
+
+          // we are now defer the widget building to the actual parent widget.
+          // Here we just pass the children's WidgetModel
+          modelMap[model]!.children = model.children;
         }
       }
       // for Custom View, we wraps it around a DataScope to separate the data context.
@@ -299,7 +302,7 @@ class ModelPayload {
 
   final Widget widget;
   final ScopeManager scopeManager;
-  List<Widget>? children;
+  List<WidgetModel>? children;
 }
 
 /// wrapper ScopeManager as a tree node

--- a/lib/framework/widget/widget.dart
+++ b/lib/framework/widget/widget.dart
@@ -15,7 +15,7 @@ import 'package:yaml/yaml.dart';
 
 /// base mixin for Ensemble Container (e.g Column)
 mixin UpdatableContainer<T extends Widget> {
-  void initChildren({List<T>? children, ItemTemplate? itemTemplate});
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate});
 }
 
 /// base class for widgets that want to participate in Ensemble layout

--- a/lib/layout/box/base_box_layout.dart
+++ b/lib/layout/box/base_box_layout.dart
@@ -92,7 +92,7 @@ class BoxLayoutController extends BaseBoxLayoutController
 }
 
 abstract class BaseBoxLayoutController extends BoxController {
-  List<Widget>? children;
+  List<WidgetModel>? children;
   EnsembleAction? onTap;
   EnsembleAction? onItemTap;
 

--- a/lib/layout/box/box_layout.dart
+++ b/lib/layout/box/box_layout.dart
@@ -1,7 +1,10 @@
+import 'dart:developer';
+
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/extensions.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/layout/box/base_box_layout.dart';
@@ -116,7 +119,7 @@ abstract class BoxLayout extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     _controller.itemTemplate = itemTemplate;
   }
@@ -127,7 +130,8 @@ abstract class BoxLayout extends StatefulWidget
   bool isVertical();
 }
 
-class BoxLayoutState extends WidgetState<BoxLayout> with TemplatedWidgetState {
+class BoxLayoutState extends WidgetState<BoxLayout>
+    with TemplatedWidgetState, HasChildren<BoxLayout> {
   List<Widget>? templatedChildren;
 
   @override
@@ -148,10 +152,14 @@ class BoxLayoutState extends WidgetState<BoxLayout> with TemplatedWidgetState {
       // In that case we want to evaluate the data to see if they are there
       registerItemTemplate(context, widget._controller.itemTemplate!,
           evaluateInitialValue: true, onDataChanged: (List dataList) {
-        setState(() {
-          templatedChildren = buildWidgetsFromTemplate(
-              context, dataList, widget._controller.itemTemplate!);
-        });
+        if (mounted) {
+          setState(() {
+            templatedChildren = buildWidgetsFromTemplate(
+                context, dataList, widget._controller.itemTemplate!);
+          });
+        } else {
+          log("Stale setState() for ${widget.runtimeType} - ${widget.hashCode}");
+        }
       });
     }
   }
@@ -164,7 +172,9 @@ class BoxLayoutState extends WidgetState<BoxLayout> with TemplatedWidgetState {
 
   @override
   Widget buildWidget(BuildContext context) {
-    List<Widget>? childrenList = widget._controller.children;
+    List<Widget>? childrenList = widget._controller.children != null
+        ? buildChildren(widget._controller.children!)
+        : null;
     List<Widget>? templatedList = templatedChildren;
 
     if (widget._controller.onItemTap != null) {

--- a/lib/layout/box/fitted_box_layout.dart
+++ b/lib/layout/box/fitted_box_layout.dart
@@ -1,6 +1,7 @@
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/model.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/layout/box/base_box_layout.dart';
 import 'package:ensemble/layout/box/box_layout.dart';
@@ -60,7 +61,7 @@ abstract class FittedBoxLayout extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
   }
 
@@ -68,7 +69,7 @@ abstract class FittedBoxLayout extends StatefulWidget
 }
 
 class FittedBoxLayoutState extends WidgetState<FittedBoxLayout>
-    with TemplatedWidgetState {
+    with TemplatedWidgetState, HasChildren<FittedBoxLayout> {
   @override
   Widget buildWidget(BuildContext context) {
     if (widget._controller.children == null ||
@@ -79,7 +80,7 @@ class FittedBoxLayoutState extends WidgetState<FittedBoxLayout>
     // by default wrap each child inside Expanded unless `auto` is specified
     List<Widget> items = [];
     for (int i = 0; i < widget._controller.children!.length; i++) {
-      Widget child = widget._controller.children![i];
+      Widget child = buildChild(widget._controller.children![i]);
 
       // default flex is 1 if not specified
       BoxFlex flex = widget._controller.childrenFits != null &&

--- a/lib/layout/data_grid.dart
+++ b/lib/layout/data_grid.dart
@@ -3,6 +3,7 @@ import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/layout/templated.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/framework/widget/widget.dart';
@@ -43,7 +44,7 @@ class DataGrid extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     this.itemTemplate = itemTemplate;
   }
@@ -132,7 +133,7 @@ class EnsembleDataColumn extends DataColumn {
 class EnsembleDataRow extends StatefulWidget
     with UpdatableContainer, Invokable {
   static const type = 'DataRow';
-  List<Widget>? children;
+  List<WidgetModel>? children;
   ItemTemplate? itemTemplate;
   bool visible = true;
 
@@ -140,7 +141,7 @@ class EnsembleDataRow extends StatefulWidget
   State<StatefulWidget> createState() => EnsembleDataRowState();
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     this.children = children;
     this.itemTemplate = itemTemplate;
   }
@@ -172,7 +173,7 @@ class EnsembleDataRowState extends State<EnsembleDataRow> {
 }
 
 class DataGridController extends BoxController {
-  List<Widget>? children;
+  List<WidgetModel>? children;
   Map<String, dynamic>? sorting;
   double? horizontalMargin;
   GenericTextController? headingTextController;
@@ -212,7 +213,7 @@ class DataColumnSort {
   });
 }
 
-class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
+class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState, HasChildren<DataGrid> {
   List<Widget>? templatedChildren;
   List<EnsembleDataColumn> _columns = [];
   List<dynamic> dataList = [];
@@ -370,7 +371,7 @@ class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
       }
       List<DataCell> cells = [];
       if (child.children != null) {
-        child.children!.asMap().forEach((index, Widget c) {
+        buildChildren(child.children!).asMap().forEach((index, Widget c) {
           // for templated row only, wrap each cell widget in a DataScopeWidget, and simply use the row's datascope
           if (rowScope != null) {
             Widget scopeWidget =
@@ -435,7 +436,7 @@ class DataGridState extends WidgetState<DataGrid> with TemplatedWidgetState {
   void _buildChildren() {
     _children.clear();
     if (widget._controller.children != null) {
-      _children.addAll(widget._controller.children!);
+      _children.addAll(buildChildren(widget._controller.children!));
     }
     if (templatedChildren != null) {
       _children.addAll(templatedChildren!);

--- a/lib/layout/flow.dart
+++ b/lib/layout/flow.dart
@@ -1,4 +1,5 @@
 import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/layout/templated.dart';
@@ -60,7 +61,7 @@ class Flow extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     this.itemTemplate = itemTemplate;
   }
@@ -78,12 +79,12 @@ class FlowController extends BoxController {
   int? maxWidth;
   int? maxHeight;
 
-  List<Widget>? children;
+  List<WidgetModel>? children;
   EnsembleAction? onItemTap;
   int selectedItemIndex = -1;
 }
 
-class FlowState extends WidgetState<Flow> with TemplatedWidgetState {
+class FlowState extends WidgetState<Flow> with TemplatedWidgetState, HasChildren<Flow> {
   List<Widget>? templatedChildren;
 
   @override
@@ -119,7 +120,7 @@ class FlowState extends WidgetState<Flow> with TemplatedWidgetState {
     List<Widget> children = [];
 
     if (widget._controller.children != null) {
-      children.addAll(widget._controller.children!);
+      children.addAll(buildChildren(widget._controller.children!));
     }
 
     if (templatedChildren != null) {

--- a/lib/layout/form.dart
+++ b/lib/layout/form.dart
@@ -1,4 +1,5 @@
 import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/layout_utils.dart';
@@ -34,7 +35,7 @@ class EnsembleForm extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
   }
 
@@ -88,7 +89,7 @@ class FormController extends WidgetController {
   static const _defaultGap = 10;
 
   EnsembleAction? onSubmit;
-  List<Widget>? children;
+  List<WidgetModel>? children;
   LabelPosition labelPosition = LabelPosition.top;
   String? labelOverflow;
   bool? enabled;
@@ -102,7 +103,7 @@ class FormController extends WidgetController {
   int gap = _defaultGap;
 }
 
-class FormState extends WidgetState<EnsembleForm> {
+class FormState extends WidgetState<EnsembleForm> with HasChildren<EnsembleForm> {
   final _formKey = GlobalKey<flutter.FormState>();
   bool validate() {
     return _formKey.currentState!.validate();
@@ -118,9 +119,9 @@ class FormState extends WidgetState<EnsembleForm> {
     Widget? body;
     // use grid if labels are side by side
     if (widget._controller.labelPosition == LabelPosition.start) {
-      body = buildGrid(widget._controller.children!);
+      body = buildGrid(buildChildren(widget._controller.children!));
     } else {
-      body = buildColumn(widget._controller.children!);
+      body = buildColumn(buildChildren(widget._controller.children!));
     }
     Widget rtn = SizedBox(
         width: widget._controller.width?.toDouble(),

--- a/lib/layout/grid_view.dart
+++ b/lib/layout/grid_view.dart
@@ -73,7 +73,7 @@ class GridView extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.itemTemplate = itemTemplate;
   }
 }

--- a/lib/layout/list_view.dart
+++ b/lib/layout/list_view.dart
@@ -1,5 +1,6 @@
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/extensions.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/layout/box/base_box_layout.dart';
 import 'package:ensemble/layout/box/box_layout.dart';
@@ -59,7 +60,7 @@ class ListView extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     _controller.itemTemplate = itemTemplate;
   }
@@ -77,7 +78,8 @@ class ListViewController extends BoxLayoutController {
   EdgeInsets? separatorPadding;
 }
 
-class ListViewState extends WidgetState<ListView> with TemplatedWidgetState {
+class ListViewState extends WidgetState<ListView>
+    with TemplatedWidgetState, HasChildren<ListView> {
   // template item is created on scroll. this will store the template's data list
   List<dynamic>? templatedDataList;
 
@@ -120,7 +122,7 @@ class ListViewState extends WidgetState<ListView> with TemplatedWidgetState {
           Widget? itemWidget;
           if (widget._controller.children != null &&
               index < widget._controller.children!.length) {
-            itemWidget = widget._controller.children![index];
+            itemWidget = buildChild(widget._controller.children![index]);
           }
           // create widget from item template
           else if (templatedDataList != null &&

--- a/lib/layout/stack.dart
+++ b/lib/layout/stack.dart
@@ -1,3 +1,4 @@
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/framework/widget/widget.dart';
@@ -31,7 +32,7 @@ class EnsembleStack extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     this.itemTemplate = itemTemplate;
   }
@@ -51,11 +52,11 @@ class EnsembleStack extends StatefulWidget
 }
 
 class StackController extends WidgetController {
-  List<Widget>? children;
+  List<WidgetModel>? children;
   Alignment? alignChildren;
 }
 
-class StackState extends WidgetState<EnsembleStack> {
+class StackState extends WidgetState<EnsembleStack> with HasChildren<EnsembleStack> {
   @override
   Widget buildWidget(BuildContext context) {
     if (widget._controller.children == null ||
@@ -65,7 +66,7 @@ class StackState extends WidgetState<EnsembleStack> {
 
     return Stack(
       alignment: widget._controller.alignChildren ?? Alignment.topLeft,
-      children: widget._controller.children!,
+      children: buildChildren(widget._controller.children!),
     );
   }
 }

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/action.dart';
@@ -7,6 +9,7 @@ import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/view/page.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/screen.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/layout/templated.dart';
@@ -96,7 +99,7 @@ class Carousel extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     _controller.itemTemplate = itemTemplate;
   }
@@ -106,7 +109,7 @@ class MyController extends BoxController {
   static const double defaultItemGap = 10;
 
   ItemTemplate? itemTemplate;
-  List<Widget>? children;
+  List<WidgetModel>? children;
 
   int? gap; // gap between the children
 
@@ -146,7 +149,7 @@ class MyController extends BoxController {
   final CarouselController _carouselController = CarouselController();
 }
 
-class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
+class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState, HasChildren<Carousel> {
   List<Widget>? templatedChildren;
 
   Widget? customIndicator;
@@ -163,10 +166,14 @@ class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
     if (widget._controller.itemTemplate != null) {
       registerItemTemplate(context, widget._controller.itemTemplate!,
           evaluateInitialValue: true, onDataChanged: (List dataList) {
-        setState(() {
-          templatedChildren = buildWidgetsFromTemplate(
-              context, dataList, widget._controller.itemTemplate!);
-        });
+        if (mounted) {
+          setState(() {
+            templatedChildren = buildWidgetsFromTemplate(
+                context, dataList, widget._controller.itemTemplate!);
+          });
+        } else {
+          log("Stale setState() for ${widget.runtimeType} - ${widget.hashCode}");
+        }
       });
     }
   }
@@ -259,13 +266,16 @@ class CarouselState extends WidgetState<Carousel> with TemplatedWidgetState {
 
   List<Widget> buildItems() {
     ViewUtil.checkValidWidget(
-        widget._controller.children, widget._controller.itemTemplate);
+        widget._controller.children != null
+            ? buildChildren(widget._controller.children!)
+            : null,
+        widget._controller.itemTemplate);
 
     // children will be rendered before templated children
     List<Widget> children = [];
 
     if (widget._controller.children != null) {
-      children.addAll(widget._controller.children!);
+      children.addAll(buildChildren(widget._controller.children!));
     }
 
     if (templatedChildren != null) {

--- a/lib/widget/conditional.dart
+++ b/lib/widget/conditional.dart
@@ -74,15 +74,19 @@ class ConditionalState extends WidgetState<Conditional> {
         expression,
         destination: BindingDestination(widget, 'conditions'),
         onDataChange: (event) {
-          setState(() {
-            _widget = _buildConditionalWidget(scopeManager, conditions);
-          });
+          if (mounted) {
+            setState(() {
+              _widget = _buildConditionalWidget(scopeManager, conditions);
+            });
+          }
         },
       );
     }
-    setState(() {
-      _widget = _buildConditionalWidget(scopeManager, conditions);
-    });
+    if (mounted) {
+      setState(() {
+        _widget = _buildConditionalWidget(scopeManager, conditions);
+      });
+    }
   }
 
   @override

--- a/lib/widget/staggered_grid.dart
+++ b/lib/widget/staggered_grid.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/layout/templated.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/screen_controller.dart';
@@ -18,7 +19,8 @@ class EnsembleStaggeredGrid extends StatefulWidget
     with
         Invokable,
         UpdatableContainer,
-        HasController<StaggeredGridController, EnsembleStaggeredGridState> {
+        HasController<StaggeredGridController,
+        EnsembleStaggeredGridState> {
   static const type = 'StaggeredGrid';
 
   EnsembleStaggeredGrid({Key? key}) : super(key: key);
@@ -56,7 +58,7 @@ class EnsembleStaggeredGrid extends StatefulWidget
   }
 
   @override
-  void initChildren({List<Widget>? children, ItemTemplate? itemTemplate}) {
+  void initChildren({List<WidgetModel>? children, ItemTemplate? itemTemplate}) {
     _controller.children = children;
     _controller.itemTemplate = itemTemplate;
     if (_controller.children != null && itemTemplate != null) {
@@ -68,7 +70,7 @@ class EnsembleStaggeredGrid extends StatefulWidget
 }
 
 class EnsembleStaggeredGridState extends WidgetState<EnsembleStaggeredGrid>
-    with TemplatedWidgetState {
+    with TemplatedWidgetState, HasChildren<EnsembleStaggeredGrid> {
   List<StaggeredTile> _staggeredTiles = [];
   List<Widget>? templatedChildren;
 
@@ -119,7 +121,7 @@ class EnsembleStaggeredGridState extends WidgetState<EnsembleStaggeredGrid>
     // children will be rendered before templated children
     List<Widget> children = [];
     if (widget._controller.children != null) {
-      children.addAll(widget._controller.children!);
+      children.addAll(buildChildren(widget._controller.children!));
     }
     if (templatedChildren != null) {
       children.addAll(templatedChildren!);
@@ -148,7 +150,7 @@ class StaggeredGridController extends BoxController {
   double? horizontalGap;
   double? verticalGap;
 
-  List<Widget>? children;
+  List<WidgetModel>? children;
   ItemTemplate? itemTemplate;
   EnsembleAction? onItemTap;
 }


### PR DESCRIPTION
Previously we created a widget outside, then pass it to the parent to add it to the parent tree. This is a problem on rebuild since the widget's context (created outside) is different, which cause the State to rebuild but retain the StatefulWidget. This was missed until we put the code in to remove a widget's binding listeners on dispose(). Since the key to remove the listener is the StatefulWidget, which stays the same while we have multiple States.

With this change, the StatefulWidget and the State are always in lock step. They are still created more often than necessary, but that's another optimization for another day.