### PR TITLE
Fixed the clear button for date input

### DIFF
--- a/lib/widget/helpers/widgets.dart
+++ b/lib/widget/helpers/widgets.dart
@@ -337,10 +337,15 @@ class InputWrapper extends StatelessWidget {
 /// is the responsibility of the parent widget who uses this.
 class ClearableInput extends StatelessWidget {
   const ClearableInput(
-      {super.key, required this.text, required this.onCleared, this.textStyle});
+      {super.key,
+      required this.text,
+      required this.onCleared,
+      this.textStyle,
+      this.enabled = false});
 
   final String text;
   final TextStyle? textStyle;
+  final bool enabled;
   final dynamic onCleared;
 
   @override
@@ -351,7 +356,10 @@ class ClearableInput extends StatelessWidget {
     return Row(mainAxisSize: MainAxisSize.min, children: [
       Flexible(child: Text(text, maxLines: 1, style: textStyle)),
       const SizedBox(width: 4),
-      InkWell(onTap: onCleared, child: const Icon(Icons.close, size: 20))
+      InkWell(
+        onTap: enabled ? onCleared : null,
+        child: const Icon(Icons.close, size: 20),
+      )
     ]);
   }
 }

--- a/lib/widget/input/form_date.dart
+++ b/lib/widget/input/form_date.dart
@@ -110,6 +110,7 @@ class DateState extends FormFieldWidgetState<Date> {
                       child: ClearableInput(
                           text: selectedValue,
                           textStyle: formFieldTextStyle,
+                          enabled: widget._controller.enabled ?? true,
                           onCleared: () {
                             setState(() {
                               widget._controller.value = null;


### PR DESCRIPTION
## Issue that this pull request solves

Closes: https://github.com/EnsembleUI/ensemble/issues/1341

## Proposed changes

The clear button was not disabled if the state is disabled. So fixed that bug.

## Checklist

- [x] I have performed a self-review of my own code

- [ ] I have wrote proper schema in studio [Check docs](https://github.com/ensembleUI/ensemble-web-studio?tab=readme-ov-file#generate-schema) (Bug so not applicable)

- [ ] I have created Ensemble Kitchen Sink Example [Over here](https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screens) (Bug so not applicable)

- [ ] I have made corresponding changes to the documentation [Over here](https://github.com/EnsembleUI/ensemble_docs) (Bug so not applicable)

- [ ] I have added tests that prove my fix is effective or that my feature works (Bug so not applicable)

