### PR TITLE
Added currentIndex, selectedIndex and indicatorMaxCount properties for Carousel Widget

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2812,8 +2812,15 @@
                       "type": "string",
                       "description": "Where to display the indicator if specified",
                       "enum": [
-                        "bottom",
-                        "top"
+                        "topLeft",
+                        "topCenter",
+                        "topRight",
+                        "centerLeft",
+                        "center",
+                        "centerRight",
+                        "bottomLeft",
+                        "bottomCenter",
+                        "bottomRight"
                       ]
                     },
                     "indicatorWidth": {
@@ -2858,6 +2865,10 @@
                         }
                       ],
                       "description": "The margin around each indicator"
+                    },
+                    "indicatorPadding": {
+                      "$ref": "#/$defs/Padding-payload",
+                      "description": "The padding around the indicator"
                     }
                   }
                 }

--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2819,9 +2819,17 @@
                       "type": "boolean",
                       "description": "Determines if carousel should loop infinitely or be limited to item length. Default (false)"
                     },
-                    "selectedItemIndex": {
+                    "selectedIndex": {
                       "type": "integer",
-                      "description": "The initial page to show when first creating the Carousel. Default (0)"
+                      "description": "It returns the selected item index of the Carousel. Default (-1) if not tapped / selected"
+                    },
+                    "currentIndex": {
+                      "type": "integer",
+                      "description": "The initial page to show when first creating the Carousel and the current index of the displaying Carousel Item. Default (0)"
+                    },
+                    "indicatorMaxCount": {
+                      "type": "integer",
+                      "description": "This property is used to show a limited number (for ex: 4) of carousel indicator when creating the carousel with more (for ex: 100+) items. Default (null)"
                     },
                     "autoplayInterval": {
                       "type": "integer",

--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2809,19 +2809,8 @@
                       ]
                     },
                     "indicatorPosition": {
-                      "type": "string",
-                      "description": "Where to display the indicator if specified",
-                      "enum": [
-                        "topLeft",
-                        "topCenter",
-                        "topRight",
-                        "centerLeft",
-                        "center",
-                        "centerRight",
-                        "bottomLeft",
-                        "bottomCenter",
-                        "bottomRight"
-                      ]
+                      "$ref": "#/$defs/type-alignment",
+                      "description": "Where to display the indicator if specified"
                     },
                     "indicatorWidth": {
                       "type": "integer"

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -61,8 +61,8 @@ class Carousel extends StatefulWidget
           _controller.indicatorHeight = Utils.optionalInt(h),
       'indicatorMargin': (value) =>
           _controller.indicatorMargin = Utils.getInsets(value),
-      'indicatorOffset': (value) =>
-          _controller.indicatorOffset = Utils.optionalDouble(value),
+      'indicatorPadding': (value) =>
+          _controller.indicatorPadding = Utils.getInsets(value),
       'indicatorColor': (value) =>
           _controller.indicatorColor = Utils.getColor(value),
       'currentIndex': (value) =>
@@ -134,7 +134,7 @@ class MyController extends BoxController {
   int? indicatorWidth;
   int? indicatorHeight;
   EdgeInsets? indicatorMargin;
-  double? indicatorOffset;
+  EdgeInsets? indicatorPadding;
   Color? indicatorColor;
   bool? autoplay;
   bool? enableLoop;
@@ -204,20 +204,19 @@ class CarouselState extends WidgetState<Carousel>
         widget._controller.indicatorType != IndicatorType.none) {
       List<Widget> indicators = buildIndicators(items);
 
-      final double indicatorOffset = widget._controller.indicatorOffset ?? 0;
-      final bool isBottom =
-          widget._controller.indicatorPosition != IndicatorPosition.top;
-
       List<Widget> children = [
         carousel,
-        Positioned(
-          top: !isBottom ? indicatorOffset : null,
-          bottom: isBottom ? indicatorOffset : null,
-          left: 0,
-          right: 0,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: indicators,
+        Positioned.fill(
+          child: Align(
+            alignment: widget._controller.indicatorPosition?.alignment ??
+                Alignment.bottomCenter,
+            child: Padding(
+              padding: widget._controller.indicatorPadding ?? EdgeInsets.zero,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: indicators,
+              ),
+            ),
           ),
         )
       ];
@@ -464,4 +463,37 @@ enum IndicatorType {
   custom,
 }
 
-enum IndicatorPosition { bottom, top }
+enum IndicatorPosition {
+  topLeft,
+  topCenter,
+  topRight,
+  centerLeft,
+  center,
+  centerRight,
+  bottomLeft,
+  bottomCenter,
+  bottomRight;
+
+  Alignment get alignment {
+    switch (this) {
+      case IndicatorPosition.topLeft:
+        return Alignment.topLeft;
+      case IndicatorPosition.topCenter:
+        return Alignment.topCenter;
+      case IndicatorPosition.topRight:
+        return Alignment.topRight;
+      case IndicatorPosition.centerLeft:
+        return Alignment.centerLeft;
+      case IndicatorPosition.center:
+        return Alignment.center;
+      case IndicatorPosition.centerRight:
+        return Alignment.centerRight;
+      case IndicatorPosition.bottomLeft:
+        return Alignment.bottomLeft;
+      case IndicatorPosition.bottomCenter:
+        return Alignment.bottomCenter;
+      case IndicatorPosition.bottomRight:
+        return Alignment.bottomRight;
+    }
+  }
+}

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -72,7 +72,7 @@ class Carousel extends StatefulWidget
       'indicatorColor': (value) =>
           _controller.indicatorColor = Utils.getColor(value),
       'selectedItemIndex': (value) =>
-          _controller.selectedItemIndex = Utils.getInt(value, fallback: 0),
+          _controller.selectedItemIndex = Utils.getInt(value, fallback: -1),
       'onItemChange': (action) => _controller.onItemChange =
           EnsembleAction.fromYaml(action, initiator: this),
       'onItemTap': (funcDefinition) => _controller.onItemTap =
@@ -149,7 +149,7 @@ class MyController extends BoxController {
   // for multi view this dispatch when clicking on a card
   EnsembleAction? onItemTap;
   EnsembleAction? onItemChange;
-  int selectedItemIndex = 0;
+  int selectedItemIndex = -1;
 
   final CarouselController _carouselController = CarouselController();
 }
@@ -167,7 +167,9 @@ class CarouselState extends WidgetState<Carousel>
   @override
   void initState() {
     super.initState();
-    focusIndex = widget._controller.selectedItemIndex;
+    if (widget._controller.selectedItemIndex != -1) {
+      focusIndex = widget._controller.selectedItemIndex;
+    }
   }
 
   @override
@@ -227,7 +229,7 @@ class CarouselState extends WidgetState<Carousel>
       // Carousel requires a fixed height, so to make sure the indicators don't shift the UI, we'll make
       // sure there's at least 1 invisible indicator that takes up the space
       if (indicators.isEmpty) {
-        indicators.add(Opacity(child: getIndicator(false), opacity: 0));
+        indicators.add(Opacity(opacity: 0, child: getIndicator(false)));
       }
 
       final double indicatorOffset = widget._controller.indicatorOffset ?? 0;
@@ -316,7 +318,7 @@ class CarouselState extends WidgetState<Carousel>
     }
   }
 
