### PR TITLE
uri and url handling uploadFIles

### DIFF
--- a/lib/action/upload_files_action.dart
+++ b/lib/action/upload_files_action.dart
@@ -85,9 +85,11 @@ Future<void> uploadFiles({
       }
     });
   }
+  String rawUrl = apiDefinition['url']?.toString().trim() ??
+      apiDefinition['uri']?.toString().trim() ??
+      '';
 
-  String url =
-      HttpUtils.resolveUrl(dataContext, apiDefinition['uri'].toString().trim());
+  String url = HttpUtils.resolveUrl(dataContext, rawUrl);
   String method = apiDefinition['method']?.toString().toUpperCase() ?? 'POST';
   final fileResponse = action.id == null
       ? null


### PR DESCRIPTION
### Describe the change
The following commit changed api uri to url and upload file was using uri which was causing failure in uploading files
https://github.com/EnsembleUI/ensemble/commit/59941140e20fe090417a3a957a438c6fbbea0016

With this change url and uri both are supported in uploadFiles

