### PR TITLE
Remove selectedIndex from the setters method

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -2830,10 +2830,6 @@
                       "type": "boolean",
                       "description": "Determines if carousel should loop infinitely or be limited to item length. Default (false)"
                     },
-                    "selectedIndex": {
-                      "type": "integer",
-                      "description": "It returns the selected item index of the Carousel. Default (-1) if not tapped / selected"
-                    },
                     "currentIndex": {
                       "type": "integer",
                       "description": "The initial page to show when first creating the Carousel and the current index of the displaying Carousel Item. Default (0)"

--- a/lib/widget/carousel.dart
+++ b/lib/widget/carousel.dart
@@ -67,8 +67,6 @@ class Carousel extends StatefulWidget
           _controller.indicatorColor = Utils.getColor(value),
       'currentIndex': (value) =>
           _controller.currentIndex = Utils.getInt(value, fallback: 0),
-      'selectedIndex': (value) =>
-          _controller.selectedIndex = Utils.getInt(value, fallback: -1),
       'indicatorMaxCount': (value) =>
           _controller.indicatorMaxCount = Utils.optionalInt(value),
       'onItemChange': (action) => _controller.onItemChange =


### PR DESCRIPTION
This `selectedIndex` property is changed only from the framework when the user taps any of the carousel item. So it should not be exposed to the user. Just removed it.