-  _onItemChange(int index) {
+  void _onItemChange(int index) {
     if (index != widget._controller.selectedItemIndex &&
         widget._controller.onItemChange != null) {
       widget._controller.selectedItemIndex = index;
@@ -334,6 +336,7 @@ class CarouselState extends WidgetState<Carousel>
         _onItemChange(index);
         setState(() {
           focusIndex = index;
+          widget._controller.selectedItemIndex = index;
         });
       },
     );
@@ -348,6 +351,7 @@ class CarouselState extends WidgetState<Carousel>
         onPageChanged: (index, _) {
           setState(() {
             focusIndex = index;
+            widget._controller.selectedItemIndex = index;
           });
         });
   }
@@ -355,7 +359,7 @@ class CarouselState extends WidgetState<Carousel>
   CarouselOptions _getBaseCarouselOptions() {
     return CarouselOptions(
       height: widget._controller.height?.toDouble(),
-      initialPage: widget._controller.selectedItemIndex,
+      initialPage: focusIndex,
       enableInfiniteScroll: widget._controller.enableLoop ?? false,
       autoPlay: widget._controller.autoplay ?? false,
       autoPlayInterval:
@@ -391,7 +395,7 @@ class CarouselState extends WidgetState<Carousel>
         widget._controller.indicatorWidth ??
         8;
 
-    final Color? indicatorColor = widget._controller.indicatorColor ??
+    final Color indicatorColor = widget._controller.indicatorColor ??
         (Theme.of(context).brightness == Brightness.dark
             ? Colors.white
             : Colors.black);
@@ -405,7 +409,7 @@ class CarouselState extends WidgetState<Carousel>
         shape: widget._controller.indicatorType == IndicatorType.rectangle
             ? BoxShape.rectangle
             : BoxShape.circle,
-        color: indicatorColor?.withOpacity(selected ? 0.9 : 0.4),
+        color: indicatorColor.withOpacity(selected ? 0.9 : 0.4),
       ),
     );
   }

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -149,7 +149,7 @@ class MyController extends BoxController {
   // for multi view this dispatch when clicking on a card
   EnsembleAction? onItemTap;
   EnsembleAction? onItemChange;
-  int selectedItemIndex = -1;
+  int selectedItemIndex = 0;
 
   final CarouselController _carouselController = CarouselController();
 }

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -53,8 +53,8 @@ class Carousel extends StatefulWidget
           Utils.optionalDouble(value, min: 0, max: 1),
       'indicatorType': (type) =>
           _controller.indicatorType = IndicatorType.values.from(type),
