### PR TITLE
Add callbackAfterInit methods for executing functions after the app is initialized

### DIFF
--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
+import 'dart:math' as math;
 
 import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/ensemble_provider.dart';
@@ -45,6 +46,23 @@ class Ensemble {
   void setExternalScreenWidgets(Map<String, CustomBuilder> widgets) {
     externalScreenWidgets = widgets;
   }
+
+  final List<Map<String, Object?>> _afterInitMethods = [];
+  void addCallbackAfterInitialization(
+      {required Function method,
+      List<dynamic>? positionalArgs,
+      Map<String, dynamic>? namedArgs}) {
+    final function = {
+      'id': math.Random().nextInt(100000),
+      'method': method,
+      'positionalArgs': positionalArgs,
+      'namedArgs': namedArgs
+    };
+    _afterInitMethods.add(function);
+  }
+
+  List<Map<String, Object?>> getCallbacksAfterInitialization() =>
+      _afterInitMethods;
 
   late FirebaseApp ensembleFirebaseApp;
   static final Map<String, dynamic> externalDataContext = {};

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -163,7 +163,7 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
   void initDeepLink(AppLifecycleState state) {
     if (!kIsWeb) {
       if (Platform.isIOS) {
-        IOSDeepLinkManager().init(state);
+        IOSDeepLinkManager().init();
       } else {
         DeepLinkManager().init();
       }

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -104,23 +104,41 @@ class EnsembleApp extends StatefulWidget {
   State<StatefulWidget> createState() => EnsembleAppState();
 }
 
-class EnsembleAppState extends State<EnsembleApp> {
+class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
   late Future<EnsembleConfig> config;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     config = initApp();
-
     // Initialize native features.
     if (!kIsWeb) {
       Workmanager().initialize(callbackDispatcher, isInDebugMode: false);
+      initDeepLink(AppLifecycleState.resumed);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    initDeepLink(state);
+  }
+
+  void initDeepLink(AppLifecycleState state) {
+    if (!kIsWeb) {
       if (Platform.isIOS) {
-        IOSDeepLinkManager().init();
+        IOSDeepLinkManager().init(state);
       } else {
         DeepLinkManager().init();
       }
     }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   /// initialize our App with the the passed in config or

--- a/lib/ios_deep_link_manager.dart
+++ b/lib/ios_deep_link_manager.dart
@@ -1,6 +1,5 @@
 import 'package:ensemble/deep_link_manager.dart';
 import 'package:ensemble/ensemble.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class IOSDeepLinkManager extends DeepLinkNavigator {
@@ -17,7 +16,7 @@ class IOSDeepLinkManager extends DeepLinkNavigator {
     return _instance;
   }
 
-  void init(AppLifecycleState state) {
+  void init() {
     _platform.setMethodCallHandler((call) {
       if (call.method == IOSDeepLinkManager._deepLinkMethod) {
         final url = Uri.parse(call.arguments);

--- a/lib/ios_deep_link_manager.dart
+++ b/lib/ios_deep_link_manager.dart
@@ -1,4 +1,5 @@
 import 'package:ensemble/deep_link_manager.dart';
+import 'package:ensemble/ensemble.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -20,10 +21,8 @@ class IOSDeepLinkManager extends DeepLinkNavigator {
     _platform.setMethodCallHandler((call) {
       if (call.method == IOSDeepLinkManager._deepLinkMethod) {
         final url = Uri.parse(call.arguments);
-        Future.delayed(
-            Duration(seconds: state == AppLifecycleState.detached ? 6 : 0), () {
-          navigateToScreen(url);
-        });
+        Ensemble().addCallbackAfterInitialization(
+            method: navigateToScreen, positionalArgs: [url]);
       }
       return Future.value(true);
     });

--- a/lib/ios_deep_link_manager.dart
+++ b/lib/ios_deep_link_manager.dart
@@ -1,4 +1,5 @@
 import 'package:ensemble/deep_link_manager.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class IOSDeepLinkManager extends DeepLinkNavigator {
@@ -15,11 +16,12 @@ class IOSDeepLinkManager extends DeepLinkNavigator {
     return _instance;
   }
 
-  void init() {
+  void init(AppLifecycleState state) {
     _platform.setMethodCallHandler((call) {
       if (call.method == IOSDeepLinkManager._deepLinkMethod) {
         final url = Uri.parse(call.arguments);
-        Future.delayed(const Duration(seconds: 6), () {
+        Future.delayed(
+            Duration(seconds: state == AppLifecycleState.detached ? 6 : 0), () {
           navigateToScreen(url);
         });
       }


### PR DESCRIPTION
Ticket: #958

In this PR, I added an `addCallbackAfterInitialization` and `getCallbacksAfterInitialization`. Also updated the ensemble app to execute all the registered functions