### PR TITLE
conditional import on web implementation

### DIFF
--- a/modules/ensemble/lib/action/save_file/save_file.dart
+++ b/modules/ensemble/lib/action/save_file/save_file.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 import 'dart:io';
 
 import 'package:ensemble/framework/action.dart';
@@ -10,7 +9,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'dart:html' as html;
+
+// Import html conditionally for web platform
+import 'save_file_web.dart' if (dart.library.io) 'save_file_stub.dart';
 
 /// Custom action to save files (images and documents) in platform-specific accessible directories
 class SaveToFileSystemAction extends EnsembleAction {
@@ -142,28 +143,7 @@ class SaveToFileSystemAction extends EnsembleAction {
   }
 
   Future<void> _downloadFileOnWeb(String fileName, Uint8List fileBytes) async {
-    try {
-      // Convert Uint8List to a Blob
-      final blob = html.Blob([fileBytes]);
-
-      // Create an object URL for the Blob
-      final url = html.Url.createObjectUrlFromBlob(blob);
-
-      // Create a download anchor element
-      final anchor = html.AnchorElement(href: url)
-        ..target = 'blank' // Open in a new tab if needed
-        ..download = fileName; // Set the download file name
-
-      // Trigger the download
-      anchor.click();
-
-      // Revoke the object URL to free resources
-      html.Url.revokeObjectUrl(url);
-
-      debugPrint('File downloaded: $fileName');
-    } catch (e) {
-      throw Exception('Failed to download file: $e');
-    }
+    await downloadFileOnWeb(fileName, fileBytes);
   }
 
   /// Factory method to construct the action from JSON

--- a/modules/ensemble/lib/action/save_file/save_file_stub.dart
+++ b/modules/ensemble/lib/action/save_file/save_file_stub.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+Future<void> downloadFileOnWeb(String fileName, Uint8List fileBytes) async {
+  throw UnsupportedError('downloadFileOnWeb is only supported on web platforms.');
+}

--- a/modules/ensemble/lib/action/save_file/save_file_web.dart
+++ b/modules/ensemble/lib/action/save_file/save_file_web.dart
@@ -1,0 +1,27 @@
+import 'dart:html' as html;
+import 'package:flutter/foundation.dart';
+
+Future<void> downloadFileOnWeb(String fileName, Uint8List fileBytes) async {
+  try {
+    // Convert Uint8List to a Blob
+    final blob = html.Blob([fileBytes]);
+
+    // Create an object URL for the Blob
+    final url = html.Url.createObjectUrlFromBlob(blob);
+
+    // Create a download anchor element
+    final anchor = html.AnchorElement(href: url)
+      ..target = 'blank' // Open in a new tab if needed
+      ..download = fileName; // Set the download file name
+
+    // Trigger the download
+    anchor.click();
+
+    // Revoke the object URL to free resources
+    html.Url.revokeObjectUrl(url);
+
+    debugPrint('File downloaded: $fileName');
+  } catch (e) {
+    throw Exception('Failed to download file: $e');
+  }
+}

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -18,7 +18,7 @@ import 'package:ensemble/action/change_locale_actions.dart';
 import 'package:ensemble/action/misc_action.dart';
 import 'package:ensemble/action/navigation_action.dart';
 import 'package:ensemble/action/notification_actions.dart';
-import 'package:ensemble/action/save_file.dart';
+import 'package:ensemble/action/save_file/save_file.dart';
 import 'package:ensemble/action/phone_contact_action.dart';
 import 'package:ensemble/action/sign_in_out_action.dart';
 import 'package:ensemble/action/toast_actions.dart';


### PR DESCRIPTION
Issue:
```
Error: Dart library 'dart:html' is not available on this platform.
import 'dart:html' as html;
       ^
Context: The unavailable library 'dart:html' is imported through these packages:
```

Fix:
Conditional Import of html package