### PR TITLE
Push screen using external navigation key

### DIFF
--- a/lib/ensemble_app.dart
+++ b/lib/ensemble_app.dart
@@ -35,6 +35,7 @@ import 'package:yaml/yaml.dart';
 
 const String backgroundUploadTask = 'backgroundUploadTask';
 const String ensembleMethodChannelName = 'com.ensembleui.host.platform';
+GlobalKey<NavigatorState>? externalAppNavigateKey;
 
 @pragma('vm:entry-point')
 void callbackDispatcher() {
@@ -93,15 +94,19 @@ void callbackDispatcher() {
 
 /// use this as the root widget for Ensemble
 class EnsembleApp extends StatefulWidget {
-  const EnsembleApp(
-      {super.key,
-      this.screenPayload,
-      this.ensembleConfig,
-      this.externalMethods,
-      this.isPreview = false,
-      this.placeholderBackgroundColor,
-      this.onAppLoad,
-      this.forcedLocale});
+  EnsembleApp({
+    super.key,
+    this.screenPayload,
+    this.ensembleConfig,
+    this.externalMethods,
+    this.isPreview = false,
+    this.placeholderBackgroundColor,
+    this.onAppLoad,
+    this.forcedLocale,
+    GlobalKey<NavigatorState>? navigatorKey,
+  }) {
+    externalAppNavigateKey = navigatorKey;
+  }
 
   final ScreenPayload? screenPayload;
   final EnsembleConfig? ensembleConfig;

--- a/lib/framework/action.dart
+++ b/lib/framework/action.dart
@@ -100,7 +100,8 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       super.options,
       this.onNavigateBack,
       super.transition,
-      super.isExternal})
+      super.isExternal,
+      super.asExternal})
       : super(asModal: false);
   EnsembleAction? onNavigateBack;
 
@@ -118,6 +119,7 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       onNavigateBack: EnsembleAction.fromYaml(payload['onNavigateBack']),
       transition: Utils.getMap(payload['transition']),
       isExternal: Utils.getBool(payload['external'], fallback: false),
+      asExternal: Utils.getBool(payload['asExternal'], fallback: false),
     );
   }
 
@@ -200,13 +202,15 @@ abstract class BaseNavigateScreenAction extends EnsembleAction {
       this.transition,
       this.payload,
       this.options,
-      this.isExternal = false});
+      this.isExternal = false,
+      this.asExternal = false});
 
   String screenName;
   bool asModal;
   Map<String, dynamic>? transition;
   final Map<String, dynamic>? options;
   final bool isExternal;
+  final bool asExternal;
   Map<String, dynamic>? payload;
 }
 

--- a/lib/screen_controller.dart
+++ b/lib/screen_controller.dart
@@ -8,6 +8,7 @@ import 'package:ensemble/action/navigation_action.dart';
 import 'package:ensemble/action/phone_contact_action.dart';
 import 'package:ensemble/action/upload_files_action.dart';
 import 'package:ensemble/ensemble.dart';
+import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/apiproviders/api_provider.dart';
 import 'package:ensemble/framework/bindings.dart';
@@ -210,6 +211,7 @@ class ScreenController {
         pageArgs: nextArgs,
         transition: action.transition,
         isExternal: action.isExternal,
+        asExternal: action.asExternal,
       );
 
       if (action is NavigateScreenAction && action.onNavigateBack != null) {
@@ -665,7 +667,7 @@ class ScreenController {
         SystemStorageBindingSource(key, storagePrefix: storagePrefix), value));
   }
 
-  /// Navigate to another screen
+  /// Navigate to another
   /// [screenName] - navigate to the screen if specified, otherwise to appHome
   /// [asModal] - shows the App in a regular or modal screen
   /// [replace] - whether to replace the current route on the stack, such that
@@ -680,6 +682,7 @@ class ScreenController {
     Map<String, dynamic>? pageArgs,
     Map<String, dynamic>? transition,
     bool isExternal = false,
+    bool asExternal = false,
   }) {
     PageType pageType = asModal == true ? PageType.modal : PageType.regular;
 
@@ -715,11 +718,24 @@ class ScreenController {
     );
     // push the new route and remove all existing screens. This is suitable for logging out.
     if (routeOption == RouteOption.clearAllScreens) {
-      Navigator.pushAndRemoveUntil(context, route, (route) => false);
+      if (asExternal) {
+        externalAppNavigateKey?.currentState
+            ?.pushAndRemoveUntil(route, (route) => false);
+      } else {
+        Navigator.pushAndRemoveUntil(context, route, (route) => false);
+      }
     } else if (routeOption == RouteOption.replaceCurrentScreen) {
-      Navigator.pushReplacement(context, route);
+      if (asExternal) {
+        externalAppNavigateKey?.currentState?.pushReplacement(route);
+      } else {
+        Navigator.pushReplacement(context, route);
+      }
     } else {
-      Navigator.push(context, route);
+      if (asExternal) {
+        externalAppNavigateKey?.currentState?.push(route);
+      } else {
+        Navigator.push(context, route);
+      }
     }
     return route;
   }

--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:math';
 import 'dart:ui';
+import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/stub/location_manager.dart';
 import 'package:ensemble/framework/theme/theme_manager.dart';
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
## Proposed changes

Added new parameter to navigateScreen called `asExternal` this uses externalNavigateKey to push screen. This allows integration of flutter app and ensemble app seems seamless. 

## EDL

```
Button: 
  label: Push screen using external key
  onTap:
    navigateScreen:
      name: Tournaments
      asExternal: true
```