### PR TITLE
listView: show loading indicator

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2699,6 +2699,13 @@
               "type": "integer",
               "description": "Selecting a ListView item gives the index of selected item"
             },
+            "showLoading": {
+              "type": "boolean",
+              "description": "Show loading indicator. (Default is false)"
+            },
+            "loadingWidget": {
+              "$ref": "#/$defs/Widget"
+            },
             "onScrollEnd": {
               "$ref": "#/$defs/Action-payload",
               "description": "Execute an Ensemble action when user has reached bottom of list."
@@ -6973,13 +6980,6 @@
         }
       }
     },
-
-    
-    
-    
-    
-    
-    
     "TextStyle": {
       "type": "object",
       "properties": {

--- a/lib/layout/list_view.dart
+++ b/lib/layout/list_view.dart
@@ -1,5 +1,7 @@
 import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
+import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/studio_debugger.dart';
 import 'package:ensemble/framework/widget/has_children.dart';
 import 'package:ensemble/framework/widget/widget.dart';
@@ -15,6 +17,8 @@ import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' as flutter;
 import 'package:ensemble/screen_controller.dart';
+
+import '../framework/view/data_scope_widget.dart';
 
 class ListView extends StatefulWidget
     with
@@ -34,6 +38,7 @@ class ListView extends StatefulWidget
   Map<String, Function> getters() {
     return {
       'selectedItemIndex': () => _controller.selectedItemIndex,
+      'data': () => _controller.widgetState?.templatedDataList,
     };
   }
 
@@ -62,6 +67,10 @@ class ListView extends StatefulWidget
         if (value is! ScrollController) return null;
         return _controller.scrollController = value;
       },
+      'showLoading': (value) =>
+          _controller.showLoading = Utils.getBool(value, fallback: false),
+      'loadingWidget': (value) => _controller.loadingWidget = value,
+      'data': (value) => _controller.itemTemplate?.data = value,
     };
   }
 
@@ -90,6 +99,12 @@ class ListViewController extends BoxLayoutController {
   EnsembleAction? onScrollEnd;
   bool reverse = false;
   ScrollController? scrollController;
+  dynamic loadingWidget;
+  bool showLoading = false;
+  ListViewState? widgetState;
+  void _bind(ListViewState state) {
+    widgetState = state;
+  }
 }
 
 class ListViewState extends WidgetState<ListView>
@@ -116,11 +131,17 @@ class ListViewState extends WidgetState<ListView>
 
   @override
   Widget buildWidget(BuildContext context) {
+    widget.controller._bind(this);
+
     // children displayed first, followed by item template
     int itemCount = (widget._controller.children?.length ?? 0) +
         (templatedDataList?.length ?? 0);
     if (itemCount == 0) {
       return const SizedBox.shrink();
+    }
+    if (widget._controller.showLoading) {
+      int indexAdd = widget._controller.loadingWidget != null ? 1 : 0;
+      itemCount = itemCount + indexAdd;
     }
 
     Widget listView = flutter.ListView.separated(
@@ -134,8 +155,20 @@ class ListViewState extends WidgetState<ListView>
         shrinkWrap: false,
         reverse: widget._controller.reverse,
         itemBuilder: (BuildContext context, int index) {
-          // show childrenfocus
           _checkScrollEnd(context, index);
+          if (widget._controller.showLoading) {
+            final total = (widget._controller.children?.length ?? 0) +
+                (templatedDataList?.length ?? 0);
+
+            if (index == total && widget._controller.loadingWidget != null) {
+              final loadingWidget =
+                  widgetBuilder(context, widget._controller.loadingWidget);
+
+              return loadingWidget ?? const SizedBox.shrink();
+            }
+          }
+
+          // show childrenfocus
           Widget? itemWidget;
           if (widget._controller.children != null &&
               index < widget._controller.children!.length) {
@@ -215,6 +248,16 @@ class ListViewState extends WidgetState<ListView>
     if (index == totalItems - 1 && widget._controller.onScrollEnd != null) {
       ScreenController()
           .executeAction(context, widget._controller.onScrollEnd!);
+    }
+  }
+
+  Widget? widgetBuilder(BuildContext context, dynamic widget) {
+    ScopeManager? parentScope = DataScopeWidget.getScope(context);
+    if (parentScope != null) {
+      return parentScope.buildWidgetFromDefinition(widget);
+    } else {
+      LanguageError('Failed to build widget');
+      return null;
     }
   }
 }

--- a/lib/page_model.dart
+++ b/lib/page_model.dart
@@ -320,7 +320,7 @@ class ViewBehavior {
 }
 
 class ItemTemplate {
-  final dynamic data;
+  dynamic data;
   final String name;
   final dynamic template;
   List<dynamic>? initialValue;


### PR DESCRIPTION
closes: Loading for infinite scroll View #920

+1 Enhance:
Now we can by pass the ensemble storage and directly concat data to `[id].data`.

Sample YAML

```yaml

ListView:
  id: listView
  styles: { reverse: true }
  loadingWidget:
    Progress:
      display: linear
      styles:
        color: blue

  onScrollEnd:
    invokeAPI:
      name: getPeople
      onResponse: |
        //@code

        var results = getPeople.body.results;
        listView.data = listView.data.concat(results);
        listView.showLoading = false;

  item-template:
    data: ${getPeople.body.results}
    name: user

    template:
      MyRow:
        inputs:
          p: ${user}
```