### PR TITLE
Added focus and Scroll for Radio Group & Dropdown

### DIFF
--- a/modules/ensemble/lib/widget/input/dropdown.dart
+++ b/modules/ensemble/lib/widget/input/dropdown.dart
@@ -297,8 +297,24 @@ class SelectOneState extends FormFieldWidgetState<SelectOne>
     });*/
     widget.controller.textEditingController =
         TextEditingController(text: widget.getValue());
+    focusNode.addListener(_handleFocusChange);
 
     super.initState();
+  }
+
+  void _handleFocusChange() {
+      // If gaining focus, scroll into view
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final context = validatorKey.currentContext;
+          if (context != null) {
+            Scrollable.ensureVisible(
+              context,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+              alignment: 0.5,
+            );
+          }
+        });
   }
 
   @override


### PR DESCRIPTION
Now RadioGroup can be focused using `focus()` method through it's id as: `radioGroupId.focus()` and upon focus, the screen will scroll to that field, same for Dropdown.

Demo :
https://github.com/user-attachments/assets/29572609-b7a8-4955-b91d-933c336c13fb


@sharjeelyunus PTAL 