### PR TITLE
Enabling overriding Locale at runtime

### DIFF
--- a/modules/ensemble/lib/action/action_invokable.dart
+++ b/modules/ensemble/lib/action/action_invokable.dart
@@ -29,6 +29,8 @@ abstract class ActionInvokable with Invokable {
       ActionType.showDialog,
       ActionType.navigateViewGroup,
       ActionType.showToast,
+      ActionType.setLocale,
+      ActionType.clearLocale,
     ]);
   }
 

--- a/modules/ensemble/lib/action/bottom_sheet_actions.dart
+++ b/modules/ensemble/lib/action/bottom_sheet_actions.dart
@@ -245,8 +245,7 @@ class DismissBottomSheetAction extends EnsembleAction {
       DismissBottomSheetAction(payload: payload?['payload']);
 
   @override
-  Future<dynamic> execute(BuildContext context, ScopeManager scopeManager,
-      {DataContext? dataContext}) {
+  Future<dynamic> execute(BuildContext context, ScopeManager scopeManager) {
     BuildContext? bottomSheetContext =
         BottomSheetScopeWidget.getRootContext(context);
     if (bottomSheetContext != null) {

--- a/modules/ensemble/lib/action/change_locale_actions.dart
+++ b/modules/ensemble/lib/action/change_locale_actions.dart
@@ -1,0 +1,39 @@
+import 'package:ensemble/ensemble.dart';
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:flutter/cupertino.dart';
+
+// Set the locale at runtime
+class SetLocaleAction extends EnsembleAction {
+  SetLocaleAction({required this.languageCode, this.countryCode});
+
+  String languageCode;
+  String? countryCode;
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager) {
+    var realLanguageCode = scopeManager.dataContext.eval(languageCode);
+    if (realLanguageCode is! String || realLanguageCode.length != 2) {
+      throw LanguageError("Language Code must be exactly two characters.");
+    }
+
+    var realCountryCode = scopeManager.dataContext.eval(countryCode);
+    if (realCountryCode != null && realCountryCode.toString().length != 2) {
+      throw LanguageError(
+          "Country Code if specified must be exactly two characters.");
+    }
+
+    Ensemble().setLocale(Locale(realLanguageCode, realCountryCode));
+    return Future.value(true);
+  }
+}
+
+// Clear the runtime locale if applicable
+class ClearLocaleAction extends EnsembleAction {
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager) {
+    Ensemble().clearLocale();
+    return Future.value(true);
+  }
+}

--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -384,17 +384,6 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
       builder: (context, child) => widget.isPreview
           ? DevicePreview.appBuilder(context, child)
           : (child ?? SizedBox.shrink()),
-      // builder: (context, child) {
-      //   Locale languageLocale = runtimeLocale ??
-      //       widget.forcedLocale ??
-      //       Localizations.localeOf(context);
-      //   bool isRtl = Bidi.isRtlLanguage(languageLocale.languageCode);
-      //   return Directionality(
-      //       textDirection: isRtl ? ui.TextDirection.rtl : ui.TextDirection.ltr,
-      //       child: widget.isPreview
-      //           ? DevicePreview.appBuilder(context, child)
-      //           : child ?? SizedBox.shrink());
-      // },
     );
     if (EnsembleThemeManager().currentTheme() != null) {
       app = ThemeProvider(

--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -14,6 +14,7 @@ import 'package:ensemble/framework/config.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event/change_locale_events.dart';
 import 'package:ensemble/framework/secrets.dart';
 import 'package:ensemble/framework/storage_manager.dart';
 import 'package:ensemble/framework/theme/theme_loader.dart';
@@ -31,6 +32,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
 import 'package:intl/intl.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:yaml/yaml.dart';
@@ -121,6 +123,7 @@ class EnsembleApp extends StatefulWidget {
   /// use this as the placeholder background while Ensemble is loading
   final Color? placeholderBackgroundColor;
 
+  /// use this if you want the App to start out with this local
   final Locale? forcedLocale;
 
   @override
@@ -130,6 +133,14 @@ class EnsembleApp extends StatefulWidget {
 class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
   bool notifiedAppLoad = false;
   late Future<EnsembleConfig> config;
+
+  // user can force the locale at runtime using this.
+  // Essentially this order: runtimeLocale ?? widget.forcedLocale ?? <system-detected locale>
+  Locale? runtimeLocale;
+
+  // our MaterialApp uses this key, so update this if we want to force
+  // the entire App to reload (e.g. change Locale at runtime)
+  Key? appKey;
 
   @override
   void initState() {
@@ -143,6 +154,20 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
     }
     AppEventBus().eventBus.on<ThemeChangeEvent>().listen((event) {
       setState(() {});
+    });
+
+    // selecting a Locale at run time
+    AppEventBus().eventBus.on<SetLocaleEvent>().listen((event) async {
+      if (runtimeLocale != event.locale) {
+        runtimeLocale = event.locale;
+        rebuildApp();
+      }
+    });
+    AppEventBus().eventBus.on<ClearLocaleEvent>().listen((event) {
+      if (runtimeLocale != null) {
+        runtimeLocale = null;
+        rebuildApp();
+      }
     });
     if (EnvConfig().isTestMode) {
       SemanticsBinding.instance.ensureSemantics();
@@ -199,6 +224,17 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
     }
   }
 
+  /**
+   * Completely rebuild our widget tree by changing the key.
+   * This is often unnecessary unless for something like changing Locale
+   * at runtime where a complete rebuild is needed.
+   */
+  void rebuildApp() {
+    setState(() {
+      appKey = UniqueKey();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
@@ -206,7 +242,8 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
         builder: ((context, snapshot) {
           if (snapshot.hasError) {
             return _appPlaceholderWrapper(
-                widget: ErrorScreen(LanguageError("Error loading configuration",
+                placeholderWidget: ErrorScreen(LanguageError(
+                    "Error loading configuration",
                     detailError: snapshot.error.toString())));
           }
 
@@ -268,6 +305,17 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
     EnsembleThemeManager().init(context, themes, defaultTheme);
   }
 
+  Locale? resolveLocale(Locale? systemLocale) {
+    // run sanity check on locale passed in from the outside
+    Locale? maybeLocale = runtimeLocale ?? widget.forcedLocale;
+    if (maybeLocale != null &&
+        kMaterialSupportedLanguages.contains(maybeLocale.languageCode)) {
+      // the country code can still be invalid. How do we check validity?
+      return maybeLocale;
+    }
+    return systemLocale;
+  }
+
   Widget renderApp(EnsembleConfig config) {
     //even of there is no theme passed in, we still call init as thememanager would initialize with default styles
     if (config.appBundle?.theme?['cssStyling'] != false) {
@@ -306,15 +354,26 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
 
     StorageManager().setIsPreview(widget.isPreview);
     Widget app = MaterialApp(
+      key: appKey,
       navigatorObservers: [Ensemble.routeObserver],
       debugShowCheckedModeBanner: false,
       navigatorKey: Utils.globalAppKey,
       theme: theme,
       localizationsDelegates: [
-        config.getI18NDelegate(forcedLocale: widget.forcedLocale),
+        // for translation
+        config.getI18NDelegate(
+            forcedLocale: runtimeLocale ?? widget.forcedLocale),
+        // for looking up localized names e.g. es to Spanish/Español
+        LocaleNamesLocalizationsDelegate(),
         GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate
       ],
+      // Note that we either need supportedLocales or this callback.
+      // Also note that the placeholder's MaterialApp also has the same
+      // requirement even if it is just a placeholder.
+      localeResolutionCallback: (systemLocale, _) =>
+          resolveLocale(systemLocale),
       home: Scaffold(
           // this outer scaffold is where the background image would be (if
           // specified). We do not want it to resize on keyboard popping up.
@@ -322,16 +381,20 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
           resizeToAvoidBottomInset: false,
           body: screen),
       useInheritedMediaQuery: widget.isPreview,
-      builder: (context, child) {
-        Locale myLocale =
-            widget.forcedLocale ?? Localizations.localeOf(context);
-        bool isRtl = Bidi.isRtlLanguage(myLocale.languageCode);
-        return Directionality(
-            textDirection: isRtl ? ui.TextDirection.rtl : ui.TextDirection.ltr,
-            child: widget.isPreview
-                ? DevicePreview.appBuilder(context, child)
-                : child ?? SizedBox.shrink());
-      },
+      builder: (context, child) => widget.isPreview
+          ? DevicePreview.appBuilder(context, child)
+          : (child ?? SizedBox.shrink()),
+      // builder: (context, child) {
+      //   Locale languageLocale = runtimeLocale ??
+      //       widget.forcedLocale ??
+      //       Localizations.localeOf(context);
+      //   bool isRtl = Bidi.isRtlLanguage(languageLocale.languageCode);
+      //   return Directionality(
+      //       textDirection: isRtl ? ui.TextDirection.rtl : ui.TextDirection.ltr,
+      //       child: widget.isPreview
+      //           ? DevicePreview.appBuilder(context, child)
+      //           : child ?? SizedBox.shrink());
+      // },
     );
     if (EnsembleThemeManager().currentTheme() != null) {
       app = ThemeProvider(
@@ -349,10 +412,16 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
   /// we are at the root here. Error/Spinner widgets need
   /// to be wrapped inside MaterialApp
   Widget _appPlaceholderWrapper(
-      {Widget? widget, Color? placeholderBackgroundColor}) {
+      {Widget? placeholderWidget, Color? placeholderBackgroundColor}) {
     return MaterialApp(
         debugShowCheckedModeBanner: false,
+        // even when this is the placeholder and will be replaced later, we still
+        // need to either set supportedLocales or handle localeResolutionCallback.
+        // Without this the system locale will be incorrect the first time.
+        localeResolutionCallback: (systemLocale, _) =>
+            resolveLocale(systemLocale),
         home: Scaffold(
-            backgroundColor: placeholderBackgroundColor, body: widget));
+            backgroundColor: placeholderBackgroundColor,
+            body: placeholderWidget));
   }
 }

--- a/modules/ensemble/lib/ensemble_provider.dart
+++ b/modules/ensemble/lib/ensemble_provider.dart
@@ -72,9 +72,6 @@ class EnsembleDefinitionProvider extends DefinitionProvider {
           getTranslationMap: getTranslationMap,
           defaultLocale: Locale(appModel.defaultLocale ?? 'en'),
           forcedLocale: forcedLocale),
-      missingTranslationHandler: (key, locale) {
-        // print("--- Missing Key: $key, languageCode: ${locale.languageCode}");
-      },
     );
   }
 

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -9,6 +9,7 @@ import 'package:ensemble/action/haptic_action.dart';
 import 'package:ensemble/action/call_native_method.dart';
 import 'package:ensemble/action/invoke_api_action.dart';
 import 'package:ensemble/action/biometric_auth_action.dart';
+import 'package:ensemble/action/change_locale_actions.dart';
 import 'package:ensemble/action/misc_action.dart';
 import 'package:ensemble/action/navigation_action.dart';
 import 'package:ensemble/action/notification_action.dart';
@@ -1110,7 +1111,8 @@ enum ActionType {
   callNativeMethod,
   deeplinkInit,
   authenticateByBiometric,
-  setLanguage,
+  setLocale,
+  clearLocale,
   signInAnonymous,
   handleDeeplink,
   createDeeplink,
@@ -1319,6 +1321,10 @@ abstract class EnsembleAction {
           initiator: initiator, payload: payload);
     } else if (actionType == ActionType.logEvent) {
       return LogEvent.from(initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.setLocale) {
+      return SetLocaleAction(languageCode: payload?['languageCode']);
+    } else if (actionType == ActionType.clearLocale) {
+      return ClearLocaleAction();
     }
 
     throw LanguageError("Invalid action.",

--- a/modules/ensemble/lib/framework/config.dart
+++ b/modules/ensemble/lib/framework/config.dart
@@ -30,6 +30,7 @@ class AppConfig with Invokable {
           EnsembleStorage(context).getProperty(useMockResponseKey) ?? false,
       'theme': () => EnsembleThemeManager().currentThemeName,
       'themes': () => EnsembleThemeManager().getThemeNames(),
+      'supportedLanguages': () => Ensemble().getSupportedLanguages(context),
     };
   }
 

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -457,6 +457,9 @@ class NativeInvokable extends ActionInvokable {
     };
   }
 
+  /**
+   * TODO: refactor the Actions below to have execute() method, then move to super class's approach
+   */
   @override
   Map<String, Function> methods() {
     // see super method for Actions already exposed there
@@ -540,6 +543,7 @@ class NativeInvokable extends ActionInvokable {
         if (action == null) return null;
         return ScreenController().executeAction(buildContext, action);
       },
+      // WARNING - don't add more to this. This approach is deprecated. See ActionInvokeable
     });
     return methods;
   }

--- a/modules/ensemble/lib/framework/event/change_locale_events.dart
+++ b/modules/ensemble/lib/framework/event/change_locale_events.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+// force a locale change while the App is running
+class SetLocaleEvent {
+  SetLocaleEvent(this.locale);
+  final Locale locale;
+}
+
+// clear the runtime forced locale if specified
+class ClearLocaleEvent {}

--- a/modules/ensemble/lib/framework/model/supported_language.dart
+++ b/modules/ensemble/lib/framework/model/supported_language.dart
@@ -1,0 +1,7 @@
+// model for a language that the app supports (has translation for it)
+class SupportedLanguage {
+  SupportedLanguage(this.languageCode, {required this.name});
+
+  String languageCode;
+  String name;
+}

--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -1,4 +1,3 @@
-
 import 'package:ensemble/framework/bindings.dart';
 import 'package:ensemble/framework/config.dart';
 import 'package:ensemble/framework/error_handling.dart';

--- a/modules/ensemble/lib/provider.dart
+++ b/modules/ensemble/lib/provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'dart:ui';
 import 'package:ensemble/ensemble.dart';
+import 'package:ensemble/framework/model/supported_language.dart';
 import 'package:ensemble/framework/widget/screen.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:flutter/material.dart';
@@ -49,6 +50,8 @@ abstract class DefinitionProvider {
   UserAppConfig? getAppConfig();
 
   Map<String, String> getSecrets();
+
+  List getSupportedLanguages();
 }
 
 class LocalDefinitionProvider extends DefinitionProvider {
@@ -122,6 +125,11 @@ class LocalDefinitionProvider extends DefinitionProvider {
   @override
   Map<String, String> getSecrets() {
     return dotenv.env;
+  }
+
+  @override
+  List getSupportedLanguages() {
+    return [];
   }
 }
 
@@ -206,131 +214,9 @@ class RemoteDefinitionProvider extends DefinitionProvider {
   Map<String, String> getSecrets() {
     return dotenv.env;
   }
-}
-
-class LegacyDefinitionProvider extends DefinitionProvider {
-  LegacyDefinitionProvider(
-      this.url, this.appId, bool cacheEnabled, I18nProps i18nProps)
-      : super(i18nProps, cacheEnabled: cacheEnabled);
-  final String url;
-  final String appId;
-  String? appHome;
-  FlutterI18nDelegate? _i18nDelegate;
 
   @override
-  FlutterI18nDelegate getI18NDelegate({Locale? forcedLocale}) {
-    _i18nDelegate ??= FlutterI18nDelegate(
-        translationLoader: NetworkFileTranslationLoader(
-            baseUri: Uri.parse(i18nProps.path),
-            forcedLocale: forcedLocale,
-            fallbackFile: i18nProps.fallbackLocale,
-            useCountryCode: i18nProps.useCountryCode,
-            decodeStrategies: [YamlDecodeStrategy()]));
-    return _i18nDelegate!;
-  }
-
-  @override
-  Future<ScreenDefinition> getDefinition(
-      {String? screenId, String? screenName}) async {
-    String params = 'ast=false&expression_to_ast=false';
-    if (screenId != null) {
-      params += '&id=$screenId';
-    } else {
-      params += '&appId=$appId';
-      // home screen is loaded if screenName is not specified
-      if (screenName != null) {
-        params += '&name=$screenName';
-      }
-    }
-    Completer<ScreenDefinition> completer = Completer();
-    dynamic res = DefinitionProvider.cache[params];
-    if (res != null) {
-      completer.complete(res);
-      return completer.future;
-    }
-    http.Response response =
-        await http.get(Uri.parse('$url/screen/content?$params'));
-    if (response.statusCode == 200) {
-      dynamic res = ScreenDefinition(loadYaml(response.body));
-      if (cacheEnabled) {
-        DefinitionProvider.cache[params] = res;
-      }
-      completer.complete(res);
-    } else {
-      completer.complete(ScreenDefinition(YamlMap()));
-    }
-    return completer.future;
-  }
-
-  /// Legacy - have to loop through all the screen to match
-  /*Future<YamlMap> getLegacyDefinition({String? screenId}) async {
-    Completer<YamlMap> completer = Completer();
-    http.Response response = await http.get(
-        Uri.parse('$url/app?id=$appId'));
-    if (response.statusCode == 200) {
-      Map<String, dynamic> result = json.decode(response.body);
-      if (result[appId] != null
-          && result[appId]['screens'] is List
-          && (result[appId]['screens'] as List).isNotEmpty) {
-        List<dynamic> screens = result[appId]['screens'];
-
-        for (dynamic screen in screens) {
-          // if loading App without specifying page, load the root page
-          if (screenId == null) {
-            if (screen['is_home']) {
-              completer.complete(loadYaml(screen['content']));
-              return completer.future;
-            }
-          } else if (screen['id'] == screenId || screen['name'] == screenId) {
-            completer.complete(loadYaml(screen['content']));
-            return completer.future;
-          }
-        }
-      }
-    }
-    completer.completeError("Error loading Ensemble page: ${screenId ?? 'Home'}");
-    return completer.future;
-  }*/
-
-  @override
-  Future<AppBundle> getAppBundle({bool? bypassCache = false}) async {
-    Completer<AppBundle> completer = Completer();
-    http.Response response =
-        await http.get(Uri.parse('$url/app/def?id=$appId'));
-    if (response.statusCode == 200) {
-      Map<String, dynamic> result = json.decode(response.body);
-
-      if (result[appId] != null) {
-        // iterate and get the home screen
-        if (result[appId]['screens'] is List) {
-          for (dynamic screen in result[appId]['screens']) {
-            if (screen['is_home']) {
-              appHome = screen['name'];
-              break;
-            }
-          }
-        }
-        // get the App bundle
-        String? content = result[appId]['theme']?['content'];
-        if (content != null) {
-          completer.complete(AppBundle(theme: await loadYaml(content)));
-          return completer.future;
-        }
-      }
-    }
-    completer.complete(AppBundle());
-    return completer.future;
-  }
-
-  // To be implemented
-  @override
-  UserAppConfig? getAppConfig() {
-    return null;
-  }
-
-  // TODO: to be implemented
-  @override
-  Map<String, String> getSecrets() {
-    return <String, String>{};
+  List getSupportedLanguages() {
+    return [];
   }
 }

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -140,6 +140,8 @@ dependencies:
   logger: ^2.2.0
   visibility_detector: ^0.4.0+2
   local_auth: ^2.2.0
+  # use this convert a language code to localized language name e.g. es => Spanish/Español
+  flutter_localized_locales: ^2.0.5
 
 
 dev_dependencies:


### PR DESCRIPTION
- Exposing actions to setLocale and clearLocale. I used this vs setLanguage because it currently set both Language and Locale. Separating them out is harder and can be done later.
- Action will call Ensemble().setLocale/clearLocale. It is made this way so a Flutter app can also call Ensemble function from Flutter code.
- Ensemble dispatch an Event, which EnsembleApp will listen and rebuild the entire app.
- Also expose "app.supportedLocales" which returns the supported languages.