### PR TITLE
Revert "Fixes the bug of setting of visible property of DataRow"

### DIFF
--- a/lib/layout/data_grid.dart
+++ b/lib/layout/data_grid.dart
@@ -136,10 +136,6 @@ class EnsembleDataRow extends StatefulWidget
   List<WidgetModel>? children;
   ItemTemplate? itemTemplate;
   bool visible = true;
-  // Callback to fire when visible changes
-  Function(bool value)? onVisibilityChanged;
-
-  EnsembleDataRow({super.key});
 
   @override
   State<StatefulWidget> createState() => EnsembleDataRowState();
@@ -163,17 +159,7 @@ class EnsembleDataRow extends StatefulWidget
   @override
   Map<String, Function> setters() {
     return {
-      'visible': (dynamic v) {
-        final bool newValue = Utils.getBool(v, fallback: visible);
-
-        // checking if old value and new value are different
-        if (visible != newValue) {
-          visible = newValue;
-
-          // Firing the callback to update the state in EnsembleDataGrid
-          onVisibilityChanged?.call(visible);
-        }
-      }
+      'visible': (dynamic v) => visible = Utils.getBool(v, fallback: visible)
     };
   }
 }
@@ -237,9 +223,6 @@ class DataGridState extends WidgetState<DataGrid>
   final List<DataRow> _rows = [];
   final List<Widget> _children = [];
 
-  // List for the visibilities for individual row
-  List<bool> rowVisibilities = [];
-
   @override
   void initState() {
     widget._controller.addListener(refreshState);
@@ -287,12 +270,6 @@ class DataGridState extends WidgetState<DataGrid>
 
     _buildDataColumn(scopeManager);
     _buildChildren();
-
-    // Ensure that _parseVisibility runs only once as it is inside buildWidget. Cannot put it in initState
-    if (rowVisibilities.isEmpty) {
-      rowVisibilities = _parseVisibility();
-    }
-
     _buildDataRow();
 
     // Setting sort column index and order
@@ -340,21 +317,6 @@ class DataGridState extends WidgetState<DataGrid>
     );
   }
 
-  // Parsers the visibility out of the list of rows
-  List<bool> _parseVisibility() {
-    List<bool> visibilities = [];
-
-    for (var widget in _children) {
-      if (widget is! EnsembleDataRow) {
-        throw Exception("Direct children of DataGrid must be of type DataRow");
-      } else {
-        visibilities.add(widget.visible);
-      }
-    }
-
-    return visibilities;
-  }
-
   TextStyle? _buildHeadingStyle() {
     TextStyle? headingTextStyle;
     if (widget.controller.headingTextController != null) {
@@ -394,10 +356,7 @@ class DataGridState extends WidgetState<DataGrid>
 
   void _buildDataRow() {
     _rows.clear();
-    // Added children.asMap().entries to have access for individual element index
-    for (int index = 0; index < _children.length; index++) {
-      Widget w = _children[index];
-
+    for (Widget w in _children) {
       DataScopeWidget? rowScope;
 
       if (w is DataScopeWidget) {
@@ -407,17 +366,8 @@ class DataGridState extends WidgetState<DataGrid>
       if (w is! EnsembleDataRow) {
         throw Exception("Direct children of DataGrid must be of type DataRow");
       }
-
       EnsembleDataRow child = w;
-
-      // Callback to update the visible of a given row changes
-      child.onVisibilityChanged = (value) {
-        setState(() {
-          rowVisibilities[index] = value;
-        });
-      };
-
-      if (!rowVisibilities[index]) {
+      if (!child.visible) {
         continue;
       }
       List<DataCell> cells = [];


### PR DESCRIPTION
Reverts EnsembleUI/ensemble#972

This PR does not take into account updating the DataGrid rows dynamically through an item-template. It breaks all grids as the the _children array can grow dynamically and the following code will break (line 420) - 

```
      if (!rowVisibilities[index]) {
        continue;
      }
```
as the rowVisibility is static