### PR TITLE
preview build trigger

### DIFF
--- a/.github/workflows/trigger-preview-build.yaml
+++ b/.github/workflows/trigger-preview-build.yaml
@@ -1,0 +1,19 @@
+name: Trigger Preview Build
+
+on: 
+    pull_request: 
+        types: [closed]
+        branches: 
+            - main
+
+jobs:
+    Trigger-Preview-Build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Create workflow dispatch event
+              uses: benc-uk/workflow-dispatch@v1
+              with:
+                workflow: 80211660
+                repo: ensembleUI/ensemble_live
+                token: ${{ secrets.PAT }}
+            


### PR DESCRIPTION
Dispatch event to run studio preview builder workflow in `ensembleUI/ensemble_live` repo when PR is closed on main.
https://github.com/EnsembleUI/ensemble_live/actions/workflows/studio-preview-deploy.yml