### PR TITLE
fix: ensure EnsembleConfigService is initialized before accessing config

### DIFF
--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -106,6 +106,7 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
     try {
       // this code block is guaranteed to run at most once
       await StorageManager().init();
+      await SecretsStore().initialize();
       Device().initDeviceInfo();
       AppInfo().initPackageInfo(_config);
       _completer!.complete();
@@ -139,9 +140,10 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
     if (_config != null) {
       return Future<EnsembleConfig>.value(_config);
     }
-    // Intialize the config service to get `ensemble-config.yaml` file to access the configuration using static property as `EnsembleConfigService.config`
-    await EnsembleConfigService.initialize();
-    await SecretsStore().initialize();
+    // Initialize the config service to get `ensemble-config.yaml` file to access the configuration using static property as `EnsembleConfigService.config`
+    if (!EnsembleConfigService.isInitialized) {
+      await EnsembleConfigService.initialize();
+    }
 
     // get the config YAML
     final YamlMap yamlMap = EnsembleConfigService.config;

--- a/modules/ensemble/lib/framework/ensemble_config_service.dart
+++ b/modules/ensemble/lib/framework/ensemble_config_service.dart
@@ -4,16 +4,26 @@ import 'package:yaml/yaml.dart';
 // EnsembleConfigService is a service that provides access to the ensemble-config.yaml file through static property once initialized
 class EnsembleConfigService {
   static YamlMap? _config;
+  static bool _isInitialized = false;
 
   static Future<void> initialize() async {
     final yamlString = await rootBundle.loadString('ensemble/ensemble-config.yaml');
     _config = loadYaml(yamlString);
+    _isInitialized = true;
   }
 
   static YamlMap get config {
     if (_config == null) {
-      throw StateError('EnsembleConfig not initialized');
+      // if config is not available, load the default config
+      _config = loadYaml('''
+definitions:
+  from: 'ensemble'
+      ''');
+      _isInitialized =
+          true;
     }
     return _config!;
   }
+
+  static bool get isInitialized => _isInitialized;
 }

--- a/modules/ensemble/lib/framework/secrets.dart
+++ b/modules/ensemble/lib/framework/secrets.dart
@@ -28,6 +28,9 @@ class SecretsStore with Invokable {
 
       // add local overrides
       try {
+        if (!EnsembleConfigService.isInitialized) {
+          await EnsembleConfigService.initialize();
+        }
         String provider = EnsembleConfigService.config["definitions"]?['from'];
         if (provider == 'local') {
           String path =


### PR DESCRIPTION
Before updated structure for local provider, the config used to be null for preview app, and we were allowing it to proceed. 

But now, we were throwing an error, that's why it was causing issues with the preview app as it doesn't have config, and we are accessing it in some places just to check whether it's a local or ensemble provider. 

That's why we need the config now. So, instead of throwing an error, we are now sending the default.