### PR TITLE
Fix form label styles

### DIFF
--- a/lib/layout/form.dart
+++ b/lib/layout/form.dart
@@ -20,9 +20,11 @@ class EnsembleForm extends StatefulWidget
         Invokable,
         HasController<FormController, FormState> {
   static const type = 'Form';
+
   EnsembleForm({Key? key}) : super(key: key);
 
   final FormController _controller = FormController();
+
   @override
   FormController get controller => _controller;
 
@@ -53,6 +55,8 @@ class EnsembleForm extends StatefulWidget
           handleLabelPosition(Utils.optionalString(value)),
       'labelOverflow': (value) =>
           _controller.labelOverflow = Utils.optionalString(value),
+      'labelStyle': (value) =>
+          _controller.labelStyle = Utils.getTextStyle(value),
       'enabled': (value) => _controller.enabled = Utils.optionalBool(value),
       'width': (value) => _controller.width = Utils.optionalInt(value),
       'height': (value) => _controller.height = Utils.optionalInt(value),
@@ -97,6 +101,7 @@ class FormController extends WidgetController {
   // labelMaxWidth applicable only to labelPosition=start
   int? labelMaxWidth;
   int? maxWidth;
+  flutter.TextStyle? labelStyle;
 
   int? width;
   int? height;
@@ -106,6 +111,7 @@ class FormController extends WidgetController {
 class FormState extends WidgetState<EnsembleForm>
     with HasChildren<EnsembleForm> {
   final _formKey = GlobalKey<flutter.FormState>();
+
   bool validate() {
     return _formKey.currentState!.validate();
   }
@@ -157,6 +163,7 @@ class FormState extends WidgetState<EnsembleForm>
                   border: InputBorder.none,
                   focusedBorder: InputBorder.none,
                   enabledBorder: InputBorder.none,
+                  labelStyle: widget._controller.labelStyle,
                   labelText: widget.shouldFormFieldShowLabel
                       ? (formItem.controller as WidgetController).label
                       : null),
@@ -184,7 +191,11 @@ class FormState extends WidgetState<EnsembleForm>
           (child.controller as WidgetController).visible &&
           (child.controller as WidgetController).label != null &&
           !inExcludedList(child.controller as WidgetController)) {
-        label = buildLabel((child.controller as WidgetController).label!,
+        label = buildLabel(
+            (child.controller as WidgetController).label!,
+            (child.controller is FormFieldController
+                ? (child.controller as FormFieldController).labelStyle
+                : null),
             (child.controller as WidgetController).labelHint);
         hasAtLeastOneLabel = true;
       } else {
@@ -224,12 +235,15 @@ class FormState extends WidgetState<EnsembleForm>
     return hasAtLeastOneLabel ? Column(children: rows) : buildColumn(formItems);
   }
 
-  Widget buildLabel(String label, String? labelHint) {
+  /// Note that this is only for side-by-side. Label display on top will have
+  /// its label at the widget level
+  Widget buildLabel(String label, TextStyle? labelStyle, String? labelHint) {
     util.TextOverflow textOverflow =
         util.TextOverflow.from(widget._controller.labelOverflow);
 
     Widget labelWidget = Text(
       Utils.translate(label, context),
+      style: labelStyle ?? widget.controller.labelStyle,
       overflow: textOverflow.overflow,
       maxLines: textOverflow.maxLine,
       softWrap: textOverflow.softWrap,

--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -277,53 +277,11 @@ class InputWrapper extends StatelessWidget {
         controller.floatLabel != null && controller.floatLabel == true;
 
     Widget rtn = controller.maxWidth == null
-        ? Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (shouldShowLabel(context) &&
-                  controller.label != null &&
-                  !isFloatLabel)
-                Container(
-                  margin: const EdgeInsets.only(bottom: 8.0),
-                  child: Text(
-                    controller.label!,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                ),
-              widget,
-              if (shouldShowLabel(context) && controller.description != null)
-                Container(
-                  margin: const EdgeInsets.only(top: 12.0),
-                  child: Text(controller.description!),
-                ),
-            ],
-          )
+        ? buildTextWidget(context, isFloatLabel)
         : ConstrainedBox(
             constraints:
                 BoxConstraints(maxWidth: controller.maxWidth!.toDouble()),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (shouldShowLabel(context) &&
-                    controller.label != null &&
-                    !isFloatLabel)
-                  Container(
-                    margin: const EdgeInsets.only(bottom: 8.0),
-                    child: Text(
-                      controller.label!,
-                      style: Theme.of(context).inputDecorationTheme.labelStyle,
-                    ),
-                  ),
-                widget,
-                if (shouldShowLabel(context) && controller.description != null)
-                  Container(
-                    margin: const EdgeInsets.only(top: 12.0),
-                    child: Text(controller.description!),
-                  ),
-              ],
-            ));
+            child: buildTextWidget(context, isFloatLabel));
 
     // we'd like to use LayoutBuilder to detect layout anomaly, but certain
     // containers don't like LayoutBuilder, since it doesn't support returning
@@ -340,6 +298,30 @@ class InputWrapper extends StatelessWidget {
     }
     return rtn;
   }
+
+  Widget buildTextWidget(context, bool isFloatLabel) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (shouldShowLabel(context) &&
+              controller.label != null &&
+              !isFloatLabel)
+            Container(
+              margin: const EdgeInsets.only(bottom: 8.0),
+              child: Text(
+                controller.label!,
+                style: controller.labelStyle ??
+                    Theme.of(context).inputDecorationTheme.labelStyle,
+              ),
+            ),
+          widget,
+          if (shouldShowLabel(context) && controller.description != null)
+            Container(
+              margin: const EdgeInsets.only(top: 12.0),
+              child: Text(controller.description!),
+            ),
+        ],
+      );
 
   bool shouldShowLabel(BuildContext context) {
     ensemble.FormState? formState = ensemble.EnsembleForm.of(context);


### PR DESCRIPTION
- FormInput now properly use its labelStyle.
- When rendering Form inputs, use the Form's labelStyle if can't find a labelStyle at the input level