### PR TITLE
#1582 Fixed Custom Widget's onLoad not dispatching in some ocassion

### DIFF
--- a/modules/ensemble/integration_test/local/customWidget_test.dart
+++ b/modules/ensemble/integration_test/local/customWidget_test.dart
@@ -49,4 +49,26 @@ void main() {
       expect(tester.getSize(find.text("2x")).width, 200);
     });
   });
+
+  testWidgets("onLoad should be called for both new and re-used widget state", (tester) async {
+    await TestHelper.loadScreen(tester, 'Custom Widget - onLoad', config);
+
+    // after API called, widget's onLoad will change text to "hello"
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+    expect(find.text('hello'), findsOneWidget);
+
+    // change the text to "Hi", then open and close bottom sheet, which will invoke the API again
+    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Say Hi")));
+    await tester.pumpAndSettle();
+    expect(find.text('hi'), findsOneWidget);
+    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Show Bottom Sheet")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Close")));
+    await tester.pumpAndSettle();
+
+    // since modal's dismiss invoke the API, the Row should re-render. The child widget inside is re-created
+    // Regardless if the widget state is reused or not (it should re-use), onLoad should be called again, which
+    // is exactly what we are trying to confirm here since the text should be changed back to "hello"
+    expect(find.text('hello'), findsOneWidget);
+  });
 }

--- a/modules/ensemble/integration_test/local/customWidget_test.dart
+++ b/modules/ensemble/integration_test/local/customWidget_test.dart
@@ -50,7 +50,8 @@ void main() {
     });
   });
 
