### PR TITLE
firebase analytics

### DIFF
--- a/modules/ensemble/lib/action/Log_event_action.dart
+++ b/modules/ensemble/lib/action/Log_event_action.dart
@@ -8,30 +8,43 @@ import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 
 class TrackEvent extends EnsembleAction {
-  final String eventName;
+  final String? eventName;
   final Map<dynamic, dynamic>? parameters;
+  final String? provider;
+  final String? operation;
+  final String? userId;
   final String logLevel;
 
   TrackEvent({
     required Invokable? initiator,
-    required this.eventName,
+    this.eventName,
     required this.logLevel,
+    required this.provider,
+    this.operation,
+    this.userId,
     this.parameters,
   }) : super(initiator: initiator);
 
   factory TrackEvent.from({Invokable? initiator, Map? payload}) {
     payload = Utils.convertYamlToDart(payload);
     String? eventName = payload?['name'];
-    if (eventName == null) {
+    String? operation = payload?['operation'];
+
+    if (operation == 'logEvent' && eventName == null) {
       throw LanguageError(
           "${ActionType.trackEvent.name} requires the event name");
+    } else if (operation == 'setUserId' && payload?['userId'] == null) {
+      throw LanguageError("${ActionType.trackEvent.name} requires the user id");
     }
 
     return TrackEvent(
       initiator: initiator,
-      eventName: eventName,
+      eventName: eventName ?? '',
       parameters: payload?['parameters'] is Map ? payload!['parameters'] : null,
       logLevel: payload?['logLevel'] ?? LogLevel.info.name,
+      provider: payload?['provider'] ?? 'firebase',
+      operation: payload?['operation'],
+      userId: payload?['userId'],
     );
   }
 
@@ -52,9 +65,14 @@ class TrackEvent extends EnsembleAction {
   Future<void> execute(BuildContext context, ScopeManager scopeManager) async {
     LogManager().log(
       LogType.appAnalytics,
-      stringToLogLevel(scopeManager.dataContext.eval(logLevel)),
-      scopeManager.dataContext.eval(eventName),
-      scopeManager.dataContext.eval(parameters) ?? {},
+      {
+        'name': scopeManager.dataContext.eval(eventName),
+        'parameters': scopeManager.dataContext.eval(parameters) ?? {},
+        'logLevel': stringToLogLevel(scopeManager.dataContext.eval(logLevel)),
+        'provider': scopeManager.dataContext.eval(provider),
+        'operation': scopeManager.dataContext.eval(operation),
+        'userId': scopeManager.dataContext.eval(userId),
+      },
     );
     // Instead of awaiting, we'll let LogManager figure it out as we don't want to block the UI
   }

--- a/modules/ensemble/lib/action/Log_event_action.dart
+++ b/modules/ensemble/lib/action/Log_event_action.dart
@@ -7,31 +7,34 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 
-class LogEvent extends EnsembleAction {
+class TrackEvent extends EnsembleAction {
   final String eventName;
   final Map<dynamic, dynamic>? parameters;
   final String logLevel;
-  LogEvent(
-      {super.initiator,
-      required this.eventName,
-      required this.logLevel,
-      this.parameters});
 
-  factory LogEvent.from({Invokable? initiator, Map? payload}) {
+  TrackEvent({
+    required Invokable? initiator,
+    required this.eventName,
+    required this.logLevel,
+    this.parameters,
+  }) : super(initiator: initiator);
+
+  factory TrackEvent.from({Invokable? initiator, Map? payload}) {
     payload = Utils.convertYamlToDart(payload);
     String? eventName = payload?['name'];
     if (eventName == null) {
       throw LanguageError(
-          "${ActionType.logEvent.name} requires the event name");
+          "${ActionType.trackEvent.name} requires the event name");
     }
 
-    return LogEvent(
-        initiator: initiator,
-        eventName: eventName,
-        parameters:
-            payload?['parameters'] is Map ? payload!['parameters'] : null,
-        logLevel: payload?['logLevel'] ?? LogLevel.info.name);
+    return TrackEvent(
+      initiator: initiator,
+      eventName: eventName,
+      parameters: payload?['parameters'] is Map ? payload!['parameters'] : null,
+      logLevel: payload?['logLevel'] ?? LogLevel.info.name,
+    );
   }
+
   static LogLevel stringToLogLevel(String? levelStr) {
     // If the level string is null, default to LogLevel.info
     if (levelStr == null) return LogLevel.info;
@@ -46,13 +49,13 @@ class LogEvent extends EnsembleAction {
   }
 
   @override
-  Future<dynamic> execute(BuildContext context, ScopeManager scopeManager) {
+  Future<void> execute(BuildContext context, ScopeManager scopeManager) async {
     LogManager().log(
-        LogType.appAnalytics,
-        stringToLogLevel(scopeManager.dataContext.eval(logLevel)),
-        scopeManager.dataContext.eval(eventName),
-        scopeManager.dataContext.eval(parameters) ?? {});
-    return Future
-        .value(); //instead of awaiting, we'll let LogManager figure it out as we don't want to block the UI
+      LogType.appAnalytics,
+      stringToLogLevel(scopeManager.dataContext.eval(logLevel)),
+      scopeManager.dataContext.eval(eventName),
+      scopeManager.dataContext.eval(parameters) ?? {},
+    );
+    // Instead of awaiting, we'll let LogManager figure it out as we don't want to block the UI
   }
 }

--- a/modules/ensemble/lib/action/Log_event_action.dart
+++ b/modules/ensemble/lib/action/Log_event_action.dart
@@ -7,7 +7,7 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 
-class TrackEvent extends EnsembleAction {
+class LogEvent extends EnsembleAction {
   final String? eventName;
   final Map<dynamic, dynamic>? parameters;
   final String? provider;
@@ -15,7 +15,7 @@ class TrackEvent extends EnsembleAction {
   final String? userId;
   final String logLevel;
 
-  TrackEvent({
+  LogEvent({
     required Invokable? initiator,
     this.eventName,
     required this.logLevel,
@@ -25,19 +25,19 @@ class TrackEvent extends EnsembleAction {
     this.parameters,
   }) : super(initiator: initiator);
 
-  factory TrackEvent.from({Invokable? initiator, Map? payload}) {
+  factory LogEvent.from({Invokable? initiator, Map? payload}) {
     payload = Utils.convertYamlToDart(payload);
     String? eventName = payload?['name'];
     String? operation = payload?['operation'];
 
     if (operation == 'logEvent' && eventName == null) {
       throw LanguageError(
-          "${ActionType.trackEvent.name} requires the event name");
+          "${ActionType.logEvent.name} requires the event name");
     } else if (operation == 'setUserId' && payload?['userId'] == null) {
-      throw LanguageError("${ActionType.trackEvent.name} requires the user id");
+      throw LanguageError("${ActionType.logEvent.name} requires the user id");
     }
 
-    return TrackEvent(
+    return LogEvent(
       initiator: initiator,
       eventName: eventName ?? '',
       parameters: payload?['parameters'] is Map ? payload!['parameters'] : null,

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -1125,7 +1125,6 @@ enum ActionType {
   resumeAudio,
   seekAudio,
   logEvent,
-  trackEvent,
 }
 
 /// payload representing an Action to do (navigateToScreen, InvokeAPI, ..)
@@ -1318,9 +1317,8 @@ abstract class EnsembleAction {
     } else if (actionType == ActionType.executeActionGroup) {
       return ExecuteActionGroupAction.fromYaml(
           initiator: initiator, payload: payload);
-    } else if (actionType == ActionType.trackEvent ||
-        actionType == ActionType.logEvent) {
-      return TrackEvent.from(initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.logEvent) {
+      return LogEvent.from(initiator: initiator, payload: payload);
     }
 
     throw LanguageError("Invalid action.",

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -1124,7 +1124,8 @@ enum ActionType {
   pauseAudio,
   resumeAudio,
   seekAudio,
-  logEvent
+  logEvent,
+  trackEvent,
 }
 
 /// payload representing an Action to do (navigateToScreen, InvokeAPI, ..)
@@ -1317,8 +1318,9 @@ abstract class EnsembleAction {
     } else if (actionType == ActionType.executeActionGroup) {
       return ExecuteActionGroupAction.fromYaml(
           initiator: initiator, payload: payload);
-    } else if (actionType == ActionType.logEvent) {
-      return LogEvent.from(initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.trackEvent ||
+        actionType == ActionType.logEvent) {
+      return TrackEvent.from(initiator: initiator, payload: payload);
     }
 
     throw LanguageError("Invalid action.",

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -533,7 +533,7 @@ class NativeInvokable extends ActionInvokable {
           ),
       ActionType.logEvent.name: (inputs) => ScreenController().executeAction(
             buildContext,
-            LogEvent.from(payload: inputs),
+            TrackEvent.from(payload: inputs),
           ),
       ActionType.authenticateByBiometric.name: (inputs) {
         final action =

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -533,7 +533,7 @@ class NativeInvokable extends ActionInvokable {
           ),
       ActionType.logEvent.name: (inputs) => ScreenController().executeAction(
             buildContext,
-            TrackEvent.from(payload: inputs),
+            LogEvent.from(payload: inputs),
           ),
       ActionType.authenticateByBiometric.name: (inputs) {
         final action =

--- a/modules/ensemble/lib/framework/logging/console_log_provider.dart
+++ b/modules/ensemble/lib/framework/logging/console_log_provider.dart
@@ -2,7 +2,7 @@ import 'package:ensemble/framework/logging/log_provider.dart';
 
 class ConsoleLogProvider extends LogProvider {
   @override
-  Future<void> handleAnalytics(Map<String, dynamic> config) async {
+  Future<void> log(Map<String, dynamic> config) async {
     // Construct a log message string
     var logLevel = (config['logLevel'] != null)
         ? config['logLevel'].toString().split('.').last

--- a/modules/ensemble/lib/framework/logging/console_log_provider.dart
+++ b/modules/ensemble/lib/framework/logging/console_log_provider.dart
@@ -2,16 +2,20 @@ import 'package:ensemble/framework/logging/log_provider.dart';
 
 class ConsoleLogProvider extends LogProvider {
   @override
-  Future<void> log(
-      String event, Map<String, dynamic> parameters, LogLevel level) async {
+  Future<void> handleAnalytics(Map<String, dynamic> config) async {
     // Construct a log message string
-    final StringBuffer logMessage = StringBuffer()
-      ..write(
-          "[${level.toString().split('.').last}] ") // Extracts enum value name
-      ..write(event)
-      ..write(' - ')
-      ..write(parameters.entries.map((e) => '${e.key}: ${e.value}').join(', '));
+    var logLevel = (config['logLevel'] != null)
+        ? config['logLevel'].toString().split('.').last
+        : LogLevel.info.name; // Extracts enum value name
 
+    final StringBuffer logMessage = StringBuffer()
+      ..write("[$logLevel] ")
+      ..write(config['name'])
+      ..write(' - ')
+      ..write(config['parameters']
+          .entries
+          .map((e) => '${e.key}: ${e.value}')
+          .join(', '));
     // Output log message to console
     print(logMessage.toString());
   }

--- a/modules/ensemble/lib/framework/logging/log_manager.dart
+++ b/modules/ensemble/lib/framework/logging/log_manager.dart
@@ -28,7 +28,7 @@ class LogManager {
 
     List<Future<void>> tasks = [];
     for (final provider in levelProviders) {
-      final task = provider.handleAnalytics(config);
+      final task = provider.log(config);
       if (provider.shouldAwait) {
         tasks.add(task);
       } else {

--- a/modules/ensemble/lib/framework/logging/log_manager.dart
+++ b/modules/ensemble/lib/framework/logging/log_manager.dart
@@ -18,23 +18,17 @@ class LogManager {
     }
   }
 
-  void addTrackEventProvider(LogLevel level, LogProvider provider) {
-    addProvider(LogType.appAnalytics, level, provider);
-  }
-
-  Future<void> log(LogType type, LogLevel level, String event,
-      Map<String, dynamic> parameters) async {
-    // For backward compatibility, handle logEvent operation
-    if (type == LogType.appAnalytics && event == 'logEvent') {
+  Future<void> log(LogType type, Map<String, dynamic> config) async {
+    if (type == LogType.appAnalytics) {
       type = LogType.appAnalytics;
     }
 
-    final levelProviders = _providers[type]?[level];
+    final levelProviders = _providers[type]?[config['logLevel']];
     if (levelProviders == null) return;
 
     List<Future<void>> tasks = [];
     for (final provider in levelProviders) {
-      final task = provider.log(event, parameters, level);
+      final task = provider.handleAnalytics(config);
       if (provider.shouldAwait) {
         tasks.add(task);
       } else {

--- a/modules/ensemble/lib/framework/logging/log_manager.dart
+++ b/modules/ensemble/lib/framework/logging/log_manager.dart
@@ -18,8 +18,17 @@ class LogManager {
     }
   }
 
+  void addTrackEventProvider(LogLevel level, LogProvider provider) {
+    addProvider(LogType.appAnalytics, level, provider);
+  }
+
   Future<void> log(LogType type, LogLevel level, String event,
       Map<String, dynamic> parameters) async {
+    // For backward compatibility, handle logEvent operation
+    if (type == LogType.appAnalytics && event == 'logEvent') {
+      type = LogType.appAnalytics;
+    }
+
     final levelProviders = _providers[type]?[level];
     if (levelProviders == null) return;
 

--- a/modules/ensemble/lib/framework/logging/log_provider.dart
+++ b/modules/ensemble/lib/framework/logging/log_provider.dart
@@ -8,8 +8,7 @@ abstract class LogProvider {
   bool shouldAwait = false;
   Map? options;
   String? ensembleAppId;
-  Future<void> log(
-      String event, Map<String, dynamic> parameters, LogLevel level);
+  Future<void> handleAnalytics(Map<String, dynamic> config);
 
   //init function to be implemented by subclasses
   Future<void> init(

--- a/modules/ensemble/lib/framework/logging/log_provider.dart
+++ b/modules/ensemble/lib/framework/logging/log_provider.dart
@@ -8,7 +8,7 @@ abstract class LogProvider {
   bool shouldAwait = false;
   Map? options;
   String? ensembleAppId;
-  Future<void> handleAnalytics(Map<String, dynamic> config);
+  Future<void> log(Map<String, dynamic> config);
 
   //init function to be implemented by subclasses
   Future<void> init(

--- a/modules/ensemble/lib/framework/stub/analytics_provider.dart
+++ b/modules/ensemble/lib/framework/stub/analytics_provider.dart
@@ -3,8 +3,7 @@ import 'package:ensemble/framework/logging/log_provider.dart';
 
 class LogProviderStub extends LogProvider {
   @override
-  Future<void> log(
-      String event, Map<String, dynamic> parameters, LogLevel level) async {
+  Future<void> log(Map<String, dynamic> config) async {
     throw ConfigError("Firebase Analytics Service is not enabled. "
         "Firebase analytics module has to be included and then enabled. Just enabling in config is not sufficient. "
         "Please review the Ensemble documentation.");

--- a/modules/firebase_analytics/lib/firebase_analytics.dart
+++ b/modules/firebase_analytics/lib/firebase_analytics.dart
@@ -78,7 +78,7 @@ class FirebaseAnalyticsProvider extends LogProvider {
     print('Firebase: Set user ID: $userId');
   }
 
-  Future<void> handleAnalytics(Map<String, dynamic> config) async {
+  Future<void> log(Map<String, dynamic> config) async {
     var operation = config['operation'] ?? 'logEvent';
     var provider = config['provider'] ?? 'firebase';
 

--- a/modules/firebase_analytics/lib/firebase_analytics.dart
+++ b/modules/firebase_analytics/lib/firebase_analytics.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 class FirebaseAnalyticsProvider extends LogProvider {
   FirebaseOptions? firebaseOptions;
   FirebaseAnalytics? _analytics;
+
   void _init({Map? options, String? ensembleAppId, bool shouldAwait = false}) {
     this.options = options;
     this.ensembleAppId = ensembleAppId;
@@ -26,28 +27,31 @@ class FirebaseAnalyticsProvider extends LogProvider {
   }
 
   @override
-  Future<void> init({Map? options,String? ensembleAppId,bool shouldAwait = false}) async {
-    _init(options: options, ensembleAppId: ensembleAppId, shouldAwait: shouldAwait);
+  Future<void> init(
+      {Map? options, String? ensembleAppId, bool shouldAwait = false}) async {
+    _init(
+        options: options,
+        ensembleAppId: ensembleAppId,
+        shouldAwait: shouldAwait);
     bool isFirebaseAppInitialized = false;
     try {
       isFirebaseAppInitialized =
           Firebase.apps.any((app) => app.name == Firebase.app().name);
     } catch (e) {
-      /// Firebase flutter web implementation throws error of uninitialized project
-      /// When project is no initialized which means we just catch the error and ignore it
+      // Firebase flutter web implementation throws error of uninitialized project
+      // When project is not initialized which means we just catch the error and ignore it
     }
-    //we have to first check if the default app has been initialized or not and if the default app has the
-    //same appId as the one passed in configuration. Throw an exception if this is not true.
+
     if (!isFirebaseAppInitialized) {
       try {
         await Firebase.initializeApp(
-          //has to be the default app for the analytics to work on native apps
+          // has to be the default app for the analytics to work on native apps
           options: firebaseOptions,
         );
       } catch (e) {
         print(
-            "failed to initialize firebase app, make sure you either have the firebase options specified in the config file (required for web) "
-                "or have the right google file for the platform - google-services.json for android and GoogleService-Info.plist for iOS.");
+            "Failed to initialize firebase app, make sure you either have the firebase options specified in the config file (required for web) "
+            "or have the right google file for the platform - google-services.json for android and GoogleService-Info.plist for iOS.");
         rethrow;
       }
     } else {
@@ -55,8 +59,8 @@ class FirebaseAnalyticsProvider extends LogProvider {
       if (firebaseOptions != null &&
           defaultApp.options.appId != firebaseOptions!.appId) {
         throw ConfigError(
-            'The appId: ${firebaseOptions?.appId} specified in the Firebase configuration for ensembleapp with id: ${ensembleAppId??'undefined'} is not the default firebase app. '
-                'And the firebase default app has already been initialized. Firebase analytics can only work with the default firebase app');
+            'The appId: ${firebaseOptions?.appId} specified in the Firebase configuration for ensembleapp with id: ${ensembleAppId ?? 'undefined'} is not the default firebase app. '
+            'And the firebase default app has already been initialized. Firebase analytics can only work with the default firebase app');
       }
     }
     _analytics = FirebaseAnalytics.instance;
@@ -66,8 +70,42 @@ class FirebaseAnalyticsProvider extends LogProvider {
   @override
   Future<void> log(
       String event, Map<String, dynamic> parameters, LogLevel level) async {
-    // Use _firebaseApp for logging...
     _analytics?.logEvent(name: event, parameters: parameters);
     print('Firebase: Logged event: $event with parameters: $parameters');
+  }
+
+  Future<void> setUserId(String userId) async {
+    await _analytics?.setUserId(id: userId);
+    print('Firebase: Set user ID: $userId');
+  }
+
+  Future<void> handleAnalytics(Map<String, dynamic> config) async {
+    if (config.containsKey('logEvent')) {
+      var logEventConfig = config['logEvent'];
+      await log(
+        logEventConfig['name'],
+        Map<String, dynamic>.from(logEventConfig['parameters']),
+        LogLevel.info,
+      );
+    } else if (config.containsKey('trackEvent')) {
+      var trackEventConfig = config['trackEvent'];
+      var provider = trackEventConfig.containsKey('provider')
+          ? trackEventConfig['provider']
+          : 'firebase';
+      if (provider == 'firebase') {
+        var operation = trackEventConfig.containsKey('operation')
+            ? trackEventConfig['operation']
+            : 'logEvent';
+        if (operation == 'logEvent') {
+          await log(
+            trackEventConfig['name'],
+            Map<String, dynamic>.from(trackEventConfig['parameters']),
+            LogLevel.info,
+          );
+        } else if (operation == 'setUserId') {
+          await setUserId(trackEventConfig['userId']);
+        }
+      }
+    }
   }
 }

--- a/modules/firebase_analytics/lib/firebase_analytics.dart
+++ b/modules/firebase_analytics/lib/firebase_analytics.dart
@@ -83,13 +83,11 @@ class FirebaseAnalyticsProvider extends LogProvider {
     var provider = config['provider'] ?? 'firebase';
 
     if (provider == 'firebase') {
-      if (operation == 'logEvent' &&
-          config.containsKey('name') &&
-          config.containsKey('parameters')) {
+      if (operation == 'logEvent' && config.containsKey('name')) {
         await logEvent(
           config['name'],
           Map<String, dynamic>.from(config['parameters']),
-          LogLevel.info,
+          config['logLevel'] ?? LogLevel.info,
         );
       } else if (operation == 'setUserId' && config.containsKey('userId')) {
         await setUserId(config['userId']);

--- a/modules/firebase_analytics/lib/firebase_analytics.dart
+++ b/modules/firebase_analytics/lib/firebase_analytics.dart
@@ -67,8 +67,7 @@ class FirebaseAnalyticsProvider extends LogProvider {
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
   }
 
-  @override
-  Future<void> log(
+  Future<void> logEvent(
       String event, Map<String, dynamic> parameters, LogLevel level) async {
     _analytics?.logEvent(name: event, parameters: parameters);
     print('Firebase: Logged event: $event with parameters: $parameters');
@@ -80,31 +79,20 @@ class FirebaseAnalyticsProvider extends LogProvider {
   }
 
   Future<void> handleAnalytics(Map<String, dynamic> config) async {
-    if (config.containsKey('logEvent')) {
-      var logEventConfig = config['logEvent'];
-      await log(
-        logEventConfig['name'],
-        Map<String, dynamic>.from(logEventConfig['parameters']),
-        LogLevel.info,
-      );
-    } else if (config.containsKey('trackEvent')) {
-      var trackEventConfig = config['trackEvent'];
-      var provider = trackEventConfig.containsKey('provider')
-          ? trackEventConfig['provider']
-          : 'firebase';
-      if (provider == 'firebase') {
-        var operation = trackEventConfig.containsKey('operation')
-            ? trackEventConfig['operation']
-            : 'logEvent';
-        if (operation == 'logEvent') {
-          await log(
-            trackEventConfig['name'],
-            Map<String, dynamic>.from(trackEventConfig['parameters']),
-            LogLevel.info,
-          );
-        } else if (operation == 'setUserId') {
-          await setUserId(trackEventConfig['userId']);
-        }
+    var operation = config['operation'] ?? 'logEvent';
+    var provider = config['provider'] ?? 'firebase';
+
+    if (provider == 'firebase') {
+      if (operation == 'logEvent' &&
+          config.containsKey('name') &&
+          config.containsKey('parameters')) {
+        await logEvent(
+          config['name'],
+          Map<String, dynamic>.from(config['parameters']),
+          LogLevel.info,
+        );
+      } else if (operation == 'setUserId' && config.containsKey('userId')) {
+        await setUserId(config['userId']);
       }
     }
   }


### PR DESCRIPTION
- restructured analytics to make it flexible to support more operations
- added setUserId support

previous EDL:

```yaml
logEvent:
  name: "Restaurant_Clicked"
  parameters:
     restaurant_name: ${name}
     restaurant_Id: ${cafeId}
     timestamp: ${ensemble.formatter.now().getDateTime()}
  ```
  
  new EDL:
  
  to log event
  ```yaml
  logEvent:
    provider: firebase # default firebase
    operation: logEvent # default logEvent
    name: "Button_Clicked" # required if operation is logEvent
    parameters:
      button_name: "Login"
      screen_name: "Login Screen"
      timestamp: "2024-06-04T12:00:00"
```

to set user id
```yaml
logEvent:
  provider: firebase
  operation: setUserId
  userId: "user123" # required if operation is setUserId
```

with this structure, analytics can be much more powerful
1. We can add more analytics libraries in `provider` 
2. currently there only 2 operations
    - logEvent
    - setUserId
  - but we can add more operations like `setUserProperty`, `logViewItem`, `logViewCart` etc in `operation` for more flexibility