### PR TITLE
Gradle errors while running starter after fresh cloning.

### DIFF
--- a/starter/android/build.gradle
+++ b/starter/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.9.10'
+    ext.javaVersion = JavaVersion.VERSION_1_8
     repositories {
         google()
         mavenCentral()
@@ -31,12 +32,13 @@ subprojects {
                     if (android.namespace == null) {
                         namespace project.group
                     }
+                    compileOptions {
+                        sourceCompatibility javaVersion
+                        targetCompatibility javaVersion
+                    }
                 }
 
-                compileOptions {
-                    sourceCompatibility javaVersion
-                    targetCompatibility javaVersion
-                }
+                
                 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
                     kotlinOptions {
                         jvmTarget = javaVersion.toString()

--- a/starter/android/build.gradle
+++ b/starter/android/build.gradle
@@ -28,9 +28,9 @@ subprojects {
             if (pluginCompileSdk != null && pluginCompileSdk < 34) {
                 project.android {
                     compileSdk 34
-                }
-                if (namespace == null) {
-                    namespace project.group
+                    if (android.namespace == null) {
+                        namespace project.group
+                    }
                 }
 
                 compileOptions {


### PR DESCRIPTION
After Clonning fresh repo,  I was getting below errors, and to make following changes in gradle to make starter run.

1: 
```
* Where:
Build file 'D:\Github\New folder\New folder\ensemble\starter\android\build.gradle' line: 32

* What went wrong:
A problem occurred configuring project ':app_settings'.
> Could not get unknown property 'namespace' for project ':app_settings' of type org.gradle.api.Project.
```
then:
2:
```
* Where:
Build file 'D:\Github\New folder\New folder\ensemble\starter\android\build.gradle' line: 39
* What went wrong:
A problem occurred configuring project ':app_settings'.
> Could not find method compileOptions() for arguments [build_b5l9pxo6pakl15xjn4l9a0pm3$_run_closure2$_closure5$_closure7@3695d42f] on project ':app_settings' of type org.gradle.api.Project.
```
then:
3:
```
* Where:
Build file 'D:\Github\New folder\New folder\ensemble\starter\android\build.gradle' line: 35

* What went wrong:
A problem occurred configuring project ':app_settings'.
> Could not get unknown property 'javaVersion' for object of type com.android.build.gradle.internal.CompileOptions$AgpDecorated.
```

so changed gradle lines a bit, and error got resolved.

Steps to reproduce:
- Clone Ensemble Repo.
- Run following commands:
`melos bootstrap` -> `cd starter` -> `flutter create --org com.ensembleui --project-name starter --platform=ios,android,web .` -> `flutter pub get` -> `flutter run` -> then above erros.