### PR TITLE
improving list view scroll

### DIFF
--- a/lib/layout/list_view.dart
+++ b/lib/layout/list_view.dart
@@ -221,6 +221,7 @@ class ListViewState extends WidgetState<ListView>
           }
         }
         if (itemWidget != null) {
+          itemWidget = KeepAliveListItem(itemWidget: itemWidget);
           return widget._controller.onItemTap == null
               ? itemWidget
               : flutter.InkWell(
@@ -294,4 +295,24 @@ class ListViewState extends WidgetState<ListView>
 
     ScreenController().executeAction(context, widget._controller.onScrollEnd!);
   }
+}
+
+class KeepAliveListItem extends StatefulWidget {
+  final Widget itemWidget;
+  const KeepAliveListItem({super.key, required this.itemWidget});
+
+  @override
+  State<KeepAliveListItem> createState() => _KeepAliveListItemState();
+}
+
+class _KeepAliveListItemState extends State<KeepAliveListItem>
+    with AutomaticKeepAliveClientMixin<KeepAliveListItem> {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.itemWidget;
+  }
+
+  @override
+  bool get wantKeepAlive => true;
 }


### PR DESCRIPTION
I have introduced mixin `AutomaticKeepAliveClientMixin` to every listview element. 
This keeps the element alive even if the item goes out of the viewport.

Reasoning: Our `ListView` item can be very heavy in terms of number of widget it is built width. If we have to built the heavy item we scroll this make scroll janky. So by keep them alive, list view can reuse them.

If we keep item alive even if we go out of view port, this will increase the memory usage as we scroll to very large number of items.