### PR TITLE
added colapsible widget

### DIFF
--- a/modules/ensemble/lib/widget/collapsible.dart
+++ b/modules/ensemble/lib/widget/collapsible.dart
@@ -65,9 +65,9 @@ class HeaderStyleComposite extends WidgetCompositeProperty {
   Map<String, Function> methods() => {};
 }
 
-// ContentStyleComposite class to handle content styling
-class ContentStyleComposite extends WidgetCompositeProperty {
-  ContentStyleComposite(super.widgetController) {
+// bodyStyleComposite class to handle body styling
+class bodyStyleComposite extends WidgetCompositeProperty {
+  bodyStyleComposite(super.widgetController) {
     backgroundColor = this.backgroundColor;
     borderColor = this.borderColor;
     borderWidth = this.borderWidth;
@@ -83,8 +83,8 @@ class ContentStyleComposite extends WidgetCompositeProperty {
   double? horizontalPadding;
   double? verticalPadding;
 
-  factory ContentStyleComposite.from(WidgetController controller, dynamic payload) {
-    ContentStyleComposite composite = ContentStyleComposite(controller);
+  factory bodyStyleComposite.from(WidgetController controller, dynamic payload) {
+    bodyStyleComposite composite = bodyStyleComposite(controller);
     if (payload is Map) {
       composite.backgroundColor = Utils.getColor(payload['backgroundColor']);
       composite.borderColor = Utils.getColor(payload['borderColor']);
@@ -134,19 +134,19 @@ class Collapsible extends StatefulWidget
     return {
       'openSections': () => _controller.openSections,
       'headerStyle': () => controller.headerStyle,
-      'contentStyle': () => _controller.contentStyle,
+      'bodyStyle': () => _controller.bodyStyle,
     };
   }
 
   @override
   Map<String, Function> setters() {
     return {
-      'items': (value) => _controller.items = List<YamlMap>.from(value),
+      'items': (value) => _controller.items = List<Map>.from(value),
       'isAccordion': (value) => _controller.isAccordion = Utils.getBool(value, fallback: true),
       'initialOpeningSequenceDelay': (value) =>
           _controller.initialOpeningSequenceDelay = Utils.optionalInt(value),
       'headerStyle': (value) => _controller.headerStyle = HeaderStyleComposite.from(controller, value),
-      'contentStyle': (value) => _controller.contentStyle = ContentStyleComposite.from(controller, value),
+      'bodyStyle': (value) => _controller.bodyStyle = bodyStyleComposite.from(controller, value),
       'leftIcon': (value) => _controller.leftIcon = value,
       'rightIcon': (value) => _controller.rightIcon = value,
       'flipLeftIconIfOpen': (value) =>
@@ -184,20 +184,20 @@ class Collapsible extends StatefulWidget
 }
 
 class CollapsibleController extends BoxController {
-  List<YamlMap> items = [];
+  List<Map> items = [];
   bool isAccordion = true;
   int? initialOpeningSequenceDelay;
   HeaderStyleComposite? _headerStyle;
-  ContentStyleComposite? _contentStyle;
+  bodyStyleComposite? _bodyStyle;
   
   HeaderStyleComposite get headerStyle => 
       _headerStyle ??= HeaderStyleComposite(this);
   
-  ContentStyleComposite get contentStyle => 
-      _contentStyle ??= ContentStyleComposite(this);
+  bodyStyleComposite get bodyStyle => 
+      _bodyStyle ??= bodyStyleComposite(this);
   
   set headerStyle(HeaderStyleComposite style) => _headerStyle = style;
-  set contentStyle(ContentStyleComposite style) => _contentStyle = style;
+  set bodyStyle(bodyStyleComposite style) => _bodyStyle = style;
 
   dynamic leftIcon;
   dynamic rightIcon;
@@ -269,13 +269,13 @@ class CollapsibleState extends EWidgetState<Collapsible> {
       flipLeftIconIfOpen: widget.controller.flipLeftIconIfOpen ?? false,
       flipRightIconIfOpen: widget.controller.flipRightIconIfOpen ?? true,
       contentBackgroundColor:
-          widget.controller.contentStyle.backgroundColor,
-      contentBorderColor: widget.controller.contentStyle.borderColor,
-      contentBorderWidth: widget.controller.contentStyle.borderWidth ?? 1.0,
-      contentBorderRadius: widget.controller.contentStyle.borderRadius ?? 0.0,
+          widget.controller.bodyStyle.backgroundColor,
+      contentBorderColor: widget.controller.bodyStyle.borderColor,
+      contentBorderWidth: widget.controller.bodyStyle.borderWidth ?? 1.0,
+      contentBorderRadius: widget.controller.bodyStyle.borderRadius ?? 0.0,
       contentHorizontalPadding:
-          widget.controller.contentStyle.horizontalPadding ?? 0.0,
-      contentVerticalPadding: widget.controller.contentStyle.verticalPadding ?? 0.0,
+          widget.controller.bodyStyle.horizontalPadding ?? 0.0,
+      contentVerticalPadding: widget.controller.bodyStyle.verticalPadding ?? 0.0,
       paddingListTop: widget.controller.paddingListTop,
       paddingListBottom: widget.controller.paddingListBottom,
       paddingListHorizontal: widget.controller.paddingListHorizontal,
@@ -314,22 +314,22 @@ class CollapsibleState extends EWidgetState<Collapsible> {
           headerPadding: Utils.optionalInsets(item['headerStyle']?['padding']) ??
               widget.controller.headerStyle.padding,
           contentBackgroundColor:
-              Utils.getColor(item['contentStyle']?['backgroundColor']) ??
-                  widget.controller.contentStyle.backgroundColor,
-          contentBorderColor: Utils.getColor(item['contentStyle']?['borderColor']) ??
-              widget.controller.contentStyle.borderColor,
+              Utils.getColor(item['bodyStyle']?['backgroundColor']) ??
+                  widget.controller.bodyStyle.backgroundColor,
+          contentBorderColor: Utils.getColor(item['bodyStyle']?['borderColor']) ??
+              widget.controller.bodyStyle.borderColor,
           contentBorderWidth:
-              Utils.optionalDouble(item['contentStyle']?['borderWidth']) ??
-                  widget.controller.contentStyle.borderWidth,
+              Utils.optionalDouble(item['bodyStyle']?['borderWidth']) ??
+                  widget.controller.bodyStyle.borderWidth,
           contentBorderRadius:
-              Utils.optionalDouble(item['contentStyle']?['borderRadius'])  ??
-                  widget.controller.contentStyle.borderRadius,
+              Utils.optionalDouble(item['bodyStyle']?['borderRadius'])  ??
+                  widget.controller.bodyStyle.borderRadius,
           contentHorizontalPadding:
-              Utils.optionalDouble(item['contentStyle']?['horizontalPadding']) ??
-                  widget.controller.contentStyle.horizontalPadding,
+              Utils.optionalDouble(item['bodyStyle']?['horizontalPadding']) ??
+                  widget.controller.bodyStyle.horizontalPadding,
           contentVerticalPadding:
-              Utils.optionalDouble(item['contentStyle']?['verticalPadding']) ??
-                  widget.controller.contentStyle.verticalPadding,
+              Utils.optionalDouble(item['bodyStyle']?['verticalPadding']) ??
+                  widget.controller.bodyStyle.verticalPadding,
           leftIcon: _buildIcon(item['leftIcon']) ??
               _buildIcon(widget.controller.leftIcon),
           rightIcon: _buildIcon(item['rightIcon']) ??
@@ -340,8 +340,8 @@ class CollapsibleState extends EWidgetState<Collapsible> {
               Utils.optionalDouble(item['paddingBetweenClosedSections']) ?? widget.controller.paddingBetweenClosedSections,
           header: _buildChildWidget(context, item['header']) ??
               Text('Section $index'),
-          content: _buildChildWidget(context, item['content']) ??
-              Text('Content for section $index'),
+          content: _buildChildWidget(context, item['body']) ??
+              Text('body for section $index'),
           onOpenSection: () {
             setState(() {
               widget.controller.openSection(index);

--- a/modules/ensemble/lib/widget/collapsible.dart
+++ b/modules/ensemble/lib/widget/collapsible.dart
@@ -13,7 +13,18 @@ import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:yaml/yaml.dart';
 import 'package:ensemble/framework/widget/icon.dart' as ensembleIcon;
 
-class HeaderStyle {
+// HeaderStyleComposite class to handle header styling
+class HeaderStyleComposite extends WidgetCompositeProperty {
+  HeaderStyleComposite(super.widgetController) {
+    backgroundColor = this.backgroundColor;
+    backgroundColorOpened = this.backgroundColorOpened;
+    borderColor = this.borderColor;
+    borderColorOpened = this.borderColorOpened;
+    borderWidth = this.borderWidth;
+    borderRadius = this.borderRadius;
+    padding = this.padding;
+  }
+
   Color? backgroundColor;
   Color? backgroundColorOpened;
   Color? borderColor;
@@ -22,18 +33,49 @@ class HeaderStyle {
   double? borderRadius;
   EdgeInsets? padding;
 
-  HeaderStyle({
-    this.backgroundColor,
-    this.backgroundColorOpened,
-    this.borderColor,
-    this.borderColorOpened,
-    this.borderWidth,
-    this.borderRadius,
-    this.padding,
-  });
+  factory HeaderStyleComposite.from(WidgetController controller, dynamic payload) {
+    HeaderStyleComposite composite = HeaderStyleComposite(controller);
+    if (payload is Map) {
+      composite.backgroundColor = Utils.getColor(payload['backgroundColor']);
+      composite.backgroundColorOpened = Utils.getColor(payload['backgroundColorOpened']);
+      composite.borderColor = Utils.getColor(payload['borderColor']);
+      composite.borderColorOpened = Utils.getColor(payload['borderColorOpened']);
+      composite.borderWidth = Utils.optionalDouble(payload['borderWidth']);
+      composite.borderRadius = Utils.optionalDouble(payload['borderRadius']);
+      composite.padding = Utils.optionalInsets(payload['padding']);
+    }
+    return composite;
+  }
+
+  @override
+  Map<String, Function> setters() => {
+    'backgroundColor': (value) => backgroundColor = Utils.getColor(value),
+    'backgroundColorOpened': (value) => backgroundColorOpened = Utils.getColor(value),
+    'borderColor': (value) => borderColor = Utils.getColor(value),
+    'borderColorOpened': (value) => borderColorOpened = Utils.getColor(value),
+    'borderWidth': (value) => borderWidth = Utils.optionalDouble(value),
+    'borderRadius': (value) => borderRadius = Utils.optionalDouble(value),
+    'padding': (value) => padding = Utils.optionalInsets(value),
+  };
+
+  @override
+  Map<String, Function> getters() => {};
+
+  @override
+  Map<String, Function> methods() => {};
 }
 
-class ContentStyle {
+// ContentStyleComposite class to handle content styling
+class ContentStyleComposite extends WidgetCompositeProperty {
+  ContentStyleComposite(super.widgetController) {
+    backgroundColor = this.backgroundColor;
+    borderColor = this.borderColor;
+    borderWidth = this.borderWidth;
+    borderRadius = this.borderRadius;
+    horizontalPadding = this.horizontalPadding;
+    verticalPadding = this.verticalPadding;
+  }
+
   Color? backgroundColor;
   Color? borderColor;
   double? borderWidth;
@@ -41,14 +83,34 @@ class ContentStyle {
   double? horizontalPadding;
   double? verticalPadding;
 
-  ContentStyle({
-    this.backgroundColor,
-    this.borderColor,
-    this.borderWidth,
-    this.borderRadius,
-    this.horizontalPadding,
-    this.verticalPadding,
-  });
+  factory ContentStyleComposite.from(WidgetController controller, dynamic payload) {
+    ContentStyleComposite composite = ContentStyleComposite(controller);
+    if (payload is Map) {
+      composite.backgroundColor = Utils.getColor(payload['backgroundColor']);
+      composite.borderColor = Utils.getColor(payload['borderColor']);
+      composite.borderWidth = Utils.optionalDouble(payload['borderWidth']);
+      composite.borderRadius = Utils.optionalDouble(payload['borderRadius']);
+      composite.horizontalPadding = Utils.optionalDouble(payload['horizontalPadding']);
+      composite.verticalPadding = Utils.optionalDouble(payload['verticalPadding']);
+    }
+    return composite;
+  }
+
+  @override
+  Map<String, Function> setters() => {
+    'backgroundColor': (value) => backgroundColor = Utils.getColor(value),
+    'borderColor': (value) => borderColor = Utils.getColor(value),
+    'borderWidth': (value) => borderWidth = Utils.optionalDouble(value),
+    'borderRadius': (value) => borderRadius = Utils.optionalDouble(value),
+    'horizontalPadding': (value) => horizontalPadding = Utils.optionalDouble(value),
+    'verticalPadding': (value) => verticalPadding = Utils.optionalDouble(value),
+  };
+
+  @override
+  Map<String, Function> getters() => {};
+
+  @override
+  Map<String, Function> methods() => {};
 }
 
 class Collapsible extends StatefulWidget
@@ -71,6 +133,8 @@ class Collapsible extends StatefulWidget
   Map<String, Function> getters() {
     return {
       'openSections': () => _controller.openSections,
+      'headerStyle': () => controller.headerStyle,
+      'contentStyle': () => _controller.contentStyle,
     };
   }
 
@@ -81,23 +145,8 @@ class Collapsible extends StatefulWidget
       'isAccordion': (value) => _controller.isAccordion = Utils.getBool(value, fallback: true),
       'initialOpeningSequenceDelay': (value) =>
           _controller.initialOpeningSequenceDelay = Utils.optionalInt(value),
-      'headerStyle': (value) => _controller.headerStyle = HeaderStyle(
-        backgroundColor: Utils.getColor(value['backgroundColor']),
-        backgroundColorOpened: Utils.getColor(value['backgroundColorOpened']),
-        borderColor: Utils.getColor(value['borderColor']),
-        borderColorOpened: Utils.getColor(value['borderColorOpened']),
-        borderWidth: Utils.optionalDouble(value['borderWidth']),
-        borderRadius: Utils.optionalDouble(value['borderRadius']),
-        padding: Utils.optionalInsets(value['padding']),
-      ),
-      'contentStyle': (value) => _controller.contentStyle = ContentStyle(
-        backgroundColor: Utils.getColor(value['backgroundColor']),
-        borderColor: Utils.getColor(value['borderColor']),
-        borderWidth: Utils.optionalDouble(value['borderWidth']),
-        borderRadius: Utils.optionalDouble(value['borderRadius']),
-        horizontalPadding: Utils.optionalDouble(value['horizontalPadding']),
-        verticalPadding: Utils.optionalDouble(value['verticalPadding']),
-      ),
+      'headerStyle': (value) => _controller.headerStyle = HeaderStyleComposite.from(controller, value),
+      'contentStyle': (value) => _controller.contentStyle = ContentStyleComposite.from(controller, value),
       'leftIcon': (value) => _controller.leftIcon = value,
       'rightIcon': (value) => _controller.rightIcon = value,
       'flipLeftIconIfOpen': (value) =>
@@ -138,8 +187,18 @@ class CollapsibleController extends BoxController {
   List<YamlMap> items = [];
   bool isAccordion = true;
   int? initialOpeningSequenceDelay;
-  HeaderStyle headerStyle = HeaderStyle();
-  ContentStyle contentStyle = ContentStyle();
+  HeaderStyleComposite? _headerStyle;
+  ContentStyleComposite? _contentStyle;
+  
+  HeaderStyleComposite get headerStyle => 
+      _headerStyle ??= HeaderStyleComposite(this);
+  
+  ContentStyleComposite get contentStyle => 
+      _contentStyle ??= ContentStyleComposite(this);
+  
+  set headerStyle(HeaderStyleComposite style) => _headerStyle = style;
+  set contentStyle(ContentStyleComposite style) => _contentStyle = style;
+
   dynamic leftIcon;
   dynamic rightIcon;
   bool? flipLeftIconIfOpen;
@@ -175,10 +234,6 @@ class CollapsibleController extends BoxController {
     final newOpenSections = List<int>.from(_openSections.value);
     newOpenSections.remove(index);
     _openSections.value = newOpenSections;
-  }
-
-  @override
-  void dispose() {
   }
 }
 

--- a/modules/ensemble/lib/widget/collapsible.dart
+++ b/modules/ensemble/lib/widget/collapsible.dart
@@ -1,0 +1,345 @@
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/view/data_scope_widget.dart';
+import 'package:ensemble/widget/helpers/controllers.dart';
+import 'package:flutter/material.dart';
+import 'package:accordion/accordion.dart';
+import 'package:ensemble/framework/widget/widget.dart';
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:yaml/yaml.dart';
+import 'package:ensemble/framework/widget/icon.dart' as ensembleIcon;
+
+class HeaderStyle {
+  Color? backgroundColor;
+  Color? backgroundColorOpened;
+  Color? borderColor;
+  Color? borderColorOpened;
+  double? borderWidth;
+  double? borderRadius;
+  EdgeInsets? padding;
+
+  HeaderStyle({
+    this.backgroundColor,
+    this.backgroundColorOpened,
+    this.borderColor,
+    this.borderColorOpened,
+    this.borderWidth,
+    this.borderRadius,
+    this.padding,
+  });
+}
+
+class ContentStyle {
+  Color? backgroundColor;
+  Color? borderColor;
+  double? borderWidth;
+  double? borderRadius;
+  double? horizontalPadding;
+  double? verticalPadding;
+
+  ContentStyle({
+    this.backgroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.borderRadius,
+    this.horizontalPadding,
+    this.verticalPadding,
+  });
+}
+
+class Collapsible extends StatefulWidget
+    with
+        Invokable,
+        HasController<CollapsibleController, CollapsibleState> {
+  static const type = 'Collapsible';
+
+  Collapsible({Key? key}) : super(key: key);
+
+  final CollapsibleController _controller = CollapsibleController();
+
+  @override
+  CollapsibleController get controller => _controller;
+
+  @override
+  State<StatefulWidget> createState() => CollapsibleState();
+
+  @override
+  Map<String, Function> getters() {
+    return {
+      'openSections': () => _controller.openSections,
+    };
+  }
+
+  @override
+  Map<String, Function> setters() {
+    return {
+      'items': (value) => _controller.items = List<YamlMap>.from(value),
+      'isAccordion': (value) => _controller.isAccordion = Utils.getBool(value, fallback: true),
+      'initialOpeningSequenceDelay': (value) =>
+          _controller.initialOpeningSequenceDelay = Utils.optionalInt(value),
+      'headerStyle': (value) => _controller.headerStyle = HeaderStyle(
+        backgroundColor: Utils.getColor(value['backgroundColor']),
+        backgroundColorOpened: Utils.getColor(value['backgroundColorOpened']),
+        borderColor: Utils.getColor(value['borderColor']),
+        borderColorOpened: Utils.getColor(value['borderColorOpened']),
+        borderWidth: Utils.optionalDouble(value['borderWidth']),
+        borderRadius: Utils.optionalDouble(value['borderRadius']),
+        padding: Utils.optionalInsets(value['padding']),
+      ),
+      'contentStyle': (value) => _controller.contentStyle = ContentStyle(
+        backgroundColor: Utils.getColor(value['backgroundColor']),
+        borderColor: Utils.getColor(value['borderColor']),
+        borderWidth: Utils.optionalDouble(value['borderWidth']),
+        borderRadius: Utils.optionalDouble(value['borderRadius']),
+        horizontalPadding: Utils.optionalDouble(value['horizontalPadding']),
+        verticalPadding: Utils.optionalDouble(value['verticalPadding']),
+      ),
+      'leftIcon': (value) => _controller.leftIcon = value,
+      'rightIcon': (value) => _controller.rightIcon = value,
+      'flipLeftIconIfOpen': (value) =>
+          _controller.flipLeftIconIfOpen = Utils.optionalBool(value),
+      'flipRightIconIfOpen': (value) =>
+          _controller.flipRightIconIfOpen = Utils.optionalBool(value),
+      'paddingListTop': (value) =>
+          _controller.paddingListTop = Utils.getDouble(value, fallback: 0.0),
+      'paddingListBottom': (value) =>
+          _controller.paddingListBottom = Utils.getDouble(value, fallback: 0.0),
+      'paddingListHorizontal': (value) => _controller.paddingListHorizontal =
+          Utils.getDouble(value, fallback: 0.0),
+      'paddingBetweenOpenSections': (value) =>
+          _controller.paddingBetweenOpenSections = Utils.optionalDouble(value),
+      'paddingBetweenClosedSections': (value) => _controller
+          .paddingBetweenClosedSections = Utils.optionalDouble(value),
+      'disableScrolling': (value) =>
+          _controller.disableScrolling = Utils.getBool(value, fallback: false),
+      'openAndCloseAnimation': (value) =>
+          _controller.openAndCloseAnimation = Utils.optionalBool(value),
+      'scaleWhenAnimating': (value) =>
+          _controller.scaleWhenAnimating = Utils.optionalBool(value),
+      'accordionId': (value) =>
+          _controller.accordionId = Utils.optionalString(value),
+    };
+  }
+
+  @override
+  Map<String, Function> methods() {
+    return {
+      'openSection': (int index) => _controller.openSection(index),
+      'closeSection': (int index) => _controller.closeSection(index),
+    };
+  }
+}
+
+class CollapsibleController extends BoxController {
+  List<YamlMap> items = [];
+  bool isAccordion = true;
+  int? initialOpeningSequenceDelay;
+  HeaderStyle headerStyle = HeaderStyle();
+  ContentStyle contentStyle = ContentStyle();
+  dynamic leftIcon;
+  dynamic rightIcon;
+  bool? flipLeftIconIfOpen;
+  bool? flipRightIconIfOpen;
+  double paddingListTop = 0.0;
+  double paddingListBottom = 0.0;
+  double paddingListHorizontal = 0.0;
+  double? paddingBetweenOpenSections;
+  double? paddingBetweenClosedSections;
+  bool disableScrolling = false;
+  bool? openAndCloseAnimation;
+  bool? scaleWhenAnimating;
+  String? accordionId;
+
+  final ValueNotifier<List<int>> _openSections = ValueNotifier<List<int>>([]);
+  List<int> get openSections => _openSections.value;
+
+  void openSection(int index) {
+    if (isAccordion) {
+      _openSections.value = [index];
+    } else {
+      final newOpenSections = List<int>.from(_openSections.value);
+      if (newOpenSections.contains(index)) {
+        newOpenSections.remove(index);
+      } else {
+        newOpenSections.add(index);
+      }
+      _openSections.value = newOpenSections;
+    }
+  }
+
+  void closeSection(int index) {
+    final newOpenSections = List<int>.from(_openSections.value);
+    newOpenSections.remove(index);
+    _openSections.value = newOpenSections;
+  }
+
+  @override
+  void dispose() {
+  }
+}
+
+class CollapsibleState extends EWidgetState<Collapsible> {
+
+  @override
+  void initState() {
+    super.initState();
+    final initialOpenSections = <int>[];
+    for (int i = 0; i < widget.controller.items.length; i++) {
+      if (widget.controller.items[i]['isOpen'] == true) {
+        initialOpenSections.add(i);
+      }
+    }
+    widget.controller._openSections.value = initialOpenSections;
+  }
+
+  @override
+  Widget buildWidget(BuildContext context) {
+    return Accordion(
+      maxOpenSections: widget.controller.isAccordion ? 1 : widget.controller.items.length,
+      initialOpeningSequenceDelay:
+          widget.controller.initialOpeningSequenceDelay ?? 0,
+      headerBackgroundColor:
+          widget.controller.headerStyle.backgroundColor,
+      headerBackgroundColorOpened:
+          widget.controller.headerStyle.backgroundColorOpened,
+      headerBorderColor: widget.controller.headerStyle.borderColor,
+      headerBorderColorOpened:
+          widget.controller.headerStyle.borderColorOpened,
+      headerBorderWidth: widget.controller.headerStyle.borderWidth ?? 1.0,
+      headerBorderRadius: widget.controller.headerStyle.borderRadius ?? 0.0,
+      flipLeftIconIfOpen: widget.controller.flipLeftIconIfOpen ?? false,
+      flipRightIconIfOpen: widget.controller.flipRightIconIfOpen ?? true,
+      contentBackgroundColor:
+          widget.controller.contentStyle.backgroundColor,
+      contentBorderColor: widget.controller.contentStyle.borderColor,
+      contentBorderWidth: widget.controller.contentStyle.borderWidth ?? 1.0,
+      contentBorderRadius: widget.controller.contentStyle.borderRadius ?? 0.0,
+      contentHorizontalPadding:
+          widget.controller.contentStyle.horizontalPadding ?? 0.0,
+      contentVerticalPadding: widget.controller.contentStyle.verticalPadding ?? 0.0,
+      paddingListTop: widget.controller.paddingListTop,
+      paddingListBottom: widget.controller.paddingListBottom,
+      paddingListHorizontal: widget.controller.paddingListHorizontal,
+      headerPadding: widget.controller.headerStyle.padding ?? EdgeInsets.zero,
+      paddingBetweenOpenSections:
+          widget.controller.paddingBetweenOpenSections ?? 0.0,
+      paddingBetweenClosedSections:
+          widget.controller.paddingBetweenClosedSections ?? 0.0,
+      disableScrolling: widget.controller.disableScrolling,
+      openAndCloseAnimation: widget.controller.openAndCloseAnimation ?? true,
+      scaleWhenAnimating: widget.controller.scaleWhenAnimating ?? true,
+      leftIcon: _buildIcon(widget.controller.leftIcon),
+      rightIcon: _buildIcon(widget.controller.rightIcon),
+      accordionId: widget.controller.accordionId ?? 'default_accordion',
+      children: List.generate(widget.controller.items.length, (index) {
+        final item = widget.controller.items[index];
+        final isOpen = widget.controller.openSections.contains(index);
+        return AccordionSection(
+          isOpen: isOpen,
+          headerBackgroundColor:
+              Utils.getColor(item['headerBackgroundColor']) ??
+                  widget.controller.headerStyle.backgroundColor,
+          headerBackgroundColorOpened:
+              Utils.getColor(item['headerBackgroundColorOpened']) ??
+                  widget.controller.headerStyle.backgroundColorOpened,
+          headerBorderColor: Utils.getColor(item['headerBorderColor']) ??
+              widget.controller.headerStyle.borderColor,
+          headerBorderColorOpened:
+              Utils.getColor(item['headerBorderColorOpened']) ??
+                  widget.controller.headerStyle.borderColorOpened,
+          headerBorderWidth: Utils.optionalDouble(item['headerBorderWidth']) ??
+              widget.controller.headerStyle.borderWidth,
+          headerBorderRadius:
+              Utils.optionalDouble(item['headerBorderRadius']) ??
+                  widget.controller.headerStyle.borderRadius,
+          headerPadding: Utils.optionalInsets(item['headerPadding']) ??
+              widget.controller.headerStyle.padding,
+          contentBackgroundColor:
+              Utils.getColor(item['contentBackgroundColor']) ??
+                  widget.controller.contentStyle.backgroundColor,
+          contentBorderColor: Utils.getColor(item['contentBorderColor']) ??
+              widget.controller.contentStyle.borderColor,
+          contentBorderWidth:
+              Utils.optionalDouble(item['contentBorderWidth']) ??
+                  widget.controller.contentStyle.borderWidth,
+          contentBorderRadius:
+              Utils.optionalDouble(item['contentBorderRadius']) ??
+                  widget.controller.contentStyle.borderRadius,
+          contentHorizontalPadding:
+              Utils.optionalDouble(item['contentHorizontalPadding']) ??
+                  widget.controller.contentStyle.horizontalPadding,
+          contentVerticalPadding:
+              Utils.optionalDouble(item['contentVerticalPadding']) ??
+                  widget.controller.contentStyle.verticalPadding,
+          leftIcon: _buildIcon(item['leftIcon']) ??
+              _buildIcon(widget.controller.leftIcon),
+          rightIcon: _buildIcon(item['rightIcon']) ??
+              _buildIcon(widget.controller.rightIcon),
+          paddingBetweenOpenSections:
+              Utils.optionalDouble(item['paddingBetweenOpenSections']) ?? widget.controller.paddingBetweenOpenSections,
+          paddingBetweenClosedSections:
+              Utils.optionalDouble(item['paddingBetweenClosedSections']) ?? widget.controller.paddingBetweenClosedSections,
+          header: _buildChildWidget(context, item['header']) ??
+              Text('Section $index'),
+          content: _buildChildWidget(context, item['content']) ??
+              Text('Content for section $index'),
+          onOpenSection: () {
+            setState(() {
+              widget.controller.openSection(index);
+            });
+            if (item['onOpenSection'] != null) {
+              final onOpenAction = EnsembleAction.from(item['onOpenSection'], initiator: widget);
+              ScreenController().executeAction(
+                context,
+                onOpenAction!,
+                event: EnsembleEvent(widget, data: {'index': index}),
+              );
+            }
+          },
+          onCloseSection: () {
+            setState(() {
+              widget.controller.closeSection(index);
+            });
+            if (item['onCloseSection'] != null) {
+              final onCloseAction = EnsembleAction.from(item['onCloseSection'], initiator: widget);
+              ScreenController().executeAction(
+                context,
+                onCloseAction!,
+                event: EnsembleEvent(widget, data: {'index': index}),
+              );
+            }
+          },
+        );
+      }),
+    );
+  }
+
+  Widget? _buildIcon(dynamic value) {
+    if (value == null) {
+      return null;
+    }
+    if (value is Map && value['Icon'] != null) {
+      final iconModel = Utils.getIcon(value['Icon']);
+      if (iconModel != null) {
+        return ensembleIcon.Icon.fromModel(iconModel);
+      }
+    }
+    return null;
+  }
+
+  Widget? _buildChildWidget(BuildContext context, dynamic widgetDefinition) {
+    if (widgetDefinition == null) {
+      return null;
+    }
+    ScopeManager? scopeManager = DataScopeWidget.getScope(context);
+    if (scopeManager != null) {
+      return scopeManager.buildWidgetFromDefinition(widgetDefinition);
+    } else {
+      throw LanguageError('Failed to build widget');
+    }
+  }
+}

--- a/modules/ensemble/lib/widget/collapsible.dart
+++ b/modules/ensemble/lib/widget/collapsible.dart
@@ -241,39 +241,39 @@ class CollapsibleState extends EWidgetState<Collapsible> {
         return AccordionSection(
           isOpen: isOpen,
           headerBackgroundColor:
-              Utils.getColor(item['headerBackgroundColor']) ??
+              Utils.getColor(item['headerStyle']?['backgroundColor']) ??
                   widget.controller.headerStyle.backgroundColor,
           headerBackgroundColorOpened:
-              Utils.getColor(item['headerBackgroundColorOpened']) ??
+              Utils.getColor(item['headerStyle']?['backgroundColorOpened']) ??
                   widget.controller.headerStyle.backgroundColorOpened,
-          headerBorderColor: Utils.getColor(item['headerBorderColor']) ??
+          headerBorderColor:Utils.getColor(item['headerStyle']?['borderColor']) ??
               widget.controller.headerStyle.borderColor,
           headerBorderColorOpened:
-              Utils.getColor(item['headerBorderColorOpened']) ??
+              Utils.getColor(item['headerStyle']?['borderColorOpened']) ??
                   widget.controller.headerStyle.borderColorOpened,
-          headerBorderWidth: Utils.optionalDouble(item['headerBorderWidth']) ??
+          headerBorderWidth: Utils.optionalDouble(item['headerStyle']?['borderWidth']) ??
               widget.controller.headerStyle.borderWidth,
           headerBorderRadius:
-              Utils.optionalDouble(item['headerBorderRadius']) ??
+              Utils.optionalDouble(item['headerStyle']?['borderRadius']) ??
                   widget.controller.headerStyle.borderRadius,
-          headerPadding: Utils.optionalInsets(item['headerPadding']) ??
+          headerPadding: Utils.optionalInsets(item['headerStyle']?['padding']) ??
               widget.controller.headerStyle.padding,
           contentBackgroundColor:
-              Utils.getColor(item['contentBackgroundColor']) ??
+              Utils.getColor(item['contentStyle']?['backgroundColor']) ??
                   widget.controller.contentStyle.backgroundColor,
-          contentBorderColor: Utils.getColor(item['contentBorderColor']) ??
+          contentBorderColor: Utils.getColor(item['contentStyle']?['borderColor']) ??
               widget.controller.contentStyle.borderColor,
           contentBorderWidth:
-              Utils.optionalDouble(item['contentBorderWidth']) ??
+              Utils.optionalDouble(item['contentStyle']?['borderWidth']) ??
                   widget.controller.contentStyle.borderWidth,
           contentBorderRadius:
-              Utils.optionalDouble(item['contentBorderRadius']) ??
+              Utils.optionalDouble(item['contentStyle']?['borderRadius'])  ??
                   widget.controller.contentStyle.borderRadius,
           contentHorizontalPadding:
-              Utils.optionalDouble(item['contentHorizontalPadding']) ??
+              Utils.optionalDouble(item['contentStyle']?['horizontalPadding']) ??
                   widget.controller.contentStyle.horizontalPadding,
           contentVerticalPadding:
-              Utils.optionalDouble(item['contentVerticalPadding']) ??
+              Utils.optionalDouble(item['contentStyle']?['verticalPadding']) ??
                   widget.controller.contentStyle.verticalPadding,
           leftIcon: _buildIcon(item['leftIcon']) ??
               _buildIcon(widget.controller.leftIcon),

--- a/modules/ensemble/lib/widget/widget_registry.dart
+++ b/modules/ensemble/lib/widget/widget_registry.dart
@@ -60,6 +60,7 @@ import 'package:ensemble/widget/switch.dart';
 import 'package:ensemble/widget/text.dart';
 import 'package:ensemble/widget/toggle_button.dart';
 import 'package:ensemble/widget/video.dart';
+import 'package:ensemble/widget/collapsible.dart';
 import 'package:ensemble/widget/visualization/barchart.dart';
 import 'package:ensemble/widget/visualization/chart_js.dart';
 import 'package:ensemble/widget/visualization/line_area_chart.dart';
@@ -135,6 +136,7 @@ class WidgetRegistry {
         PopupMenu.type: () => PopupMenu(),
         EnsembleCalendar.type: () => EnsembleCalendar(),
         Countdown.type: () => Countdown(),
+        Collapsible.type: () => Collapsible(),
 
         // form fields
         RadioButton.type: () => RadioButton(),
@@ -191,5 +193,6 @@ class WidgetRegistry {
         // handling common GPT widget mistakes
         "Container": () => Column(),
         "ScrollView": () => ScrollView(),
+        // "EnsembleAccordion": () => EnsembleAccordion(),
       };
 }

--- a/modules/ensemble/lib/widget/widget_registry.dart
+++ b/modules/ensemble/lib/widget/widget_registry.dart
@@ -193,6 +193,5 @@ class WidgetRegistry {
         // handling common GPT widget mistakes
         "Container": () => Column(),
         "ScrollView": () => ScrollView(),
-        // "EnsembleAccordion": () => EnsembleAccordion(),
       };
 }

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -138,6 +138,7 @@ dependencies:
   # use this convert a language code to localized language name e.g. es => Spanish/Español
   flutter_localized_locales: ^2.0.5
   root_jailbreak_sniffer: ^1.0.6
+  accordion: ^2.6.0
 
 dependency_overrides:
   http: ^0.13.5


### PR DESCRIPTION
requested ticket: https://github.com/EnsembleUI/ensemble/issues/1629

TODO:
- right now  it just supports `items` not `itemTemplate`, will create ticket for that as I tried to implement it for now but it was not happening, maybe I was missing something and it was taking a lot of time. Will work on it in free time.

Example EDL: 
```yaml
Collapsible:
  isAccordion: true
  headerStyle:
    backgroundColor: red
    borderColor: green
    borderColorOpened: red
    backgroundColorOpened: grey
    borderWidth: 5
    borderRadius: 5
  bodyStyle:
    backgroundColor: white
    borderColor: green
    borderWidth: 3
    horizontalPadding: 20
  flipRightIconIfOpen: true
  openAndCloseAnimation: true
  paddingBetweenOpenSections: 10
  paddingBetweenClosedSections: 10
  items:
    - header: 
        Text: 
          text: "Section 1 Heading"
      body: 
        Text: 
          text: "Section 1 body"
      isOpen: true
      leftIcon:
        Icon: 
          name: code
    - header: 
        Text: 
          text: "Section 2 Heading"
      body: 
        Text: 
          text: "Section 2 body"
      headerStyle:
         backgroundColor: green
      bodyStyle:
        backgroundColor: white
        borderColor: green
        borderWidth: 3
        horizontalPadding: 40
        verticalPadding: 80
      onOpenSection: 
        executeCode:
          body: |
            console.log('section 2 open');
      onCloseSection: |
        console.log("Section 2 closed"); 
```