### PR TITLE
Remove default value of tabbar alignment and update schema

### DIFF
--- a/lib/layout/tab_bar.dart
+++ b/lib/layout/tab_bar.dart
@@ -289,8 +289,7 @@ class TabBarState extends WidgetState<BaseTabBar>
     final indicatorSize =
         TabBarIndicatorSize.values.from(widget._controller.indicatorSize);
     final tabAlignment =
-        TabAlignment.values.from(widget._controller.tabAlignment) ??
-            TabAlignment.start;
+        TabAlignment.values.from(widget._controller.tabAlignment);
 
     Widget tabBar = TabBar(
       labelPadding: labelPadding,


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1162

TabBar Alignment default start value is removed, it's an issue when setting tabbar alignment = start when the isScrollable property is false

```
tabPosition: stretch - Tabbar will not scroll
tabPosition: start - Tabbar will be scrollable
```

NOTE:
1. If `tabPosition: stretch` (not scrollable), only `tabAlignment: fill` and `tabAlignment: center `are supported. Otherwise an exception is thrown.
2. If `tabPosition: start` (scrollable), only `tabAlignment: start`, `tabAlignment: startOffset`, and `tabAlignment: center` are supported. Otherwise an exception is thrown.
3. If this is null, then the value of [TabBarTheme.tabAlignment] is used.
4. If [TabBarTheme.tabAlignment] is null and [ThemeData.useMaterial3] is true, then `tabAlignment: startOffset` is used if `tabPosition: start`, otherwise `tabAlignment: fill` is used.
5. If [TabBarTheme.tabAlignment] is null and [ThemeData.useMaterial3] is false, then `tabAlignment: center` is used if `tabPosition: start`, otherwise `tabAlignment: fill` is used.