### PR TITLE
flutter 3.29 build issues solved

### DIFF
--- a/modules/auth/pubspec.yaml
+++ b/modules/auth/pubspec.yaml
@@ -39,10 +39,10 @@ dependencies:
 
   get_it: ^8.0.0
   google_sign_in: ^6.1.4
-  sign_in_with_apple: ^5.0.0
+  sign_in_with_apple: ^6.1.4
   firebase_auth: ^5.3.1
   firebase_core: ^3.6.0
-  flutter_web_auth_2: ^2.1.4
+  flutter_web_auth_2: ^4.1.0
   flutter_svg: ^2.0.7
   crypto: ^3.0.3
   # auth0_flutter: ^1.2.1

--- a/modules/ensemble/lib/action/saveFile/save_mobile.dart
+++ b/modules/ensemble/lib/action/saveFile/save_mobile.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:image_gallery_saver/image_gallery_saver.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:vision_gallery_saver/vision_gallery_saver.dart';
 // Conditionally import the file that has `dart:html` vs. the stub:
 import 'download_stub.dart' if (dart.library.html) 'download_web.dart';
 
@@ -11,7 +11,7 @@ Future<void> saveImageToDCIM(String fileName, Uint8List fileBytes) async {
     if (kIsWeb) {
       downloadFileOnWeb(fileName, fileBytes);
     } else {
-      final result = await ImageGallerySaver.saveImage(
+      final result = await VisionGallerySaver.saveImage(
         fileBytes,
         name: fileName,
       );

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -91,9 +91,16 @@ dependencies:
   walletconnect_dart: ^0.0.11
   http_parser: ^4.0.2
   shared_preferences: ^2.1.1
-  workmanager: ^0.5.1
+  workmanager:
+    git:
+      url: https://github.com/fluttercommunity/flutter_workmanager.git
+      ref: main 
+      path: workmanager
   flutter_local_notifications: ^17.2.3
-  image_gallery_saver: ^2.0.3
+  image_gallery_saver:
+    git:
+      url: https://github.com/TheNoumanDev/image_gallery_saver.git
+      ref: flutter_2_29_registrar_fix
   flutter_i18n: ^0.35.1
   pointer_interceptor: ^0.9.3+4
   flutter_secure_storage: ^9.2.2

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   otp_pin_field:
     git:
       url: https://github.com/EnsembleUI/ensemble.git
-      ref: main
+      ref: flutter_3_29_upgrade_fix
       path: modules/otp_pin_field
   form_validator: ^2.1.1
   flutter_svg: ^2.0.7

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   otp_pin_field:
     git:
       url: https://github.com/EnsembleUI/ensemble.git
-      ref: flutter_3_29_upgrade_fix
+      ref: main
       path: modules/otp_pin_field
   form_validator: ^2.1.1
   flutter_svg: ^2.0.7
@@ -97,10 +97,7 @@ dependencies:
       ref: main 
       path: workmanager
   flutter_local_notifications: ^17.2.3
-  image_gallery_saver:
-    git:
-      url: https://github.com/TheNoumanDev/image_gallery_saver.git
-      ref: flutter_2_29_registrar_fix
+  vision_gallery_saver: ^2.0.1
   flutter_i18n: ^0.35.1
   pointer_interceptor: ^0.9.3+4
   flutter_secure_storage: ^9.2.2

--- a/modules/ensemble_bluetooth/pubspec.yaml
+++ b/modules/ensemble_bluetooth/pubspec.yaml
@@ -24,7 +24,11 @@ dependencies:
 
   collection: ^1.17.1
   flutter_blue_plus: ^1.33.4
-  workmanager: ^0.5.2
+  workmanager:
+    git:
+      url: https://github.com/fluttercommunity/flutter_workmanager.git
+      ref: main 
+      path: workmanager
   permission_handler: ^11.3.1
 
 dev_dependencies:

--- a/modules/otp_pin_field/android/build.gradle
+++ b/modules/otp_pin_field/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.shivam.otp_pin_field'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '2.1.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -43,7 +43,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/modules/otp_pin_field/android/src/main/kotlin/com/shivam/otp_pin_field/AppSignatureHelper.kt
+++ b/modules/otp_pin_field/android/src/main/kotlin/com/shivam/otp_pin_field/AppSignatureHelper.kt
@@ -49,20 +49,21 @@ class AppSignatureHelper(context: Context?) : ContextWrapper(context) {
                 // Get all package signatures for the current package
                 val packageName: String = packageName
                 val packageManager: PackageManager = packageManager
-                val signatures: Array<Signature> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        packageManager.getPackageInfo(
-                            packageName,
-                            PackageManager.GET_SIGNING_CERTIFICATES
-                        ).signingInfo.apkContentsSigners
-                    } else {
-                        packageManager.getPackageInfo(
-                            packageName,
-                            PackageManager.GET_SIGNATURES
-                        ).signatures
-                    }
+                val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    packageManager.getPackageInfo(
+                        packageName,
+                        PackageManager.GET_SIGNING_CERTIFICATES
+                    ).signingInfo?.apkContentsSigners?.let { Array(it.size) { i -> it[i] } } ?: emptyArray()
+                } else {
+                    @Suppress("DEPRECATION")
+                    packageManager.getPackageInfo(
+                        packageName,
+                        PackageManager.GET_SIGNATURES
+                    ).signatures
+                }
 
-                // For each signature create a compatible hash
-                for (signature in signatures) {
+                // Updated this part to handle null safety
+                signatures?.forEach { signature ->
                     val hash = hash(packageName, signature.toCharsString())
                     if (hash != null) {
                         appCodes.add(String.format("%s", hash))

--- a/modules/otp_pin_field/android/src/main/kotlin/com/shivam/otp_pin_field/OtpPinFieldPlugin.kt
+++ b/modules/otp_pin_field/android/src/main/kotlin/com/shivam/otp_pin_field/OtpPinFieldPlugin.kt
@@ -44,12 +44,6 @@ class OtpPinFieldPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
     constructor()
 
-    private constructor(registrar: PluginRegistry.Registrar) {
-        activity = registrar.activity()
-        setupChannel(registrar.messenger())
-        registrar.addActivityResultListener(activityResultListener)
-    }
-
     fun setCode(code: String?) {
         channel?.invokeMethod("smsCode", code)
     }
@@ -178,9 +172,5 @@ class OtpPinFieldPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
     companion object {
         private const val channelName = "otp_pin_field"
-
-        fun registerWith(registrar: PluginRegistry.Registrar) {
-            OtpPinFieldPlugin(registrar)
-        }
     }
 }

--- a/modules/otp_pin_field/pubspec.yaml
+++ b/modules/otp_pin_field/pubspec.yaml
@@ -4,9 +4,9 @@ version: 1.2.2
 homepage: https://github.com/shivbo96/otp_pin_field
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"  # Update to match your Dart version
-  flutter: ">=3.29.0"
-  
+  sdk: ">=3.5.0"
+  flutter: ">=3.24.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/modules/otp_pin_field/pubspec.yaml
+++ b/modules/otp_pin_field/pubspec.yaml
@@ -4,9 +4,9 @@ version: 1.2.2
 homepage: https://github.com/shivbo96/otp_pin_field
 
 environment:
-  sdk: ">=3.5.0"
-  flutter: ">=3.24.0"
-
+  sdk: ">=3.7.0 <4.0.0"  # Update to match your Dart version
+  flutter: ">=3.29.0"
+  
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Flutter 3.29 comes with deprecation of many plugins

### Workmanager Package Changes:
- Changed from pub.dev package (0.5.2) to direct git reference because:
  1. The pub version uses deprecated Flutter plugin registration system (`Registrar` and `PluginRegistrantCallback`)
  2. Flutter 3.29.0 removed these deprecated APIs in favor of new embedding system
  3. The git main branch has updated code using new Flutter plugin APIs but new version has not been published to pub.dev with these updates yet, for that issue is there (https://github.com/fluttercommunity/flutter_workmanager/issues/588)

### Changes in OTP Pin Field Package:
- Removed `registerWith` method and `Registrar` constructor.
- Added null safety check for `signingInfo.apkContentsSigners` to fix type mismatch errors
- No changes to core feature implementation or business logic


### `image_gallery_saver` Package:
- Original package (2.0.3) not maintained and has Flutter 3.29.0 compatibility issues
- Created temporary fork and branch `flutter_2_29_registrar_fix` with required updates
- Removed deprecated plugin registration system and fixed for new Flutter embedding
- Note: will put a PR for the original package, but that package is no more maintained as it already have a lot of pending PRs.