### PR TITLE
fix: footer render on body changes

### DIFF
--- a/lib/framework/view/footer.dart
+++ b/lib/framework/view/footer.dart
@@ -348,6 +348,16 @@ class _FooterLayoutState extends State<FooterLayout> {
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     EdgeInsets minInset = mediaQuery.padding.copyWith(bottom: 0.0);
 
+    _addIfNonNull(
+      children,
+      widget.body,
+      _FooterSlot.body,
+      removeLeftPadding: false,
+      removeTopPadding: false,
+      removeRightPadding: false,
+      removeBottomPadding: true,
+    );
+
     if (widget.footer != null) {
       _addIfNonNull(
         children,
@@ -359,16 +369,6 @@ class _FooterLayoutState extends State<FooterLayout> {
         removeBottomPadding: false,
       );
     }
-
-    _addIfNonNull(
-      children,
-      widget.body,
-      _FooterSlot.body,
-      removeLeftPadding: false,
-      removeTopPadding: false,
-      removeRightPadding: false,
-      removeBottomPadding: true,
-    );
 
     return CustomMultiChildLayout(
       delegate: _FooterLayout(minInsets: minInset),


### PR DESCRIPTION
### Describe change
- FooterLayout is a custom layout builder like column to handle footer widget properly when it can be fixed size or unconstraint size when used draggable.
- This FooterLayout build priority is updated from footer widget first to body widget first.

### Issue number
closes: https://github.com/EnsembleUI/ensemble/issues/1148

### EDL
N.A 