### PR TITLE
Add navigate to view group action - v2

### DIFF
--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -129,7 +129,7 @@ class NavigateViewGroupAction extends EnsembleAction {
   Future execute(BuildContext context, ScopeManager scopeManager,
       {DataContext? dataContext}) {
     PageGroupWidget.getPageController(context)?.jumpToPage(_viewIndex);
-    bottomNavBarNotifier.updatePage(_viewIndex);
+    viewGroupNotifier.updatePage(_viewIndex);
     return Future.value(null);
   }
 }

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -14,6 +14,8 @@ import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/keychain_manager.dart';
 import 'package:ensemble/framework/permissions_manager.dart';
 import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/view/bottom_nav_page_group.dart';
+import 'package:ensemble/framework/view/page_group.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
@@ -111,6 +113,24 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       return NavigateScreenAction(screenName: inputs);
     }
     return NavigateScreenAction.fromYaml(payload: Utils.getYamlMap(inputs));
+  }
+}
+
+class NavigateViewGroupAction extends EnsembleAction {
+  NavigateViewGroupAction({dynamic viewIndex}) : _viewIndex = viewIndex;
+
+  final dynamic _viewIndex;
+
+  factory NavigateViewGroupAction.from({Map? payload}) {
+    return NavigateViewGroupAction(viewIndex: payload?['viewIndex']);
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) {
+    PageGroupWidget.getPageController(context)?.jumpToPage(_viewIndex);
+    bottomNavBarNotifier.updatePage(_viewIndex);
+    return Future.value(null);
   }
 }
 
@@ -816,6 +836,7 @@ class ClearKeychain extends EnsembleAction {
 enum ActionType {
   invokeAPI,
   navigateScreen,
+  navigateViewGroup,
   navigateExternalScreen,
   navigateModalScreen,
   showBottomModal,
@@ -907,6 +928,8 @@ abstract class EnsembleAction {
     } else if (actionType == ActionType.navigateExternalScreen) {
       return NavigateExternalScreen.from(
           initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.navigateViewGroup) {
+      return NavigateViewGroupAction.from(payload: payload);
     } else if (actionType == ActionType.navigateModalScreen) {
       return NavigateModalScreenAction.fromYaml(
           initiator: initiator, payload: payload);

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -414,9 +414,6 @@ class EnsembleBottomAppBarState extends State<EnsembleBottomAppBar> {
   void initState() {
     super.initState();
     _selectedIndex = widget.selectedIndex;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      // _updateIndex(_selectedIndex);
-    });
   }
 
   @override

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -15,21 +15,6 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/framework/widget/icon.dart' as ensemble;
 import 'package:flutter/material.dart';
 
-class BottomNavBarNotifier extends ChangeNotifier {
-  int _viewIndex = 0;
-
-  int get viewIndex => _viewIndex;
-
-  void updatePage(int index, {bool isReload = true}) {
-    _viewIndex = index;
-    if (isReload) {
-      notifyListeners();
-    }
-  }
-}
-
-final bottomNavBarNotifier = BottomNavBarNotifier();
-
 class FABBottomAppBarItem {
   FABBottomAppBarItem({
     required this.icon,
@@ -86,7 +71,7 @@ class PageGroupWidgetWrapper extends StatelessWidget {
       return PageGroupWidget(
         scopeManager: scopeManager,
         pageController:
-            PageController(initialPage: bottomNavBarNotifier.viewIndex),
+            PageController(initialPage: viewGroupNotifier.viewIndex),
         child: child,
       );
     }
@@ -126,7 +111,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     if (widget.menu.reloadView == false) {
       controller = PageController(initialPage: widget.selectedPage);
     }
-    bottomNavBarNotifier.updatePage(widget.selectedPage, isReload: false);
+    viewGroupNotifier.updatePage(widget.selectedPage, isReload: false);
     menuItems = widget.menu.menuItems
         .where((element) => element.floating != true)
         .toList();
@@ -232,9 +217,9 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
         floatingActionButton: _buildFloatingButton(),
         body: widget.menu.reloadView == true
             ? ListenableBuilder(
-                listenable: bottomNavBarNotifier,
+                listenable: viewGroupNotifier,
                 builder: (_, __) =>
-                    widget.children[bottomNavBarNotifier.viewIndex])
+                    widget.children[viewGroupNotifier.viewIndex])
             : Builder(
                 builder: (context) {
                   final controller = PageGroupWidget.getPageController(context);
@@ -292,9 +277,9 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
     }
 
     return ListenableBuilder(
-      listenable: bottomNavBarNotifier,
+      listenable: viewGroupNotifier,
       builder: (context, _) {
-        final viewIndex = bottomNavBarNotifier.viewIndex;
+        final viewIndex = viewGroupNotifier.viewIndex;
 
         return EnsembleBottomAppBar(
           key: UniqueKey(),
@@ -313,10 +298,10 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
           notchedShape: const CircularNotchedRectangle(),
           onTabSelected: (index) {
             if (widget.menu.reloadView == true) {
-              bottomNavBarNotifier.updatePage(index);
+              viewGroupNotifier.updatePage(index);
             } else {
               PageGroupWidget.getPageController(context)!.jumpToPage(index);
-              bottomNavBarNotifier.updatePage(index);
+              viewGroupNotifier.updatePage(index);
             }
           },
           items: navItems,

--- a/lib/framework/view/page_group.dart
+++ b/lib/framework/view/page_group.dart
@@ -43,15 +43,18 @@ class PageGroup extends StatefulWidget {
 /// We need this because the menu (i.e. drawer) is determined at the PageGroup
 /// level, but need to be injected under each child Page to render.
 class PageGroupWidget extends DataScopeWidget {
-  const PageGroupWidget(
-      {super.key,
-      required super.scopeManager,
-      required super.child,
-      this.navigationDrawer,
-      this.navigationEndDrawer});
+  const PageGroupWidget({
+    super.key,
+    required super.scopeManager,
+    required super.child,
+    this.navigationDrawer,
+    this.navigationEndDrawer,
+    this.pageController,
+  });
 
   final Drawer? navigationDrawer;
   final Drawer? navigationEndDrawer;
+  final PageController? pageController;
 
   static Drawer? getNavigationDrawer(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<PageGroupWidget>()
@@ -60,6 +63,10 @@ class PageGroupWidget extends DataScopeWidget {
   static Drawer? getNavigationEndDrawer(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<PageGroupWidget>()
       ?.navigationEndDrawer;
+
+  static PageController? getPageController(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<PageGroupWidget>()
+      ?.pageController;
 
   /// return the ScopeManager which includes the dataContext
   /// TODO: have to repeat this function in DataScopeWidget?


### PR DESCRIPTION
Ticket: #855
Now it supports all the menu and the reloadView works correctly with these changes
- Drawer
- SideBar
- BottomNavBar

```yaml
Button:
  label: Navigate To Chat
  onTap:
    navigateViewGroup:
      viewIndex: 2
```

Video:
https://drive.google.com/file/d/1btA1-lZ53Opkx5ddRxhdF7ZP2PYbrvvE/view?usp=share_link
