### PR TITLE
Fixed notification on terminated state

### DIFF
--- a/lib/ensemble.dart
+++ b/lib/ensemble.dart
@@ -53,8 +53,15 @@ class Ensemble {
     externalScreenWidgets = widgets;
   }
 
-  final Set<Function> _afterInitMethods = {};
+  // TODO: combine push callback and regular callback
+  final Set<Function> _pushNotificationCallbacks = {};
+  void addPushNotificationCallback({required Function method}) {
+    _pushNotificationCallbacks.add(method);
+  }
 
+  Set<Function> getPushNotificationCallbacks() => _pushNotificationCallbacks;
+
+  final Set<Function> _afterInitMethods = {};
   void addCallbackAfterInitialization({required Function method}) {
     _afterInitMethods.add(method);
   }

--- a/lib/framework/notification_manager.dart
+++ b/lib/framework/notification_manager.dart
@@ -120,7 +120,8 @@ class NotificationManager {
         'body': message.notification?.body,
         'data': message.data
       });
-      Ensemble().addCallbackAfterInitialization(
+      // notification will be executed AFTER the home screen has finished rendering
+      Ensemble().addPushNotificationCallback(
           method: () => handleNotification(message));
     }).catchError((err) {
       // ignore: avoid_print

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -25,6 +25,7 @@ class Page extends StatefulWidget {
     super.key,
     required DataContext dataContext,
     required SinglePageModel pageModel,
+    required this.onRendered,
   })  : _initialDataContext = dataContext,
         _pageModel = pageModel;
 
@@ -35,6 +36,8 @@ class Page extends StatefulWidget {
   /// the page load. In these cases we do not have the context to travel
   /// to the DataScopeWidget. This should only be used for this purpose.
   ScopeManager? rootScopeManager;
+
+  final Function() onRendered;
 
   //final Widget bodyWidget;
   //final Menu? menu;
@@ -171,9 +174,14 @@ class PageState extends State<Page>
       /// Probably not ideal as we want to fire this off asap. It's the API response that
       /// needs to make sure Invokable IDs are there (through currently our code can't
       /// separate them out yet
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        ScreenController().executeActionWithScope(
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await ScreenController().executeActionWithScope(
             context, _scopeManager, widget._pageModel.viewBehavior.onLoad!);
+
+        // after loading all the script, execute onRendered
+        // This is not exactly right but we don't have a way to know when the page
+        // has completely rendered. This will be sufficient for most use case
+        widget.onRendered();
       });
     }
 


### PR DESCRIPTION
Two separate issues:
1.  Depending on the order of execution, some time the Notificaiton's screen appear first then the Home screen comes in.
2.  Screen order is correct, but Back button doesn't work on Notification's screen. The problem was because Landing screen calls an API then redirect the user to Home. When notification comes in in terminated state, it executes the notification's page navigation BEFORE the Landing screen even returns the API.

The fix are both:
1. Make sure notfication's screen executes AFTER Landing Screen's onLoad.
2. Refactored apps logic to not call an API onLoad. This actually fixed a separate issue where a delay is there before the hoem screen loads