### PR TITLE
TextInput/PasswordInput: maxLength and maxLengthEnforcement 

### DIFF
--- a/modules/ensemble/lib/widget/input/form_textfield.dart
+++ b/modules/ensemble/lib/widget/input/form_textfield.dart
@@ -158,6 +158,9 @@ abstract class BaseTextInput extends StatefulWidget
       'textStyle': (style) => _controller.textStyle = Utils.getTextStyle(style),
       'autofillHints': (value) =>
           _controller.autofillHints = Utils.getListOfStrings(value),
+      'maxLength': (value) => _controller.maxLength = Utils.optionalInt(value),
+      'maxLengthEnforcement': (value) =>
+          _controller.maxLengthEnforcement = _getMaxLengthEnforcement(value),
     });
     return setters;
   }
@@ -234,6 +237,8 @@ class TextInputController extends FormFieldController with HasTextPlaceholder {
   bool? multiline;
   int? minLines;
   int? maxLines;
+  int? maxLength;
+  MaxLengthEnforcement? maxLengthEnforcement;
 
   List<String>? autofillHints;
 }
@@ -475,6 +480,9 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
           inputFormatters: _inputFormatter,
           minLines: isMultiline() ? widget._controller.minLines : null,
           maxLines: isMultiline() ? widget._controller.maxLines : 1,
+          maxLength: widget._controller.maxLength,
+          maxLengthEnforcement: widget._controller.maxLengthEnforcement ??
+              MaxLengthEnforcement.none,
           obscureText: isObscureOrPlainText(),
           enableSuggestions: !widget.isPassword(),
           autocorrect: !widget.isPassword(),
@@ -596,4 +604,16 @@ class _InputDoneButton extends StatelessWidget {
       ),
     );
   }
+}
+
+MaxLengthEnforcement? _getMaxLengthEnforcement(String? value) {
+  switch (value) {
+    case 'none':
+      return MaxLengthEnforcement.none;
+    case 'enforced':
+      return MaxLengthEnforcement.enforced;
+    case 'truncateAfterCompositionEnds':
+      return MaxLengthEnforcement.truncateAfterCompositionEnds;
+  }
+  return null;
 }

--- a/modules/ensemble/lib/widget/input/form_textfield.dart
+++ b/modules/ensemble/lib/widget/input/form_textfield.dart
@@ -482,7 +482,7 @@ class TextInputState extends FormFieldWidgetState<BaseTextInput>
           maxLines: isMultiline() ? widget._controller.maxLines : 1,
           maxLength: widget._controller.maxLength,
           maxLengthEnforcement: widget._controller.maxLengthEnforcement ??
-              MaxLengthEnforcement.none,
+              MaxLengthEnforcement.enforced,
           obscureText: isObscureOrPlainText(),
           enableSuggestions: !widget.isPassword(),
           autocorrect: !widget.isPassword(),


### PR DESCRIPTION
Closes: https://github.com/EnsembleUI/ensemble/issues/1548

EDL:

```yaml
 - TextInput:
       label: Hello world
       maxLength: 10
       maxLengthEnforcement: none # none, enforced, truncateAfterCompositionEnds
- PasswordInput:
       maxLength: 8
       maxLengthEnforcement: enforced
```

![image](https://github.com/user-attachments/assets/f5f01d1c-62dc-45ae-b41c-bd859d6a4463)
