### PR TITLE
corrected the phone validator function for text input in form widget.

### DIFF
--- a/modules/ensemble/lib/util/input_validator.dart
+++ b/modules/ensemble/lib/util/input_validator.dart
@@ -11,6 +11,7 @@ class InputValidator {
 
   /// check if value is a valid phone number
   static bool phone(String value) {
-    return null == ValidationBuilder().phone().test(value);
+    final RegExp PhoneRegExp = RegExp(r'^\d{7,15}$');
+    return null == ValidationBuilder().regExp(PhoneRegExp,"Please enter a valid Phone Number").test(value);
   }
 }

--- a/modules/ensemble/test/validators_test.dart
+++ b/modules/ensemble/test/validators_test.dart
@@ -23,5 +23,18 @@ void main() {
         false);
   });
 
-  test("Validate phones", () {});
+  test("Validate phones", () {
+      // Test valid phone numbers
+      expect(InputValidator.phone("1234567"), true);
+      expect(InputValidator.phone("123456789012345"), true);
+      
+      // Test invalid phone numbers
+      expect(InputValidator.phone("123"), false);
+      expect(InputValidator.phone("abcdefghi"), false);
+      expect(InputValidator.phone("12345678901234567890"), false);
+      expect(InputValidator.phone(""), false);
+      expect(InputValidator.phone("1234>567"), false);
+      expect(InputValidator.phone("<1234567"), false);
+      expect(InputValidator.phone("1234@567"), false);
+  });
 }


### PR DESCRIPTION
The phone validator function was coming from the following package:
![image](https://github.com/EnsembleUI/ensemble/assets/76642732/db08c679-b8c9-4f9b-acbb-184c99432a17)

 and was accepting strings greater then 7 and less then 15 consisting only of digit with regExp "^\d{7,15}$" which is correct but the bug was in the function.
 
![image](https://github.com/EnsembleUI/ensemble/assets/76642732/d55103f1-b8f0-422f-a4f3-218de00b7742)
the function is removing the non-digit number then checking the phoneExp thats why it is returning true.

so am just using simple regExp function that will do the work using the above mentioned Expression and the message doesnt mattar, we are just returning the bool.

