### PR TITLE
uploadFiles: new option batchSize

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -3971,6 +3971,10 @@
                 "options": {
                   "type": "object",
                   "properties": {
+                    "batchSize": {
+                      "type": "integer",
+                      "description": "If specified, the total set of files to be uploaded will be divided into batches, with each batch containing a number of files equal to batchSize"
+                    },
                     "maxFileSize": {
                       "type": "integer",
                       "description": "File size that is allowed (default 100 mb), If multiple is allow then sum of all files"
@@ -6973,13 +6977,6 @@
         }
       }
     },
-
-    
-    
-    
-    
-    
-    
     "TextStyle": {
       "type": "object",
       "properties": {

--- a/lib/action/upload_files_action.dart
+++ b/lib/action/upload_files_action.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:ensemble/ensemble_app.dart';
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/bindings.dart';
+import 'package:ensemble/framework/data_context.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/widget/toast.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/extensions.dart';
+import 'package:ensemble/util/http_utils.dart';
+import 'package:ensemble/util/upload_utils.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:yaml/yaml.dart';
+
+Future<void> uploadFiles({
+  required BuildContext context,
+  required FileUploadAction action,
+  required DataContext dataContext,
+  ScopeManager? scopeManager,
+  Map<String, YamlMap>? apiMap,
+}) async {
+  List<File>? selectedFiles = _getRawFiles(action.files, dataContext);
+
+  if (selectedFiles == null) {
+    if (action.onError != null) {
+      ScreenController().executeAction(context, action.onError!);
+    }
+    return;
+  }
+
+  if (isFileSizeOverLimit(context, dataContext, selectedFiles, action)) {
+    if (action.onError != null) {
+      ScreenController().executeAction(context, action.onError!);
+    }
+    return;
+  }
+
+  if (action.id != null && scopeManager != null) {
+    final uploadFilesResponse =
+        scopeManager.dataContext.getContextById(action.id!);
+    scopeManager.dataContext.addInvokableContext(
+        action.id!,
+        (uploadFilesResponse is UploadFilesResponse)
+            ? uploadFilesResponse
+            : UploadFilesResponse());
+  }
+
+  final apiDefinition = apiMap?[action.uploadApi];
+  if (apiDefinition == null) {
+    throw LanguageError(
+        'Unable to find api definition for ${action.uploadApi}');
+  }
+
+  if (apiDefinition['inputs'] is YamlList && action.inputs != null) {
+    for (var input in apiDefinition['inputs']) {
+      final value = dataContext.eval(action.inputs![input]);
+      if (value != null) {
+        dataContext.addDataContextById(input, value);
+      }
+    }
+  }
+
+  Map<String, String> headers = {};
+  if (apiDefinition['headers'] is YamlMap) {
+    (apiDefinition['headers'] as YamlMap).forEach((key, value) {
+      if (value != null) {
+        headers[key.toString()] = dataContext.eval(value).toString();
+      }
+    });
+  }
+
+  Map<String, String> fields = {};
+  if (apiDefinition['body'] is YamlMap) {
+    (apiDefinition['body'] as YamlMap).forEach((key, value) {
+      if (value != null) {
+        fields[key.toString()] = dataContext.eval(value).toString();
+      }
+    });
+  }
+
+  String url =
+      HttpUtils.resolveUrl(dataContext, apiDefinition['uri'].toString().trim());
+  String method = apiDefinition['method']?.toString().toUpperCase() ?? 'POST';
+  final fileResponse = action.id == null
+      ? null
+      : scopeManager?.dataContext.getContextById(action.id!)
+          as UploadFilesResponse;
+
+  List<List<File>> fileBatches;
+  if (action.batchSize != null) {
+    fileBatches = [];
+    for (int i = 0; i < selectedFiles.length; i += action.batchSize!) {
+      int end = (i + action.batchSize! < selectedFiles.length)
+          ? i + action.batchSize!
+          : selectedFiles.length;
+      fileBatches.add(selectedFiles.sublist(i, end));
+    }
+  } else {
+    fileBatches = [selectedFiles];
+  }
+
+  for (var fileBatch in fileBatches) {
+    if (action.isBackgroundTask) {
+      if (kIsWeb) {
+        throw LanguageError('Background Upload is not supported on web');
+      }
+      await _setBackgroundUploadTask(
+        context: context,
+        action: action,
+        selectedFiles: fileBatch,
+        headers: headers,
+        fields: fields,
+        method: method,
+        url: url,
+        fileResponse: fileResponse,
+        scopeManager: scopeManager,
+      );
+
+      return;
+    }
+    final taskId = Utils.generateRandomId(8);
+    fileResponse?.addTask(UploadTask(id: taskId));
+
+    final response = await UploadUtils.uploadFiles(
+      headers: headers,
+      fields: fields,
+      method: method,
+      url: url,
+      files: fileBatch,
+      fieldName: action.fieldName,
+      showNotification: action.showNotification,
+      onError: action.onError == null
+          ? null
+          : (error) =>
+              ScreenController().executeAction(context, action.onError!),
+      progressCallback: (progress) {
+        fileResponse?.setProgress(taskId, progress);
+        scopeManager?.dispatch(
+            ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+      },
+      taskId: taskId,
+    );
+
+    if (response == null) {
+      fileResponse?.setStatus(taskId, UploadStatus.failed);
+      return;
+    }
+    fileResponse?.setHeaders(taskId, response.headers);
+    fileResponse?.setBody(taskId, response.body);
+    fileResponse?.setStatus(taskId, UploadStatus.completed);
+    scopeManager?.dispatch(
+        ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+
+    if (action.onComplete != null) {
+      // TODO: @snehmehta, fix this
+      ScreenController().executeAction(context, action.onComplete!);
+    }
+  }
+}
+
+List<File>? _getRawFiles(dynamic rawFiles, DataContext dataContext) {
+  var files = dataContext.eval(rawFiles);
+  if (files is YamlList || files is List) {
+    return files
+        .map((element) {
+          if (element is String) {
+            return File.fromString(element);
+          }
+          return File.fromJson(element);
+        })
+        .toList()
+        .cast<File>();
+  }
+
+  if (files is Map && files.containsKey('path')) {
+    return [File.fromJson(files)];
+  }
+
+  if (files is String) {
+    final rawFiles = File.fromString(files);
+    return [rawFiles];
+  }
+
+  return null;
+}
+
+bool isFileSizeOverLimit(BuildContext context, DataContext dataContext,
+    List<File> selectedFiles, FileUploadAction action) {
+  final defaultMaxFileSize = 100.mb;
+  const defaultOverMaxFileSizeMessage =
+      'The size of is which is larger than the maximum allowed';
+
+  final totalSize = selectedFiles.fold<double>(
+      0, (previousValue, element) => previousValue + (element.size ?? 0));
+  final maxFileSize = action.maxFileSize?.kb ?? defaultMaxFileSize;
+
+  final message = Utils.translateWithFallback(
+    'ensemble.input.overMaxFileSizeMessage',
+    action.overMaxFileSizeMessage ?? defaultOverMaxFileSizeMessage,
+  );
+
+  if (totalSize > maxFileSize) {
+    ToastController().showToast(
+        context,
+        ShowToastAction(
+            type: ToastType.error,
+            message: message,
+            alignment: Alignment.bottomCenter,
+            duration: 3),
+        null,
+        dataContext: dataContext);
+    if (action.onError != null) {
+      ScreenController().executeAction(context, action.onError!);
+    }
+    return true;
+  }
+  return false;
+}
+
+Future<void> _setBackgroundUploadTask({
+  required BuildContext context,
+  required FileUploadAction action,
+  required List<File> selectedFiles,
+  required Map<String, String> headers,
+  required Map<String, String> fields,
+  required String method,
+  required String url,
+  UploadFilesResponse? fileResponse,
+  ScopeManager? scopeManager,
+}) async {
+  final taskId = Utils.generateRandomId(8);
+  fileResponse?.addTask(UploadTask(id: taskId, isBackground: true));
+
+  await Workmanager().registerOneOffTask(
+    'uploadTask',
+    backgroundUploadTask,
+    tag: taskId,
+    inputData: {
+      'fieldName': action.fieldName,
+      'files': selectedFiles.map((e) => json.encode(e.toJson())).toList(),
+      'headers': json.encode(headers),
+      'fields': json.encode(fields),
+      'method': method,
+      'url': url,
+      'taskId': taskId,
+      'showNotification': action.showNotification,
+    },
+    constraints: Constraints(
+      networkType: NetworkTypeExtension.fromString(action.networkType),
+      requiresBatteryNotLow: action.requiresBatteryNotLow,
+    ),
+  );
+
+  var port = ReceivePort();
+  IsolateNameServer.registerPortWithName(port.sendPort, taskId);
+  StreamSubscription<dynamic>? subscription;
+  subscription = port.listen((dynamic data) async {
+    if (data is! Map) return;
+    if (data.containsKey('progress')) {
+      final taskId = data['taskId'];
+      fileResponse?.setStatus(taskId, UploadStatus.running);
+      fileResponse?.setProgress(taskId, data['progress']);
+      if (action.id != null) {
+        scopeManager?.dispatch(
+            ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+      }
+    }
+
+    if (data.containsKey('cancel')) {
+      if (action.id != null) {
+        scopeManager?.dispatch(
+            ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+      }
+      subscription?.cancel();
+    }
+
+    if (data.containsKey('error')) {
+      final taskId = data['taskId'];
+      fileResponse?.setStatus(taskId, UploadStatus.failed);
+      if (action.id != null) {
+        scopeManager?.dispatch(
+            ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+      }
+      if (action.onError != null) {
+        ScreenController().executeAction(context, action.onError!);
+      }
+      subscription?.cancel();
+    }
+    if (data.containsKey('responseBody')) {
+      final taskId = data['taskId'];
+      final response =
+          Response.fromBody(data['responseBody'], data['responseHeaders']);
+      fileResponse?.setBody(taskId, response.body);
+      fileResponse?.setHeaders(taskId, response.headers);
+      fileResponse?.setStatus(taskId, UploadStatus.completed);
+
+      if (action.id != null) {
+        scopeManager?.dispatch(
+            ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
+      }
+
+      if (action.onComplete != null) {
+        ScreenController().executeAction(context, action.onComplete!);
+      }
+      subscription?.cancel();
+    }
+  });
+}
+
+extension NetworkTypeExtension on NetworkType {
+  static NetworkType fromString(String? str) {
+    if (str == null) return NetworkType.connected;
+    switch (str.toLowerCase()) {
+      case 'connected':
+        return NetworkType.connected;
+      case 'metered':
+        return NetworkType.metered;
+      case 'not_required':
+        return NetworkType.not_required;
+      case 'not_roaming':
+        return NetworkType.not_roaming;
+      case 'unmetered':
+        return NetworkType.unmetered;
+      case 'temporarily_unmetered':
+        return NetworkType.temporarily_unmetered;
+      default:
+        return NetworkType.connected;
+    }
+  }
+}

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -531,6 +531,7 @@ class FileUploadAction extends EnsembleAction {
     this.networkType,
     this.requiresBatteryNotLow,
     required this.showNotification,
+    this.batchSize,
   }) : super(inputs: inputs);
 
   String? id;
@@ -545,6 +546,7 @@ class FileUploadAction extends EnsembleAction {
   String? networkType;
   bool? requiresBatteryNotLow;
   bool showNotification;
+  int? batchSize;
 
   factory FileUploadAction.fromYaml({Map? payload}) {
     if (payload == null || payload['uploadApi'] == null) {
@@ -571,6 +573,7 @@ class FileUploadAction extends EnsembleAction {
           Utils.optionalBool(payload['options']?['requiresBatteryNotLow']),
       showNotification: Utils.getBool(payload['options']?['showNotification'],
           fallback: false),
+      batchSize: Utils.optionalInt(payload['options']?['batchSize']),
     );
   }
 }

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -1,15 +1,11 @@
 // ignore_for_file: use_build_context_synchronously
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:isolate';
-import 'dart:math' show Random;
-import 'dart:ui';
 
 import 'package:app_settings/app_settings.dart';
 import 'package:ensemble/action/navigation_action.dart';
+import 'package:ensemble/action/upload_files_action.dart';
 import 'package:ensemble/ensemble.dart';
-import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/bindings.dart';
 import 'package:ensemble/framework/data_context.dart';
@@ -31,11 +27,7 @@ import 'package:ensemble/framework/widget/screen.dart';
 import 'package:ensemble/framework/widget/toast.dart';
 import 'package:ensemble/layout/ensemble_page_route.dart';
 import 'package:ensemble/page_model.dart';
-import 'package:ensemble/receive_intent_manager.dart';
-import 'package:ensemble/util/extensions.dart';
-import 'package:ensemble/util/http_utils.dart';
 import 'package:ensemble/util/notification_utils.dart';
-import 'package:ensemble/util/upload_utils.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -45,7 +37,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:walletconnect_dart/walletconnect_dart.dart';
 import 'package:web_socket_client/web_socket_client.dart';
-import 'package:workmanager/workmanager.dart';
 import 'package:yaml/yaml.dart';
 
 import 'framework/widget/wallet_connect_modal.dart';
@@ -629,291 +620,6 @@ class ScreenController {
     localizedContext.evalCode(codeBlock);
   }*/
 
-  Future<void> uploadFiles({
-    required BuildContext context,
-    required FileUploadAction action,
-    required DataContext dataContext,
-    ScopeManager? scopeManager,
-    Map<String, YamlMap>? apiMap,
-  }) async {
-    List<File>? selectedFiles = _getRawFiles(action.files, dataContext);
-
-    if (selectedFiles == null) {
-      if (action.onError != null) executeAction(context, action.onError!);
-      return;
-    }
-
-    if (isFileSizeOverLimit(context, dataContext, selectedFiles, action)) {
-      if (action.onError != null) executeAction(context, action.onError!);
-      return;
-    }
-
-    if (action.id != null && scopeManager != null) {
-      final uploadFilesResponse =
-          scopeManager.dataContext.getContextById(action.id!);
-      scopeManager.dataContext.addInvokableContext(
-          action.id!,
-          (uploadFilesResponse is UploadFilesResponse)
-              ? uploadFilesResponse
-              : UploadFilesResponse());
-    }
-
-    final apiDefinition = apiMap?[action.uploadApi];
-    if (apiDefinition == null) {
-      throw LanguageError(
-          'Unable to find api definition for ${action.uploadApi}');
-    }
-
-    if (apiDefinition['inputs'] is YamlList && action.inputs != null) {
-      for (var input in apiDefinition['inputs']) {
-        final value = dataContext.eval(action.inputs![input]);
-        if (value != null) {
-          dataContext.addDataContextById(input, value);
-        }
-      }
-    }
-
-    Map<String, String> headers = {};
-    if (apiDefinition['headers'] is YamlMap) {
-      (apiDefinition['headers'] as YamlMap).forEach((key, value) {
-        if (value != null) {
-          headers[key.toString()] = dataContext.eval(value).toString();
-        }
-      });
-    }
-
-    Map<String, String> fields = {};
-    if (apiDefinition['body'] is YamlMap) {
-      (apiDefinition['body'] as YamlMap).forEach((key, value) {
-        if (value != null) {
-          fields[key.toString()] = dataContext.eval(value).toString();
-        }
-      });
-    }
-
-    String url = HttpUtils.resolveUrl(
-        dataContext, apiDefinition['uri'].toString().trim());
-    String method = apiDefinition['method']?.toString().toUpperCase() ?? 'POST';
-    final fileResponse = action.id == null
-        ? null
-        : scopeManager?.dataContext.getContextById(action.id!)
-            as UploadFilesResponse;
-
-    List<List<File>> fileBatches;
-    if (action.batchSize != null) {
-      fileBatches = [];
-      for (int i = 0; i < selectedFiles.length; i += action.batchSize!) {
-        int end = (i + action.batchSize! < selectedFiles.length)
-            ? i + action.batchSize!
-            : selectedFiles.length;
-        fileBatches.add(selectedFiles.sublist(i, end));
-      }
-    } else {
-      fileBatches = [selectedFiles];
-    }
-
-    for (var fileBatch in fileBatches) {
-      if (action.isBackgroundTask) {
-        if (kIsWeb) {
-          throw LanguageError('Background Upload is not supported on web');
-        }
-        await _setBackgroundUploadTask(
-          context: context,
-          action: action,
-          selectedFiles: fileBatch,
-          headers: headers,
-          fields: fields,
-          method: method,
-          url: url,
-          fileResponse: fileResponse,
-          scopeManager: scopeManager,
-        );
-
-        return;
-      }
-      final taskId = generateRandomId(8);
-      fileResponse?.addTask(UploadTask(id: taskId));
-
-      final response = await UploadUtils.uploadFiles(
-        headers: headers,
-        fields: fields,
-        method: method,
-        url: url,
-        files: fileBatch,
-        fieldName: action.fieldName,
-        showNotification: action.showNotification,
-        onError: action.onError == null
-            ? null
-            : (error) => executeAction(context, action.onError!),
-        progressCallback: (progress) {
-          fileResponse?.setProgress(taskId, progress);
-          scopeManager?.dispatch(
-              ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-        },
-        taskId: taskId,
-      );
-
-      if (response == null) {
-        fileResponse?.setStatus(taskId, UploadStatus.failed);
-        return;
-      }
-      fileResponse?.setHeaders(taskId, response.headers);
-      fileResponse?.setBody(taskId, response.body);
-      fileResponse?.setStatus(taskId, UploadStatus.completed);
-      scopeManager?.dispatch(
-          ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-
-      if (action.onComplete != null) executeAction(context, action.onComplete!);
-    }
-  }
-
-  List<File>? _getRawFiles(dynamic rawFiles, DataContext dataContext) {
-    var files = dataContext.eval(rawFiles);
-    if (files is YamlList || files is List) {
-      return files
-          .map((element) {
-            if (element is String) {
-              return File.fromString(element);
-            }
-            return File.fromJson(element);
-          })
-          .toList()
-          .cast<File>();
-    }
-
-    if (files is Map && files.containsKey('path')) {
-      return [File.fromJson(files)];
-    }
-
-    if (files is String) {
-      final rawFiles = File.fromString(files);
-      return [rawFiles];
-    }
-
-    return null;
-  }
-
-  bool isFileSizeOverLimit(BuildContext context, DataContext dataContext,
-      List<File> selectedFiles, FileUploadAction action) {
-    final defaultMaxFileSize = 100.mb;
-    const defaultOverMaxFileSizeMessage =
-        'The size of is which is larger than the maximum allowed';
-
-    final totalSize = selectedFiles.fold<double>(
-        0, (previousValue, element) => previousValue + (element.size ?? 0));
-    final maxFileSize = action.maxFileSize?.kb ?? defaultMaxFileSize;
-
-    final message = Utils.translateWithFallback(
-      'ensemble.input.overMaxFileSizeMessage',
-      action.overMaxFileSizeMessage ?? defaultOverMaxFileSizeMessage,
-    );
-
-    if (totalSize > maxFileSize) {
-      ToastController().showToast(
-          context,
-          ShowToastAction(
-              type: ToastType.error,
-              message: message,
-              alignment: Alignment.bottomCenter,
-              duration: 3),
-          null,
-          dataContext: dataContext);
-      if (action.onError != null) executeAction(context, action.onError!);
-      return true;
-    }
-    return false;
-  }
-
-  Future<void> _setBackgroundUploadTask({
-    required BuildContext context,
-    required FileUploadAction action,
-    required List<File> selectedFiles,
-    required Map<String, String> headers,
-    required Map<String, String> fields,
-    required String method,
-    required String url,
-    UploadFilesResponse? fileResponse,
-    ScopeManager? scopeManager,
-  }) async {
-    final taskId = generateRandomId(8);
-    fileResponse?.addTask(UploadTask(id: taskId, isBackground: true));
-
-    await Workmanager().registerOneOffTask(
-      'uploadTask',
-      backgroundUploadTask,
-      tag: taskId,
-      inputData: {
-        'fieldName': action.fieldName,
-        'files': selectedFiles.map((e) => json.encode(e.toJson())).toList(),
-        'headers': json.encode(headers),
-        'fields': json.encode(fields),
-        'method': method,
-        'url': url,
-        'taskId': taskId,
-        'showNotification': action.showNotification,
-      },
-      constraints: Constraints(
-        networkType: NetworkTypeExtension.fromString(action.networkType),
-        requiresBatteryNotLow: action.requiresBatteryNotLow,
-      ),
-    );
-
-    var port = ReceivePort();
-    IsolateNameServer.registerPortWithName(port.sendPort, taskId);
-    StreamSubscription<dynamic>? subscription;
-    subscription = port.listen((dynamic data) async {
-      if (data is! Map) return;
-      if (data.containsKey('progress')) {
-        final taskId = data['taskId'];
-        fileResponse?.setStatus(taskId, UploadStatus.running);
-        fileResponse?.setProgress(taskId, data['progress']);
-        if (action.id != null) {
-          scopeManager?.dispatch(
-              ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-        }
-      }
-
-      if (data.containsKey('cancel')) {
-        if (action.id != null) {
-          scopeManager?.dispatch(
-              ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-        }
-        subscription?.cancel();
-      }
-
-      if (data.containsKey('error')) {
-        final taskId = data['taskId'];
-        fileResponse?.setStatus(taskId, UploadStatus.failed);
-        if (action.id != null) {
-          scopeManager?.dispatch(
-              ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-        }
-        if (action.onError != null) {
-          executeAction(context, action.onError!);
-        }
-        subscription?.cancel();
-      }
-      if (data.containsKey('responseBody')) {
-        final taskId = data['taskId'];
-        final response =
-            Response.fromBody(data['responseBody'], data['responseHeaders']);
-        fileResponse?.setBody(taskId, response.body);
-        fileResponse?.setHeaders(taskId, response.headers);
-        fileResponse?.setStatus(taskId, UploadStatus.completed);
-
-        if (action.id != null) {
-          scopeManager?.dispatch(
-              ModelChangeEvent(APIBindingSource(action.id!), fileResponse));
-        }
-
-        if (action.onComplete != null) {
-          executeAction(context, action.onComplete!);
-        }
-        subscription?.cancel();
-      }
-    });
-  }
-
   void dispatchStorageChanges(BuildContext context, String key, dynamic value) {
     ScopeManager? scopeManager = getScopeManager(context);
     if (scopeManager != null) {
@@ -1107,34 +813,3 @@ class ScreenController {
 }
 
 enum RouteOption { replaceCurrentScreen, clearAllScreens }
-
-String generateRandomId(int length) {
-  var rand = Random();
-  var codeUnits = List.generate(length, (index) {
-    return rand.nextInt(26) + 97; // ASCII code for lowercase a-z
-  });
-
-  return String.fromCharCodes(codeUnits);
-}
-
-extension NetworkTypeExtension on NetworkType {
-  static NetworkType fromString(String? str) {
-    if (str == null) return NetworkType.connected;
-    switch (str.toLowerCase()) {
-      case 'connected':
-        return NetworkType.connected;
-      case 'metered':
-        return NetworkType.metered;
-      case 'not_required':
-        return NetworkType.not_required;
-      case 'not_roaming':
-        return NetworkType.not_roaming;
-      case 'unmetered':
-        return NetworkType.unmetered;
-      case 'temporarily_unmetered':
-        return NetworkType.temporarily_unmetered;
-      default:
-        return NetworkType.connected;
-    }
-  }
-}

--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -846,4 +846,13 @@ class Utils {
     // Fallback - Returning same passed-in object to the caller
     return dataMapObjects;
   }
+
+  static String generateRandomId(int length) {
+    var rand = Random();
+    var codeUnits = List.generate(length, (index) {
+      return rand.nextInt(26) + 97; // ASCII code for lowercase a-z
+    });
+
+    return String.fromCharCodes(codeUnits);
+  }
 }


### PR DESCRIPTION
closes: https://github.com/EnsembleUI/ensemble/issues/975

Introducing `batchSize` option in `uploadFiles`, we can specify number of batch of files to be uploaded with a single http call.

Sample EDL
```yaml
Button:
  label: Upload Picked files
  onTap:
    pickFiles:
      id: picker
      allowMultiple: true
      onComplete:
        uploadFiles:
          id: fileUploader
          files: ${picker.files}
          uploadApi: fileUploadApi
          options:
            batchSize: 2
          onComplete: |
            //@code
            console.log(fileUploader.body);
          onError: |
            //@code

            console.log('Failed');

```