### PR TITLE
[1882] Fixed External links are not opening in a webview for Android

### DIFF
--- a/modules/ensemble/lib/widget/webview/native/webviewstate.dart
+++ b/modules/ensemble/lib/widget/webview/native/webviewstate.dart
@@ -233,7 +233,6 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
               () => widget.controller.error = "Error loading html content");
         },
         onCreateWindow: (controller, createWindowAction) async {
-          print('onCreateWindow: ${createWindowAction.request.url}');
           // Get the URL from the creation request
           final url = createWindowAction.request.url?.toString();
           if (url != null) {
@@ -244,8 +243,6 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
         },
         shouldOverrideUrlLoading: (controller, navigationAction) async {
           final url = navigationAction.request.url?.toString() ?? '';
-          print('shouldOverrideUrlLoading: $url');
-          // Rest of your existing navigation handling
           WebViewNavigationEvent event = WebViewNavigationEvent(widget, url);
           if (widget.controller.onNavigationRequest != null) {
             ScreenController().executeAction(

--- a/modules/ensemble/lib/widget/webview/native/webviewstate.dart
+++ b/modules/ensemble/lib/widget/webview/native/webviewstate.dart
@@ -146,41 +146,39 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
                 headers: widget.controller.headers,
               )
             : null,
-        initialOptions: InAppWebViewGroupOptions(
-          crossPlatform: InAppWebViewOptions(
-            useShouldOverrideUrlLoading: true,
-            mediaPlaybackRequiresUserGesture: false,
-            javaScriptEnabled: true,
-            useOnLoadResource: true,
-            clearCache: true,
-            transparentBackground: true,
-            supportZoom: true,
-            preferredContentMode: UserPreferredContentMode.MOBILE,
-          ),
-          android: AndroidInAppWebViewOptions(
-            useHybridComposition: true,
-            hardwareAcceleration: true,
-            mixedContentMode:
-                AndroidMixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
-            safeBrowsingEnabled: false,
-            domStorageEnabled: true,
-            databaseEnabled: true,
-            supportMultipleWindows: true,
-            builtInZoomControls: true,
-            displayZoomControls: false,
-            allowFileAccess: true,
-            useWideViewPort: true,
-            allowContentAccess: true,
-            loadWithOverviewMode: true,
-          ),
-          ios: IOSInAppWebViewOptions(
-            allowsInlineMediaPlayback: true,
-            allowsBackForwardNavigationGestures: true,
-            enableViewportScale: true,
-            suppressesIncrementalRendering: false,
-            allowsPictureInPictureMediaPlayback: true,
-            isFraudulentWebsiteWarningEnabled: false,
-          ),
+        initialSettings: InAppWebViewSettings(
+          // Cross Platform Settings
+          useShouldOverrideUrlLoading: true,
+          mediaPlaybackRequiresUserGesture: false,
+          javaScriptEnabled: true,
+          useOnLoadResource: true,
+          transparentBackground: true,
+          supportZoom: true,
+          clearCache: true,
+          preferredContentMode: UserPreferredContentMode.MOBILE,
+
+          // Android Specific Settings
+          useHybridComposition: true,
+          hardwareAcceleration: true,
+          mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+          safeBrowsingEnabled: false,
+          domStorageEnabled: true,
+          databaseEnabled: true,
+          supportMultipleWindows: true,
+          builtInZoomControls: true,
+          displayZoomControls: false,
+          allowFileAccess: true,
+          useWideViewPort: true,
+          allowContentAccess: true,
+          loadWithOverviewMode: true,
+
+          // iOS Specific Settings
+          allowsInlineMediaPlayback: true,
+          allowsBackForwardNavigationGestures: true,
+          enableViewportScale: true,
+          suppressesIncrementalRendering: false,
+          allowsPictureInPictureMediaPlayback: true,
+          isFraudulentWebsiteWarningEnabled: false,
         ),
         gestureRecognizers: gestureRecognizers,
         onWebViewCreated: (controller) async {
@@ -234,9 +232,20 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
           setState(
               () => widget.controller.error = "Error loading html content");
         },
+        onCreateWindow: (controller, createWindowAction) async {
+          print('onCreateWindow: ${createWindowAction.request.url}');
+          // Get the URL from the creation request
+          final url = createWindowAction.request.url?.toString();
+          if (url != null) {
+            // Load the URL in the current WebView instead of creating a new window
+            await controller.loadUrl(urlRequest: URLRequest(url: WebUri(url)));
+          }
+          return true;
+        },
         shouldOverrideUrlLoading: (controller, navigationAction) async {
           final url = navigationAction.request.url?.toString() ?? '';
-
+          print('shouldOverrideUrlLoading: $url');
+          // Rest of your existing navigation handling
           WebViewNavigationEvent event = WebViewNavigationEvent(widget, url);
           if (widget.controller.onNavigationRequest != null) {
             ScreenController().executeAction(


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1882

- Fixed that bug for Android.
- Also removed the deprecated properties and used the new ones.

Test:
- On Android opening external links other then the one we pass at the begining.
- Tested the same for iOS.
- Also tested webview with KPN Inhome.