### PR TITLE
Add borderRadius for the bottom nav bar

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -4318,6 +4318,19 @@
             "floatingIconColor": {
               "$ref": "#/$defs/typeColors",
               "description": "Floating item icon color, starting with '0xFF' for full opacity e.g 0xFFCCCCCC"
+            },
+            "height": {
+              "type": "integer",
+              "description": "Set the height of the BottomNavBar."
+            },
+            "padding": {
+              "$ref": "#/$defs/Padding-payload"
+            },
+            "margin": {
+              "$ref": "#/$defs/Margin-payload"
+            },
+            "borderRadius": {
+              "$ref": "#/$defs/borderRadius"
             }
           }
         },

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -237,6 +237,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
       backgroundColor: Utils.getColor(widget.menu.styles?['backgroundColor']) ??
           Colors.white,
       height: Utils.optionalDouble(widget.menu.styles?['height'] ?? 60),
+      margin: widget.menu.styles?['margin'],
       padding: widget.menu.styles?['padding'],
       borderRadius: Utils.getBorderRadius(widget.menu.styles?['borderRadius'])
           ?.getValue(),
@@ -266,6 +267,7 @@ class EnsembleBottomAppBar extends StatefulWidget {
     required this.items,
     required this.selectedIndex,
     this.height,
+    this.margin,
     this.padding,
     this.borderRadius,
     this.iconSize = 24.0,
@@ -284,6 +286,7 @@ class EnsembleBottomAppBar extends StatefulWidget {
   final List<FABBottomAppBarItem> items;
   final int selectedIndex;
   final double? height;
+  final dynamic margin;
   final dynamic padding;
   final double iconSize;
   final int? floatingMargin;
@@ -365,20 +368,21 @@ class EnsembleBottomAppBarState extends State<EnsembleBottomAppBar> {
 
     return Theme(
       data: ThemeData(useMaterial3: false),
-      child: ClipRRect(
-        borderRadius: widget.borderRadius ?? BorderRadius.zero,
+      child: Container(
+        margin: Utils.optionalInsets(widget.margin) ?? EdgeInsets.zero,
+        decoration: BoxDecoration(
+          borderRadius: widget.borderRadius ?? BorderRadius.zero,
+        ),
+        clipBehavior: Clip.hardEdge,
         child: BottomAppBar(
-          padding: const EdgeInsets.all(0),
+          padding: Utils.optionalInsets(widget.padding) ?? EdgeInsets.zero,
           shape: widget.notchedShape,
           color: widget.backgroundColor,
           notchMargin: _defaultFloatingNotch,
-          child: Padding(
-            padding: Utils.optionalInsets(widget.padding) ?? EdgeInsets.zero,
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: items,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: items,
           ),
         ),
       ),

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -190,7 +190,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     );
   }
 
-  EnsembleBottomAppBar? _buildBottomNavBar() {
+  Widget? _buildBottomNavBar() {
     List<FABBottomAppBarItem> navItems = [];
 
     final unselectedColor = Utils.getColor(widget.menu.styles?['color']) ??
@@ -198,6 +198,8 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     final selectedColor =
         Utils.getColor(widget.menu.styles?['selectedColor']) ??
             Theme.of(context).primaryColor;
+    final borderRadius =
+        Utils.getBorderRadius(widget.menu.styles?['borderRadius'])?.getValue();
 
     // final menu = widget.menu;
     for (int i = 0; i < menuItems.length; i++) {
@@ -232,20 +234,24 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
       );
     }
 
-    return EnsembleBottomAppBar(
-      selectedIndex: widget.selectedPage,
-      backgroundColor: Utils.getColor(widget.menu.styles?['backgroundColor']) ??
-          Colors.white,
-      height: Utils.optionalDouble(widget.menu.styles?['height'] ?? 60),
-      padding: widget.menu.styles?['padding'],
-      color: unselectedColor,
-      selectedColor: selectedColor,
-      notchedShape: const CircularNotchedRectangle(),
-      onTabSelected: controller.jumpToPage,
-      items: navItems,
-      isFloating: fabMenuItem != null,
-      floatingAlignment: floatingAlignment,
-      floatingMargin: floatingMargin,
+    return ClipRRect(
+      borderRadius: borderRadius ?? BorderRadius.zero,
+      child: EnsembleBottomAppBar(
+        selectedIndex: widget.selectedPage,
+        backgroundColor:
+            Utils.getColor(widget.menu.styles?['backgroundColor']) ??
+                Colors.white,
+        height: Utils.optionalDouble(widget.menu.styles?['height'] ?? 60),
+        padding: widget.menu.styles?['padding'],
+        color: unselectedColor,
+        selectedColor: selectedColor,
+        notchedShape: const CircularNotchedRectangle(),
+        onTabSelected: controller.jumpToPage,
+        items: navItems,
+        isFloating: fabMenuItem != null,
+        floatingAlignment: floatingAlignment,
+        floatingMargin: floatingMargin,
+      ),
     );
   }
 

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -373,7 +373,7 @@ class EnsembleBottomAppBarState extends State<EnsembleBottomAppBar> {
         decoration: BoxDecoration(
           borderRadius: widget.borderRadius ?? BorderRadius.zero,
         ),
-        clipBehavior: Clip.hardEdge,
+        clipBehavior: widget.borderRadius != null ? Clip.hardEdge : Clip.none,
         child: BottomAppBar(
           padding: Utils.optionalInsets(widget.padding) ?? EdgeInsets.zero,
           shape: widget.notchedShape,

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -190,7 +190,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     );
   }
 
-  Widget? _buildBottomNavBar() {
+  EnsembleBottomAppBar? _buildBottomNavBar() {
     List<FABBottomAppBarItem> navItems = [];
 
     final unselectedColor = Utils.getColor(widget.menu.styles?['color']) ??
@@ -198,8 +198,6 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     final selectedColor =
         Utils.getColor(widget.menu.styles?['selectedColor']) ??
             Theme.of(context).primaryColor;
-    final borderRadius =
-        Utils.getBorderRadius(widget.menu.styles?['borderRadius'])?.getValue();
 
     // final menu = widget.menu;
     for (int i = 0; i < menuItems.length; i++) {
@@ -234,24 +232,22 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
       );
     }
 
-    return ClipRRect(
-      borderRadius: borderRadius ?? BorderRadius.zero,
-      child: EnsembleBottomAppBar(
-        selectedIndex: widget.selectedPage,
-        backgroundColor:
-            Utils.getColor(widget.menu.styles?['backgroundColor']) ??
-                Colors.white,
-        height: Utils.optionalDouble(widget.menu.styles?['height'] ?? 60),
-        padding: widget.menu.styles?['padding'],
-        color: unselectedColor,
-        selectedColor: selectedColor,
-        notchedShape: const CircularNotchedRectangle(),
-        onTabSelected: controller.jumpToPage,
-        items: navItems,
-        isFloating: fabMenuItem != null,
-        floatingAlignment: floatingAlignment,
-        floatingMargin: floatingMargin,
-      ),
+    return EnsembleBottomAppBar(
+      selectedIndex: widget.selectedPage,
+      backgroundColor: Utils.getColor(widget.menu.styles?['backgroundColor']) ??
+          Colors.white,
+      height: Utils.optionalDouble(widget.menu.styles?['height'] ?? 60),
+      padding: widget.menu.styles?['padding'],
+      borderRadius: Utils.getBorderRadius(widget.menu.styles?['borderRadius'])
+          ?.getValue(),
+      color: unselectedColor,
+      selectedColor: selectedColor,
+      notchedShape: const CircularNotchedRectangle(),
+      onTabSelected: controller.jumpToPage,
+      items: navItems,
+      isFloating: fabMenuItem != null,
+      floatingAlignment: floatingAlignment,
+      floatingMargin: floatingMargin,
     );
   }
 
@@ -271,6 +267,7 @@ class EnsembleBottomAppBar extends StatefulWidget {
     required this.selectedIndex,
     this.height,
     this.padding,
+    this.borderRadius,
     this.iconSize = 24.0,
     required this.backgroundColor,
     required this.color,
@@ -296,6 +293,7 @@ class EnsembleBottomAppBar extends StatefulWidget {
   final bool isFloating;
   final FloatingAlignment floatingAlignment;
   final NotchedShape notchedShape;
+  final BorderRadius? borderRadius;
   final VoidCallback? onFabTapped;
   final ValueChanged<int> onTabSelected;
 
@@ -367,17 +365,20 @@ class EnsembleBottomAppBarState extends State<EnsembleBottomAppBar> {
 
     return Theme(
       data: ThemeData(useMaterial3: false),
-      child: BottomAppBar(
-        padding: const EdgeInsets.all(0),
-        shape: widget.notchedShape,
-        color: widget.backgroundColor,
-        notchMargin: _defaultFloatingNotch,
-        child: Padding(
-          padding: Utils.optionalInsets(widget.padding) ?? EdgeInsets.zero,
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: items,
+      child: ClipRRect(
+        borderRadius: widget.borderRadius ?? BorderRadius.zero,
+        child: BottomAppBar(
+          padding: const EdgeInsets.all(0),
+          shape: widget.notchedShape,
+          color: widget.backgroundColor,
+          notchMargin: _defaultFloatingNotch,
+          child: Padding(
+            padding: Utils.optionalInsets(widget.padding) ?? EdgeInsets.zero,
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: items,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Ticket: [#869](https://github.com/EnsembleUI/ensemble/issues/869)

```yaml
BottomNavBar:
  styles:
    {
      backgroundColor: indigo,
      color: green,
      selectedColor: blue,
      floatingBackgroundColor: blue,
      floatingIconColor: white,
      notchColor: white,
      height: 60,
      padding: 0 20,
      borderRadius: 30 30 0 0,
    }
```

<img src="https://github.com/EnsembleUI/ensemble/assets/12869588/beeb7143-8336-4c34-8de0-76189d134d04" width="350" />
