### PR TITLE
Add height, width properties to switch and update schema

### DIFF
--- a/assets/schema/ensemble_schema.json
+++ b/assets/schema/ensemble_schema.json
@@ -1877,7 +1877,7 @@
         }
       ]
     },
-    "TripleStateSwitch-payload": {
+    "TripleSwitch-payload": {
       "type": "object",
       "allOf": [
         {
@@ -1887,13 +1887,26 @@
           "type": "object",
           "properties": {
             "value": {
-              "type": "boolean"
+              "type": "string",
+              "enum": [
+                "off",
+                "mixed",
+                "on"
+              ]
             },
             "leadingText": {
               "type": "string"
             },
             "trailingText": {
               "type": "string"
+            },
+            "height": {
+              "type": "integer",
+              "description": "The height of the switch"
+            },
+            "width": {
+              "type": "integer",
+              "description": "The width of the switch"
             },
             "styles": {
               "allOf": [
@@ -1902,9 +1915,9 @@
                 },
                 {
                   "properties": {
-                    "intermediateColor": {
+                    "mixedColor": {
                       "$ref": "#/$defs/type-color",
-                      "description": "The middle state color of the Switch Widget."
+                      "description": "The mixed state color of the Switch Widget."
                     }
                   }
                 }
@@ -5977,13 +5990,13 @@
           }
         },
         {
-          "title": "TripleStateSwitch",
+          "title": "TripleSwitch",
           "required": [
-            "TripleStateSwitch"
+            "TripleSwitch"
           ],
           "properties": {
-            "TripleStateSwitch": {
-              "$ref": "#/$defs/TripleStateSwitch-payload",
+            "TripleSwitch": {
+              "$ref": "#/$defs/TripleSwitch-payload",
               "description": "Kitchen Sink Example: https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screen/"
             }
           }

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -220,7 +220,6 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
 }
 
 class SwitchBaseController extends FormFieldController {
-  bool custom = false;
   dynamic value;
   String? leadingText;
   String? trailingText;

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -242,8 +242,8 @@ class SwitchBaseController extends FormFieldController {
   Color? inactiveColor;
   Color? inactiveThumbColor;
   Color? mixedColor;
-  double? width = 100;
-  double? height = 40;
+  double? width = 80;
+  double? height = 30;
 
   framework.EnsembleAction? onChange;
 }
@@ -315,6 +315,9 @@ class TripleStateSwitch extends StatelessWidget {
             BorderRadius.circular(
               200,
             ),
+      ),
+      margin: const EdgeInsets.symmetric(
+        horizontal: 8,
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: 1,

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -35,8 +35,6 @@ class EnsembleTripleSwitch extends SwitchBase {
     ..addAll({
       'value': (value) => _controller.value =
           SwitchState.values.from(value)?.name ?? SwitchState.off.name,
-      'custom': (value) =>
-          _controller.custom = Utils.getBool(value, fallback: false),
       'height': (value) => _controller.height = Utils.optionalDouble(value),
       'width': (value) => _controller.width = Utils.optionalDouble(value),
     });
@@ -168,17 +166,10 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
       state: switchState,
       onChanged: isEnabled()
           ? (value) {
-              if (!widget._controller.custom) {
-                (widget as EnsembleTripleSwitch?)?.onToggle(value);
-              }
-              onChange(value.name);
+              (widget as EnsembleTripleSwitch?)?.onToggle(value);
+              onChange();
             }
           : (_) {},
-      onThumbTapped: (value) {
-        if (widget._controller.custom) {
-          onChange(value.name);
-        }
-      },
     );
   }
 
@@ -215,19 +206,15 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
         onChanged: isEnabled()
             ? (value) {
                 (widget as EnsembleSwitch?)?.onToggle(value);
-                onChange(value);
+                onChange();
               }
             : null);
   }
 
-  void onChange(dynamic value) {
+  void onChange() {
     if (widget._controller.onChange != null) {
       ScreenController().executeAction(context, widget._controller.onChange!,
-          event: EnsembleEvent(widget,
-              data:
-                  (widget._controller.custom && widget is EnsembleTripleSwitch)
-                      ? {'value': value}
-                      : null));
+          event: EnsembleEvent(widget));
     }
   }
 }
@@ -268,7 +255,6 @@ class TripleStateSwitch extends StatelessWidget {
     Key? key,
     required this.onChanged,
     required this.state,
-    this.onThumbTapped,
     this.startBackgroundColor,
     this.middleBackgroundColor,
     this.endBackgroundColor,
@@ -283,7 +269,6 @@ class TripleStateSwitch extends StatelessWidget {
   }) : super(key: key);
 
   final Function(SwitchState) onChanged;
-  final Function(SwitchState)? onThumbTapped;
   final double? width;
   final double? height;
   final BorderRadius? borderRadius;
@@ -368,29 +353,26 @@ class TripleStateSwitch extends StatelessWidget {
                 : state == SwitchState.mixed
                     ? AlignmentDirectional.center
                     : AlignmentDirectional.centerEnd,
-            child: InkWell(
-              onTap: () => onThumbTapped?.call(state),
-              child: child ??
-                  Container(
-                    height: height,
-                    width: height,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: !disable!
-                          ? dotColor ?? SwitchColors.dotColor
-                          : SwitchColors.disableDotColor,
-                      boxShadow: !disable!
-                          ? [
-                              const BoxShadow(
-                                color: Colors.black,
-                                blurRadius: 10,
-                                spreadRadius: -5,
-                              ),
-                            ]
-                          : null,
-                    ),
+            child: child ??
+                Container(
+                  height: height,
+                  width: height,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: !disable!
+                        ? dotColor ?? SwitchColors.dotColor
+                        : SwitchColors.disableDotColor,
+                    boxShadow: !disable!
+                        ? [
+                            const BoxShadow(
+                              color: Colors.black,
+                              blurRadius: 10,
+                              spreadRadius: -5,
+                            ),
+                          ]
+                        : null,
                   ),
-            ),
+                ),
           ),
         ],
       ),

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -308,8 +308,8 @@ class TripleStateSwitch extends StatelessWidget {
             ? state == SwitchState.off
                 ? startBackgroundColor ?? SwitchColors.backgroundColor
                 : state == SwitchState.mixed
-                    ? middleBackgroundColor ?? SwitchColors.backgroundColor
-                    : endBackgroundColor ?? SwitchColors.backgroundColor
+                    ? middleBackgroundColor ?? Colors.grey
+                    : endBackgroundColor ?? Theme.of(context).primaryColor
             : SwitchColors.disableBackgroundColor,
         borderRadius: borderRadius ??
             BorderRadius.circular(

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -202,7 +202,7 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
     return Switch(
         trackColor: trackColor,
         thumbColor: thumbColor,
-        value: widget._controller.value,
+        value: widget._controller.value == true,
         onChanged: isEnabled()
             ? (value) {
                 (widget as EnsembleSwitch?)?.onToggle(value);


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1154

Added the following
1. height
2. width
3. custom - If it's true, we've to manually change the switch from onChange callback using the `event.data.value`
4. Updated the schema

Updates (30 Jan):
- Deleted custom property and it's logic
- Fixed the null issue in the switch widget

```yaml
TripleSwitch:
  id: tripleSwitchId
  leadingText: "Entire Place"
  value: mixed
  enabled: true
  required: true
  width: 150
  height: 50
  styles:
    {
      activeThumbColor: white,
      inactiveThumbColor: grey,
      activeColor: 0xFFD6D6CE,
      inactiveColor: 0xFF425C59,
      mixedColor: 0xFF858174,
    }
  onChange:
    executeCode:
      body: |
        //@code
        console.log("TripleStateSwitch Value: "+this.value);
```