### PR TITLE
Add switchScreen, onTap and onTapHaptic actions for the bottom nav bar item

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -5080,6 +5080,10 @@
                 "type": "boolean",
                 "description": "Mark this item as a floating icon"
               },
+              "switchScreen": {
+                "type": "boolean",
+                "description": "Disable the screen switching when clicking the bottom nav bar item. Default (True)"
+              },
               "floatingMargin": {
                 "$ref": "#/$defs/Margin-payload",
                 "description": "The margin around the floating."

--- a/lib/framework/menu.dart
+++ b/lib/framework/menu.dart
@@ -71,6 +71,7 @@ abstract class Menu {
               floatingAlignment:
                   Utils.optionalString(item['floatingAlignment']) ?? 'center',
               floatingMargin: Utils.optionalInt(item['floatingMargin']),
+              switchScreen: Utils.getBool(item['switchScreen'], fallback: true),
               onTap: item['onTap'],
               onTapHaptic: Utils.optionalString(item['onTapHaptic']),
               isExternal: Utils.getBool(item['isExternal'], fallback: false),
@@ -207,6 +208,7 @@ class MenuItem {
     this.iconLibrary,
     this.selected,
     this.floating = false,
+    this.switchScreen = true,
     this.floatingAlignment = 'center',
     this.floatingMargin,
     this.onTap,
@@ -223,6 +225,7 @@ class MenuItem {
   final String? iconLibrary;
   final dynamic selected;
   final bool floating;
+  final bool switchScreen;
   final String floatingAlignment;
   final int? floatingMargin;
   final dynamic onTap;

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -13,14 +13,16 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/framework/widget/icon.dart' as ensemble;
 import 'package:flutter/material.dart';
 
-class FABBottomAppBarItem {
-  FABBottomAppBarItem({
+class BottomNavBarItem {
+  BottomNavBarItem({
     required this.icon,
     required this.text,
     required this.isCustom,
     this.activeIcon,
     this.isFloating = false,
     this.floatingMargin,
+    this.onTap,
+    this.onTapHaptic,
   });
 
   Widget icon;
@@ -29,6 +31,8 @@ class FABBottomAppBarItem {
   bool isFloating;
   bool isCustom;
   double? floatingMargin;
+  EnsembleAction? onTap;
+  String? onTapHaptic;
 }
 
 enum FloatingAlignment {
@@ -240,7 +244,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
   }
 
   Widget? _buildBottomNavBar() {
-    List<FABBottomAppBarItem> navItems = [];
+    List<BottomNavBarItem> navItems = [];
 
     final unselectedColor = Utils.getColor(widget.menu.styles?['color']) ??
         Theme.of(context).unselectedWidgetColor;
@@ -272,11 +276,13 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
               : null);
 
       navItems.add(
-        FABBottomAppBarItem(
+        BottomNavBarItem(
           icon: icon,
           activeIcon: activeIcon,
           isCustom: isCustom,
           text: label,
+          onTap: EnsembleAction.fromYaml(item.onTap),
+          onTapHaptic: item.onTapHaptic,
         ),
       );
     }
@@ -314,6 +320,21 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
             } else {
               PageGroupWidget.getPageController(context)!.jumpToPage(index);
               viewGroupNotifier.updatePage(index);
+            }
+
+            // Executing onTap action
+            if (navItems[index].onTap != null) {
+              ScreenController().executeActionWithScope(
+                  context, widget.scopeManager, navItems[index].onTap!);
+            }
+
+            // Executing haptic feedback action
+            if (navItems[index].onTapHaptic != null) {
+              ScreenController().executeAction(
+                context,
+                HapticAction(
+                    type: navItems[index].onTapHaptic!, onComplete: null),
+              );
             }
           },
           items: navItems,
@@ -360,7 +381,7 @@ class EnsembleBottomAppBar extends StatefulWidget {
   }) {
     // assert(items.length == 2 || items.length == 4);
   }
-  final List<FABBottomAppBarItem> items;
+  final List<BottomNavBarItem> items;
   final int selectedIndex;
   final double? height;
   final dynamic margin;
@@ -484,7 +505,7 @@ class EnsembleBottomAppBarState extends State<EnsembleBottomAppBar> {
   }
 
   Widget _buildTabItem({
-    required FABBottomAppBarItem item,
+    required BottomNavBarItem item,
     required int index,
     required ValueChanged<int> onPressed,
   }) {


### PR DESCRIPTION
In this PR, I added the following
1. Added `onTap` action for all nav bar item
2. Currently, the `onTapHaptic` is added only for the FAB. Now I added it for other items too
3. Added `switchScreen` property, this will disable the page switching and the bottom nav bar item selected states. Developer have to manually invoke whatever the page they want to with the `onTap` action callback