### PR TITLE
fix: include useAuth in module initialization check

### DIFF
--- a/starter/lib/generated/ensemble_modules.dart
+++ b/starter/lib/generated/ensemble_modules.dart
@@ -89,9 +89,9 @@ class EnsembleModules {
   Future<void> init() async {
     // Note that notifications is not a module
 
-    if (useMoEngage || useNotifications || useFirebaseAnalytics) {
+    if (useMoEngage || useNotifications || useFirebaseAnalytics || useAuth) {
       // if payload is not passed, Firebase configuration files
-      // are required to be added manualy to iOS and Android
+      // are required to be added manually to iOS and Android
       try {
         await Firebase.initializeApp();
       } catch (e) {


### PR DESCRIPTION
Auth module was initializing firebase differently then the other modules, and if user only enable the Auth module, it causes the duplicate firebase app error
<img src="https://github.com/user-attachments/assets/e7e92bc8-8057-449c-92bc-6718cbcfc57e" height="250">
This PR insures, to initialize the user firebase app before running the ensemble firebase
