### PR TITLE
add support for firebase auth requirements for apple signon

### DIFF
--- a/modules/auth/lib/signin/auth_manager.dart
+++ b/modules/auth/lib/signin/auth_manager.dart
@@ -41,7 +41,20 @@ class AuthManager with UserAuthentication {
       {required AuthenticatedUser user,
       required String idToken,
       AuthToken? token,
+      /// Optional string but required to complete Firebase Auth Sign-In with Apple flow.
+      ///
+      /// This is the authorization code returned by Apple Sign In and will be used to authenticate with Firebase as the accessToken.
+      ///
+      /// Can be `null` since it only applies to Apple Sign In
+      /// See [Firebase docs](https://firebase.google.com/docs/auth/ios/apple#sign_in_with_apple_and_authenticate_with_firebase) for more information.
+      /// Inspriration from [Mediuam](https://medium.com/@muhammad.fathy/resolving-the-firebase-auth-invalid-credential-invalid-oauth-response-from-apple-com-6bca6b6a8575)
       String? authCode,
+      /// Optional string which, if set, will be be embedded in the resulting `identityToken` for Firebase Auth Sign-In with Apple flow.
+      ///
+      /// This can be used to mitigate replay attacks by using a unique argument per sign-in attempt.
+      ///
+      /// Can be `null`, in which case no nonce will be passed to the request.
+      /// See [Firebase docs](https://firebase.google.com/docs/auth/ios/apple#sign_in_with_apple_and_authenticate_with_firebase) for more information.
       String? rawNonce}) async {
     if (user.provider == null || user.provider == SignInProvider.local) {
       return _signInLocally(context, user: user);
@@ -162,6 +175,7 @@ class AuthManager with UserAuthentication {
       return GoogleAuthProvider.credential(
           idToken: idToken, accessToken: accessToken);
     } else if (client == SignInClient.apple) {
+      /// Supply rawNonce and authCode as the accessToken to complete the  Apple Sign In Flow
       return OAuthProvider('apple.com').credential(idToken: idToken, rawNonce: rawNonce, accessToken: authCode);
     }
     throw RuntimeError("Invalid Sign In Client");

--- a/modules/auth/lib/signin/widget/sign_in_with_apple.dart
+++ b/modules/auth/lib/signin/widget/sign_in_with_apple.dart
@@ -80,7 +80,10 @@ class SignInWithAppleState extends EWidgetState<SignInWithAppleImpl> {
         buttonController: widget._controller,
         onTap: () async {
           try {
+            /// Generate a cryptographically secure nonce for Apple Sign In
             final rawNonce = generateNonce();
+            /// Hash the nonce for later use within the Apple Sign In request for secure verification.
+            /// This is the nonce that will be used to verify the identity token after the user signs in with Apple.
             final nonce = sha256.convert(utf8.encode(rawNonce)).toString();
             final credential =
                 await SignInWithApple.getAppleIDCredential(scopes: [


### PR DESCRIPTION
Updated to support firebase type.  

Inspired by:
https://firebase.google.com/docs/auth/ios/apple#sign_in_with_apple_and_authenticate_with_firebase
https://medium.com/@muhammad.fathy/resolving-the-firebase-auth-invalid-credential-invalid-oauth-response-from-apple-com-6bca6b6a8575


Issue:

I've been able to use Firebase Auth with SignInWithGoogle successfully.  However, SignInWithApple gives the following error when trying to signin using a simulator 

Error:

`flutter: Async Error: [firebase_auth/invalid-credential] Invalid OAuth response from apple.co`