-      'indicatorPosition': (position) => _controller.indicatorPosition =
-          IndicatorPosition.values.from(position),
+      'indicatorPosition': (position) =>
+          _controller.indicatorPosition = Utils.getAlignment(position),
       'indicatorWidth': (w) =>
           _controller.indicatorWidth = Utils.optionalInt(w),
       'indicatorHeight': (h) =>
@@ -130,7 +130,7 @@ class MyController extends BoxController {
   int? autoLayoutBreakpoint; // applicable only for auto layout
 
   IndicatorType? indicatorType;
-  IndicatorPosition? indicatorPosition;
+  Alignment? indicatorPosition;
   int? indicatorWidth;
   int? indicatorHeight;
   EdgeInsets? indicatorMargin;
@@ -208,8 +208,8 @@ class CarouselState extends WidgetState<Carousel>
         carousel,
         Positioned.fill(
           child: Align(
-            alignment: widget._controller.indicatorPosition?.alignment ??
-                Alignment.bottomCenter,
+            alignment:
+                widget._controller.indicatorPosition ?? Alignment.bottomCenter,
             child: Padding(
               padding: widget._controller.indicatorPadding ?? EdgeInsets.zero,
               child: Row(
@@ -461,39 +461,4 @@ enum IndicatorType {
   circle,
   rectangle,
   custom,
-}
-
-enum IndicatorPosition {
-  topLeft,
-  topCenter,
-  topRight,
-  centerLeft,
-  center,
-  centerRight,
-  bottomLeft,
-  bottomCenter,
-  bottomRight;
-
-  Alignment get alignment {
-    switch (this) {
-      case IndicatorPosition.topLeft:
-        return Alignment.topLeft;
-      case IndicatorPosition.topCenter:
-        return Alignment.topCenter;
-      case IndicatorPosition.topRight:
-        return Alignment.topRight;
-      case IndicatorPosition.centerLeft:
-        return Alignment.centerLeft;
-      case IndicatorPosition.center:
-        return Alignment.center;
-      case IndicatorPosition.centerRight:
-        return Alignment.centerRight;
-      case IndicatorPosition.bottomLeft:
-        return Alignment.bottomLeft;
-      case IndicatorPosition.bottomCenter:
-        return Alignment.bottomCenter;
-      case IndicatorPosition.bottomRight:
-        return Alignment.bottomRight;
-    }
-  }
 }

--- a/lib/widget/image.dart
+++ b/lib/widget/image.dart
@@ -84,7 +84,6 @@ class ImageController extends BoxController {
 }
 
 class ImageState extends WidgetState<EnsembleImage> {
-
   @override
   Widget buildWidget(BuildContext context) {
     String source = widget._controller.source.trim();
@@ -211,7 +210,6 @@ class ImageState extends WidgetState<EnsembleImage> {
     }
     return fallbackWidget;
   }
-
 }
 
 class EnsembleImageCacheManager {


### PR DESCRIPTION
In this PR, I've fixed a few issues and updated the schema

**1. Index Updates:** Ticket: #949 and #955

1. `currentIndex`
    - For setting the initial index of the carousel which starts the carousel from that child of index.
    - To get the current index which is displayed in the carousel
    - Default (0)
2. `selectedIndex` 
    - To get the selectedIndex only when the user clicks on the carousel item otherwise it'll return -1. Default (-1)
3. `indicatorMaxCount` 
    - This property shows a limited number (for ex: 4) of **carousel indicator** when creating the carousel with more (for ex: 100+) items. 
    - Default (null), if this property is null the indicator works normally how it works before (based on the currentIndex property)

**2. Indicator Alignment and Padding** - Ticket: [#952](https://github.com/EnsembleUI/ensemble/issues/952)
- Here, I added multiple alignment (topLeft, bottomCenter, etc) support for the carousel indicator and replaced the `indicatorOffset` with the `indicatorPadding` property