### PR TITLE
Simplified callbackAfterInit method call logic and handle errors

### DIFF
--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -47,12 +47,12 @@ class Ensemble {
     externalScreenWidgets = widgets;
   }
 
-  final List<Function> _afterInitMethods = [];
+  final Set<Function> _afterInitMethods = {};
   void addCallbackAfterInitialization({required Function method}) {
     _afterInitMethods.add(method);
   }
 
-  List<Function> getCallbacksAfterInitialization() => _afterInitMethods;
+  Set<Function> getCallbacksAfterInitialization() => _afterInitMethods;
 
   late FirebaseApp ensembleFirebaseApp;
   static final Map<String, dynamic> externalDataContext = {};

--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -47,22 +47,12 @@ class Ensemble {
     externalScreenWidgets = widgets;
   }
 
-  final List<Map<String, Object?>> _afterInitMethods = [];
-  void addCallbackAfterInitialization(
-      {required Function method,
-      List<dynamic>? positionalArgs,
-      Map<String, dynamic>? namedArgs}) {
-    final function = {
-      'id': math.Random().nextInt(100000),
-      'method': method,
-      'positionalArgs': positionalArgs,
-      'namedArgs': namedArgs
-    };
-    _afterInitMethods.add(function);
+  final List<Function> _afterInitMethods = [];
+  void addCallbackAfterInitialization({required Function method}) {
+    _afterInitMethods.add(method);
   }
 
-  List<Map<String, Object?>> getCallbacksAfterInitialization() =>
-      _afterInitMethods;
+  List<Function> getCallbacksAfterInitialization() => _afterInitMethods;
 
   late FirebaseApp ensembleFirebaseApp;
   static final Map<String, dynamic> externalDataContext = {};

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -134,16 +134,16 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
 
   Future<void> executeCallbacks() async {
     final callbacks = List.from(Ensemble().getCallbacksAfterInitialization());
-    try {
-      callbacks.asMap().forEach((index, value) async {
-        // Removing a method and getting the function with index to execute it
-        final methodToCall =
-            Ensemble().getCallbacksAfterInitialization().removeAt(index);
-        await Function.apply(methodToCall, null);
-      });
-    } catch (e) {
-      print('Failed to execute a method: $e');
-    }
+
+    callbacks.asMap().forEach((index, function) async {
+      // Removing a method and getting the function with index to execute it
+      Ensemble().getCallbacksAfterInitialization().remove(function);
+      try {
+        await Function.apply(function, null);
+      } catch (e) {
+        print('Failed to execute a method: $e');
+      }
+    });
   }
 
   void initDeepLink(AppLifecycleState state) {

--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -133,31 +133,17 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
   }
 
   Future<void> executeCallbacks() async {
-    List<int?> functionIds = [];
-    final callbacks = Ensemble().getCallbacksAfterInitialization();
-    for (final Map<String, Object?> callback in callbacks) {
-      final id = callback['id'] as int?;
-      final method = callback['method'] as Function?;
-      final positionalPayloads = callback['positionalArgs'] as List<dynamic>?;
-      final namedPayloads = callback['namedArgs'] as Map<String, dynamic>?;
-      Map<Symbol, dynamic>? namedParams;
-      namedPayloads?.forEach((key, value) {
-        namedParams = {Symbol(key): value};
+    final callbacks = List.from(Ensemble().getCallbacksAfterInitialization());
+    try {
+      callbacks.asMap().forEach((index, value) async {
+        // Removing a method and getting the function with index to execute it
+        final methodToCall =
+            Ensemble().getCallbacksAfterInitialization().removeAt(index);
+        await Function.apply(methodToCall, null);
       });
-
-      if (method != null) {
-        await Function.apply(method, positionalPayloads, namedParams);
-        functionIds.add(id);
-      }
+    } catch (e) {
+      print('Failed to execute a method: $e');
     }
-
-    // Looping function id to remove the functions in the callback object with the id
-    for (final id in functionIds) {
-      callbacks.removeWhere((element) => element['id'] == id);
-    }
-
-    // Reset to empty
-    functionIds = [];
   }
 
   void initDeepLink(AppLifecycleState state) {

--- a/lib/ios_deep_link_manager.dart
+++ b/lib/ios_deep_link_manager.dart
@@ -21,7 +21,7 @@ class IOSDeepLinkManager extends DeepLinkNavigator {
       if (call.method == IOSDeepLinkManager._deepLinkMethod) {
         final url = Uri.parse(call.arguments);
         Ensemble().addCallbackAfterInitialization(
-            method: navigateToScreen, positionalArgs: [url]);
+            method: () => navigateToScreen(url));
       }
       return Future.value(true);
     });


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/958
Enhancement:

In this PR, I entirely refactored the method calling after an ensemble app initialized.

1. `addCallbackAfterInitialization` - It stores the method in the `_afterInitMethods` (List of type Function)
2. `getCallbacksAfterInitialization` - It returns `_afterInitMethods` (List of type Function)
3. When the ensemble app is initialized or resumed, it executes the `executeCallbacks` method which will remove a method which is stored in the `getCallbacksAfterInitialization` and execute that removed method.
4. Error handled