### PR TITLE
onScroll callback for listview

### DIFF
--- a/lib/layout/list_view.dart
+++ b/lib/layout/list_view.dart
@@ -1,6 +1,7 @@
 import 'package:ensemble/action/haptic_action.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/studio/studio_debugger.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
@@ -79,6 +80,8 @@ class ListView extends StatefulWidget
           _controller.hasReachedMax = Utils.getBool(value, fallback: false),
       'loadingWidget': (value) => _controller.loadingWidget = value,
       'data': (value) => _controller.itemTemplate?.data = value,
+      'onScroll': (value) =>
+          controller.onScroll = EnsembleAction.fromYaml(value, initiator: this),
     };
   }
 
@@ -113,6 +116,7 @@ class ListViewController extends BoxLayoutController {
   bool hasReachedMax = false;
 
   ListViewState? widgetState;
+  EnsembleAction? onScroll;
 
   void _bind(ListViewState state) {
     widgetState = state;
@@ -177,6 +181,15 @@ class ListViewState extends WidgetState<ListView>
       isLoading: showLoading,
       onFetchData: _fetchData,
       hasReachedMax: widget._controller.hasReachedMax,
+      onScroll: (pixel) {
+        if (widget._controller.onScroll != null) {
+          ScreenController().executeAction(
+            context,
+            widget._controller.onScroll!,
+            event: EnsembleEvent(null, data: {'pixel': pixel}),
+          );
+        }
+      },
       scrollController: (footerScope != null &&
               footerScope.isColumnScrollableAndRoot(context))
           ? null


### PR DESCRIPTION
## Issue that this pull request solves

Closes: https://github.com/EnsembleUI/ensemble/issues/1387

## Proposed changes

Added callback `onScroll` to listview

## EDL

```yaml
       ListView:
          id: listView
          onScroll: |
              ensemble.debug(event.data.pixel);
```

## Checklist

- [x] I have performed a self-review of my own code

- [ ] I have wrote proper schema in studio [Check docs](https://github.com/ensembleUI/ensemble-web-studio?tab=readme-ov-file#generate-schema)

- [ ] I have created Ensemble Kitchen Sink Example [Over here](https://studio.ensembleui.com/app/e24402cb-75e2-404c-866c-29e6c3dd7992/screens)

- [ ] I have made corresponding changes to the documentation [Over here](https://github.com/EnsembleUI/ensemble_docs)

- [ ] I have added tests that prove my fix is effective or that my feature works

