### PR TITLE
inputs / payload support to navigateViewGroup

### DIFF
--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -149,7 +149,7 @@ class NavigateViewGroupAction extends EnsembleAction {
       scopeManager.dataContext.addDataContext(payload!);
     }
     PageGroupWidget.getPageController(context)?.jumpToPage(_viewIndex);
-    viewGroupNotifier.updatePage(_viewIndex);
+    viewGroupNotifier.updatePage(_viewIndex, payload: payload);
     return Future.value(null);
   }
 }

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -173,8 +173,7 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
       final floatingItemColor =
           Utils.getColor(widget.menu.runtimeStyles?['floatingIconColor']) ??
               Theme.of(context).colorScheme.onSecondary;
-      final floatingBackgroundColor =
-          Utils.getColor(
+      final floatingBackgroundColor = Utils.getColor(
               widget.menu.runtimeStyles?['floatingBackgroundColor']) ??
           Theme.of(context).colorScheme.secondary;
 

--- a/lib/framework/view/bottom_nav_page_group.dart
+++ b/lib/framework/view/bottom_nav_page_group.dart
@@ -9,6 +9,7 @@ import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/view/bottom_nav_page_view.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/view/page_group.dart';
+import 'package:ensemble/page_model.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/framework/widget/icon.dart' as ensemble;
@@ -92,11 +93,13 @@ class BottomNavPageGroup extends StatefulWidget {
     required this.menu,
     required this.selectedPage,
     required this.children,
+    required this.screenPayload,
   });
 
   final ScopeManager scopeManager;
   final Menu menu;
   final int selectedPage;
+  final List<ScreenPayload> screenPayload;
   final List<Widget> children;
 
   @override
@@ -234,8 +237,18 @@ class _BottomNavPageGroupState extends State<BottomNavPageGroup>
         body: widget.menu.reloadView == true
             ? ListenableBuilder(
                 listenable: viewGroupNotifier,
-                builder: (_, __) =>
-                    widget.children[viewGroupNotifier.viewIndex])
+                builder: (_, __) {
+                  final screenPayload =
+                      widget.screenPayload[viewGroupNotifier.viewIndex];
+                  final screen = ScreenController().getScreen(
+                    key: UniqueKey(),
+                    screenName: screenPayload.screenName,
+                    pageArgs:
+                        viewGroupNotifier.payload ?? screenPayload.arguments,
+                    isExternal: screenPayload.isExternal,
+                  );
+                  return screen;
+                })
             : Builder(
                 builder: (context) {
                   final controller = PageGroupWidget.getPageController(context);

--- a/lib/framework/view/page.dart
+++ b/lib/framework/view/page.dart
@@ -389,8 +389,9 @@ class PageState extends State<Page>
     bool hasDrawer = _drawer != null || _endDrawer != null;
 
     Widget? _bottomNavBar;
-    if ( widget._pageModel.menu != null ) {
-      EnsembleThemeManager().configureStyles(_scopeManager.dataContext, widget._pageModel.menu!, widget._pageModel.menu!);
+    if (widget._pageModel.menu != null) {
+      EnsembleThemeManager().configureStyles(_scopeManager.dataContext,
+          widget._pageModel.menu!, widget._pageModel.menu!);
     }
     // build the navigation menu (bottom nav bar or drawer). Note that menu is not applicable on modal pages
     if (widget._pageModel.menu != null &&
@@ -593,8 +594,7 @@ class PageState extends State<Page>
         );
       }
 
-      MenuItemDisplay itemDisplay =
-          MenuItemDisplay.values
+      MenuItemDisplay itemDisplay = MenuItemDisplay.values
               .from(sidebarMenu.runtimeStyles?['itemDisplay']) ??
           MenuItemDisplay.stacked;
 


### PR DESCRIPTION
## Issue that this pull request solves

Closes: https://github.com/EnsembleUI/ensemble/issues/1345

## Proposed changes

Added support for inputs / payload to `navigateViewGroup` action

## EDL

```yaml

navigateViewGroup:
  viewIndex: 1
  inputs:
    foo: bar
```

## Checklist

- [x] I have performed a self-review of my own code

- [ ] I have wrote proper schema in studio [Check docs](https://github.com/ensembleUI/ensemble-web-studio?tab=readme-ov-file#generate-schema)

- [ ] I have created Ensemble Kitchen Sink Example [Over here](https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screens)

- [ ] I have made corresponding changes to the documentation [Over here](https://github.com/EnsembleUI/ensemble_docs)

- [ ] I have added tests that prove my fix is effective or that my feature works