-  testWidgets("onLoad should be called for both new and re-used widget state", (tester) async {
+  testWidgets("onLoad should be called for both new and re-used widget state",
+      (tester) async {
     await TestHelper.loadScreen(tester, 'Custom Widget - onLoad', config);
 
     // after API called, widget's onLoad will change text to "hello"
@@ -58,12 +59,15 @@ void main() {
     expect(find.text('hello'), findsOneWidget);
 
     // change the text to "Hi", then open and close bottom sheet, which will invoke the API again
-    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Say Hi")));
+    await tester.tap(find.descendant(
+        of: find.byType(Button), matching: find.text("Say Hi")));
     await tester.pumpAndSettle();
     expect(find.text('hi'), findsOneWidget);
-    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Show Bottom Sheet")));
+    await tester.tap(find.descendant(
+        of: find.byType(Button), matching: find.text("Show Bottom Sheet")));
     await tester.pumpAndSettle();
-    await tester.tap(find.descendant(of: find.byType(Button), matching: find.text("Close")));
+    await tester.tap(
+        find.descendant(of: find.byType(Button), matching: find.text("Close")));
     await tester.pumpAndSettle();
 
     // since modal's dismiss invoke the API, the Row should re-render. The child widget inside is re-created

--- a/modules/ensemble/integration_test/local/widgets/Custom Widget - onLoad.yaml
+++ b/modules/ensemble/integration_test/local/widgets/Custom Widget - onLoad.yaml
@@ -1,0 +1,51 @@
+View:
+  styles:
+    useSafeArea: true
+    scrollableView: true
+  onLoad:
+    invokeAPI:
+      name: getUsers
+  body:
+    Column:
+      children:
+        - Row:
+            item-template:
+              data: ${getUsers.body.results}
+              name: user
+              template:
+                User:
+                  inputs:
+                    user: ${user}
+
+        - Button:
+            label: Show Bottom Sheet
+            onTap:
+              showBottomSheet:
+                body:
+                  Button:
+                    label: Close
+                    onTap:
+                      dismissBottomSheet:
+
+                onDismiss:
+                  invokeAPI:
+                    name: getUsers
+
+User:
+  inputs: [user]
+  onLoad: |
+    myText.text = "hello";
+  body:
+    Column:
+      children:
+        - Text:
+            id: myText
+        - Button:
+            label: Say Hi
+            onTap: |-
+              myText.text = "hi";
+
+
+API:
+  getUsers:
+    url: https://randomuser.me/api/?results=1

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -1130,13 +1130,15 @@ class APIResponse with Invokable {
     return {
       'isSuccess': () => _response?.apiState.isSuccess,
       'isError': () => _response?.apiState.isError,
-      'isLoading': () => _response?.apiState.isLoading,
+      'isLoading': () => isLoading(),
       'body': () => _response?.body,
       'headers': () => _response?.headers,
       'statusCode': () => _response?.statusCode,
       'reasonPhrase': () => _response?.reasonPhrase
     };
   }
+
+  bool isLoading() => _response?.apiState.isLoading == true;
 
   @override
   Map<String, Function> methods() {

--- a/modules/ensemble/lib/framework/definition_providers/provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/provider.dart
@@ -121,7 +121,7 @@ abstract class FileDefinitionProvider extends DefinitionProvider {
 
   @override
   Map<String, String> getSecrets() {
-    return dotenv.env;
+    return dotenv.isInitialized ? dotenv.env : {};
   }
 
   @override

--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -30,7 +30,8 @@ mixin HasItemTemplate<T extends Widget> {
 
 /// Deprecated. Use [EnsembleWidgetState] instead
 /// base class for widgets that want to participate in Ensemble layout
-abstract class EWidgetState<W extends HasController> extends BaseWidgetState<W> {
+abstract class EWidgetState<W extends HasController>
+    extends BaseWidgetState<W> {
   ScopeManager? scopeManager;
 
   void resolveStylesIfUnresolved(BuildContext context) {

--- a/modules/ensemble/lib/layout/templated.dart
+++ b/modules/ensemble/lib/layout/templated.dart
@@ -33,6 +33,12 @@ mixin TemplatedWidgetState<W extends StatefulWidget> on State<W> {
                     (widget as EnsembleWidget).controller, 'itemTemplate')
                 : BindingDestination(widget as Invokable, 'itemTemplate'),
             onDataChange: (ModelChangeEvent event) {
+          // Optimization - we don't care if API status is in loading state
+          if (event.source is APIBindingSource &&
+              event.payload is APIResponse &&
+              event.payload.isLoading()) {
+            return;
+          }
           // evaluate the expression
           dynamic dataList = scopeManager.dataContext.eval(itemTemplate.data);
           if (dataList is List) {

--- a/modules/ensemble/lib/widget/custom_widget/custom_widget.dart
+++ b/modules/ensemble/lib/widget/custom_widget/custom_widget.dart
@@ -70,7 +70,6 @@ class CustomWidgetController extends EnsembleWidgetController {
 }
 
 class _CustomWidgetState extends EnsembleWidgetState<CustomWidget> {
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();

--- a/modules/ensemble/lib/widget/custom_widget/custom_widget.dart
+++ b/modules/ensemble/lib/widget/custom_widget/custom_widget.dart
@@ -12,9 +12,7 @@ import 'package:flutter/cupertino.dart';
 
 class CustomWidget extends EnsembleWidget<CustomWidgetController> {
   CustomWidget._(super.controller,
-      {super.key, required this.model, required this.scopeManager}) {
-    log("Custom Widget $hashCode created");
-  }
+      {super.key, required this.model, required this.scopeManager});
 
   final CustomWidgetModel model;
   final ScopeManager scopeManager;
@@ -72,9 +70,10 @@ class CustomWidgetController extends EnsembleWidgetController {
 }
 
 class _CustomWidgetState extends EnsembleWidgetState<CustomWidget> {
+
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     CustomWidgetLifecycle lifecycleActions = widget.model.getLifecycleActions();
     if (lifecycleActions.onLoad != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
- When Custom Widget reuses its state, onLoad is not being called. We just need to move from initState() to didChangeDependency().
- While on it, noticed it was called multiple times because API changes dispatch LOADING state, which is something we don't care from itemTemplate's perspective
- While at it, fixed the issue with dotEnv in local provider.