### PR TITLE
https://github.com/EnsembleUI/ensemble/issues/1786 if the date was in…

### DIFF
--- a/modules/ensemble_ts_interpreter/lib/invokables/invokablecommons.dart
+++ b/modules/ensemble_ts_interpreter/lib/invokables/invokablecommons.dart
@@ -237,15 +237,15 @@ class Date extends Object with Invokable, SupportsPrimitiveOperations {
 
   Map<String, Function> getters() {
     return {
-      'time': () => dateTime.millisecondsSinceEpoch,
-      'year': () => dateTime.year,
-      'month': () => dateTime.month - 1, // JavaScript months are zero-based
-      'day': () => dateTime.day,
-      'weekday': () => dateTime.weekday % 7, // JavaScript days are zero-based
-      'hour': () => dateTime.hour,
-      'minute': () => dateTime.minute,
-      'second': () => dateTime.second,
-      'millisecond': () => dateTime.millisecond,
+      'time': () => dateTime.toLocal().millisecondsSinceEpoch,
+      'year': () => dateTime.toLocal().year,
+      'month': () => dateTime.toLocal().month - 1, // JavaScript months are zero-based
+      'day': () => dateTime.toLocal().day,
+      'weekday': () => dateTime.toLocal().weekday % 7, // JavaScript days are zero-based
+      'hour': () => dateTime.toLocal().hour,
+      'minute': () => dateTime.toLocal().minute,
+      'second': () => dateTime.toLocal().second,
+      'millisecond': () => dateTime.toLocal().millisecond,
       'timezoneOffset': () => -dateTime.timeZoneOffset.inMinutes,
       'isoString': () => dateTime.toUtc().toIso8601String(),
       'localDateString': () => dateTime.toLocal().toString().split(' ')[0],
@@ -298,15 +298,15 @@ class Date extends Object with Invokable, SupportsPrimitiveOperations {
 
   Map<String, Function> methods() {
     return {
-      'getTime': () => dateTime.millisecondsSinceEpoch,
-      'getFullYear': () => dateTime.year,
-      'getMonth': () => dateTime.month - 1, // JavaScript months are zero-based
-      'getDate': () => dateTime.day,
-      'getDay': () => dateTime.weekday % 7, // JavaScript days are zero-based
-      'getHours': () => dateTime.hour,
-      'getMinutes': () => dateTime.minute,
-      'getSeconds': () => dateTime.second,
-      'getMilliseconds': () => dateTime.millisecond,
+      'getTime': () => dateTime.toLocal().millisecondsSinceEpoch,
+      'getFullYear': () => dateTime.toLocal().year,
+      'getMonth': () => dateTime.toLocal().month - 1, // JavaScript months are zero-based
+      'getDate': () => dateTime.toLocal().day,
+      'getDay': () => dateTime.toLocal().weekday % 7, // JavaScript days are zero-based
+      'getHours': () => dateTime.toLocal().hour,
+      'getMinutes': () => dateTime.toLocal().minute,
+      'getSeconds': () => dateTime.toLocal().second,
+      'getMilliseconds': () => dateTime.toLocal().millisecond,
       'getTimezoneOffset': () => -dateTime.timeZoneOffset.inMinutes,
       'toISOString': () => dateTime.toUtc().toIso8601String(),
       'toLocaleDateString': _toLocaleDateString,

--- a/modules/ensemble_ts_interpreter/test/new_interpreter_tests.dart
+++ b/modules/ensemble_ts_interpreter/test/new_interpreter_tests.dart
@@ -932,6 +932,52 @@ void main() {
     expect(context['c'], 0);
     expect(context['d'], null);
   });
+  test('dateLocalUtc', () {
+    Map<String, dynamic> context = {};
+    String code = """
+      var date = new Date('2024-12-22T04:49:07.521Z');
+      // Methods
+      var getTime = date.getTime();
+      var getFullYear = date.getFullYear();
+      var getMonth = date.getMonth();
+      var getDate = date.getDate();
+      var getHours = date.getHours();
+      var getMinutes = date.getMinutes();
+      var getSeconds = date.getSeconds();
+      var getDay = date.getDay();
+      var getMilliseconds = date.getMilliseconds();
+      var getUTCTime = date.getTime();
+      var getUTCFullYear = date.getUTCFullYear();
+      var getUTCMonth = date.getUTCMonth();
+      var getUTCDate = date.getUTCDate();
+      var getUTCHours = date.getUTCHours();
+      var getUTCMinutes = date.getUTCMinutes();
+      var getUTCSeconds = date.getUTCSeconds();
+      var getUTCMilliseconds = date.getUTCMilliseconds();
+      var getUTCDay = date.getUTCDay();
+      
+      
+
+      """;
+    JSInterpreter.fromCode(code, SimpleContext(context)).evaluate();
+    DateTime date = DateTime.parse('2024-12-22T04:49:07.521Z');
+    expect(context['getTime'], isNotNull);
+    expect(context['getFullYear'], date.toLocal().year);
+    expect(context['getMonth'], date.toLocal().month - 1);
+    expect(context['getDate'], date.toLocal().day);
+    expect(context['getHours'], date.toLocal().hour);
+    expect(context['getMinutes'], date.toLocal().minute);
+    expect(context['getSeconds'], date.toLocal().second);
+    expect(context['getDay'], date.toLocal().weekday % 7);
+    expect(context['getUTCTime'], isNotNull);
+    expect(context['getUTCFullYear'], date.year);
+    expect(context['getUTCMonth'], date.month - 1);
+    expect(context['getUTCDate'], date.day);
+    expect(context['getUTCHours'], date.hour);
+    expect(context['getUTCMinutes'], date.minute);
+    expect(context['getUTCSeconds'], date.second);
+    expect(context['getUTCDay'], date.weekday % 7);
+  });
   test('datefunction', () {
     Map<String, dynamic> context = {};
     String code = """


### PR DESCRIPTION
…itialized with utc timezone, instead of local date, it was using the utc date when calling getDay and other such related methods. This is correct from Dart's point of view but incorrect from js point of view as js always returns local date's attributes unless specifically asked for utc date