### PR TITLE
feat(maps): add fixedMarker and draggableMarker functionality to Map Widget

### DIFF
--- a/modules/location/lib/widget/maps/maps.dart
+++ b/modules/location/lib/widget/maps/maps.dart
@@ -87,6 +87,8 @@ class EnsembleMapWidget extends StatefulWidget
       'mapType': (value) => _controller.mapType = value,
       'fixedMarker': (value) =>
           _controller.fixedMarker = Utils.getBool(value, fallback: false),
+      'draggableMarker': (value) =>
+          _controller.draggableMarker = Utils.getBool(value, fallback: false),
       'markers': (markerData) => setMarkers(markerData),
       'scrollableMarkerOverlay': (value) => _controller
               .scrollableMarkerOverlay =
@@ -188,6 +190,7 @@ class MyController extends WidgetController with LocationCapability {
   bool zoomEnabled = true;
 
   bool fixedMarker = false;
+  bool draggableMarker = false;
 
   // toolbar has multiple button options
   bool showToolbar = true;

--- a/modules/location/lib/widget/maps/maps.dart
+++ b/modules/location/lib/widget/maps/maps.dart
@@ -85,10 +85,10 @@ class EnsembleMapWidget extends StatefulWidget
           _controller.toolbarRight = Utils.optionalInt(value, min: 0),
 
       'mapType': (value) => _controller.mapType = value,
-      'fixedMarker': (value) =>
-          _controller.fixedMarker = Utils.getBool(value, fallback: false),
-      'draggableMarker': (value) =>
-          _controller.draggableMarker = Utils.getBool(value, fallback: false),
+      'fixedMarker': (value) => _controller.fixedMarker =
+          Utils.getBool(value, fallback: _controller.fixedMarker),
+      'draggableMarker': (value) => _controller.draggableMarker =
+          Utils.getBool(value, fallback: _controller.draggableMarker),
       'markers': (markerData) => setMarkers(markerData),
       'scrollableMarkerOverlay': (value) => _controller
               .scrollableMarkerOverlay =

--- a/modules/location/lib/widget/maps/maps.dart
+++ b/modules/location/lib/widget/maps/maps.dart
@@ -85,6 +85,8 @@ class EnsembleMapWidget extends StatefulWidget
           _controller.toolbarRight = Utils.optionalInt(value, min: 0),
 
       'mapType': (value) => _controller.mapType = value,
+      'fixedMarker': (value) =>
+          _controller.fixedMarker = Utils.getBool(value, fallback: false),
       'markers': (markerData) => setMarkers(markerData),
       'scrollableMarkerOverlay': (value) => _controller
               .scrollableMarkerOverlay =
@@ -184,6 +186,8 @@ class MyController extends WidgetController with LocationCapability {
   bool scrollEnabled = true;
   bool tiltEnabled = true;
   bool zoomEnabled = true;
+
+  bool fixedMarker = false;
 
   // toolbar has multiple button options
   bool showToolbar = true;

--- a/modules/location/lib/widget/maps/maps.dart
+++ b/modules/location/lib/widget/maps/maps.dart
@@ -189,7 +189,9 @@ class MyController extends WidgetController with LocationCapability {
   bool tiltEnabled = true;
   bool zoomEnabled = true;
 
+  // Determines whether the marker remains fixed at the center of the map when the user moves the map.
   bool fixedMarker = false;
+  // Determines whether the marker can be dragged by the user.
   bool draggableMarker = false;
 
   // toolbar has multiple button options

--- a/modules/location/lib/widget/maps/maps_state.dart
+++ b/modules/location/lib/widget/maps/maps_state.dart
@@ -264,6 +264,10 @@ class EnsembleMapState extends MapsActionableState
             position: markerPayload.latLng,
             icon: markerAsset ?? BitmapDescriptor.defaultMarker,
             consumeTapEvents: true,
+            draggable: widget.controller.draggableMarker,
+            onDrag: (latLng) {
+              _moveCamera(latLng);
+            },
             onTap: () {
               _selectMarker(markerId);
 
@@ -618,6 +622,10 @@ class EnsembleMapState extends MapsActionableState
           markerId: const MarkerId("fixed_marker"),
           position: _fixedMarker.position,
           icon: _fixedMarker.icon ?? BitmapDescriptor.defaultMarker,
+          draggable: widget.controller.draggableMarker,
+          onDrag: (position) {
+            _moveCamera(position);
+          },
         ));
       } else {
         if (markerPayload.marker != null) {

--- a/modules/location/lib/widget/maps/maps_state.dart
+++ b/modules/location/lib/widget/maps/maps_state.dart
@@ -12,7 +12,6 @@ import 'package:ensemble/layout/templated.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/debouncer.dart';
 import 'package:ensemble/util/utils.dart';
-import 'package:ensemble/widget/shape.dart';
 import 'package:ensemble_location/location_manager.dart';
 import 'package:ensemble_location/widget/maps/custom_marker_pin.dart';
 import 'package:ensemble_location/widget/maps/map_actions.dart';
@@ -627,10 +626,8 @@ class EnsembleMapState extends MapsActionableState
             _moveCamera(position);
           },
         ));
-      } else {
-        if (markerPayload.marker != null) {
-          markers.add(markerPayload.marker!);
-        }
+      } else if (markerPayload.marker != null) {
+        markers.add(markerPayload.marker!);
       }
     }
 


### PR DESCRIPTION
fixes: https://github.com/EnsembleUI/ensemble/issues/1764

### Changes
- Added `fixedMarker` and `draggableMarker` properties to the Map widget.
- `fixedMarker`: When enabled, this keeps the marker fixed at the center of the map, following the movement of the map as the user moves.
- `draggableMarker`: When enabled, this allows the marker to be dragged by the user to any location on the map.
- The updated latitude and longitude of the marker can be accessed via the `onCameraMove` action.
 
### Examples
`fixedMarker`
https://github.com/user-attachments/assets/5ab2fdda-dce3-4f70-9161-6edc2babd362

`draggableMarker`
https://github.com/user-attachments/assets/1184df6f-f1dd-4041-b7a3-2a631939d762

