### PR TITLE
Add keyboard toolbar with done button

### DIFF
--- a/lib/widget/input/form_textfield.dart
+++ b/lib/widget/input/form_textfield.dart
@@ -14,6 +14,7 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/widget/input/form_helper.dart';
 import 'package:ensemble/widget/helpers/widgets.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokablecontroller.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:email_validator/email_validator.dart';
@@ -217,6 +218,15 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
   // This is so we can be consistent with the other input widgets' onChange
   String previousText = '';
   bool didItChange = false;
+  // password is obscure by default
+  late bool currentlyObscured;
+  late List<TextInputFormatter> _inputFormatter;
+  OverlayEntry? overlayEntry;
+  bool get toolbarDoneStatus {
+    final status = widget.keyboardType == TextInputType.phone ||
+        widget.keyboardType == TextInputType.number;
+    return status;
+  }
 
   void evaluateChanges() {
     if (didItChange) {
@@ -232,9 +242,28 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
     }
   }
 
-  // password is obscure by default
-  late bool currentlyObscured;
-  late List<TextInputFormatter> _inputFormatter;
+  void showOverlay(BuildContext context) {
+    if (overlayEntry != null || !toolbarDoneStatus) return;
+    OverlayState overlayState = Overlay.of(context);
+    overlayEntry = OverlayEntry(builder: (context) {
+      return Positioned(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        right: 0.0,
+        left: 0.0,
+        child: const _InputDoneButton(),
+      );
+    });
+
+    overlayState.insert(overlayEntry!);
+  }
+
+  void removeOverlayAndUnfocus() {
+    if (overlayEntry != null) {
+      overlayEntry!.remove();
+      overlayEntry = null;
+    }
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
 
   @override
   void initState() {
@@ -410,6 +439,8 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
           controller: widget.textController,
           focusNode: focusNode,
           enabled: isEnabled(),
+          onTap: () => showOverlay(context),
+          onTapOutside: (_) => removeOverlayAndUnfocus(),
           onFieldSubmitted: (value) => widget.controller.submitForm(context),
           onChanged: (String txt) {
             if (txt != previousText) {
@@ -494,3 +525,25 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
 }
 
 enum InputType { email, phone, ipAddress, number, text, url, datetime }
+
+class _InputDoneButton extends StatelessWidget {
+  const _InputDoneButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Colors.grey[200],
+      alignment: Alignment.topRight,
+      padding: const EdgeInsets.only(top: 1.0, bottom: 1.0),
+      child: CupertinoButton(
+        padding: const EdgeInsets.only(right: 24.0, top: 2.0, bottom: 2.0),
+        onPressed: () => FocusScope.of(context).requestFocus(FocusNode()),
+        child: const Text(
+          'Done',
+          style: TextStyle(color: Colors.black, fontWeight: FontWeight.normal),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Ticket - https://github.com/EnsembleUI/ensemble/issues/1017

In this PR, I added the following
1. Added a toolbar with done button for the keyboard which has input type of `number` and `phone` of `TextInput`
2. `onTapOutside` method in the TextFormField, which will remove the keyboard focus automatically

<img src="https://github.com/EnsembleUI/ensemble/assets/12869588/6bd198ce-410a-43b4-bb4d-37903e68e946" width=350>

