### PR TITLE
TabBar Item will now evalute string expressions

### DIFF
--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -108,6 +108,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
 
   Widget _buildTabWidget(ScopeManager? scopeManager, TabItem tabItem) {
     final tabWidget = tabItem.tabWidget;
+    final label = scopeManager!.dataContext.eval(tabItem.label);
     if (scopeManager != null && tabWidget != null) {
       final customWidget = scopeManager.buildWidgetFromDefinition(tabWidget);
       return Tab(
@@ -115,7 +116,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
       );
     }
     return Tab(
-      text: tabItem.label,
+      text: label,
       icon:
           tabItem.icon != null ? ensemble.Icon.fromModel(tabItem.icon!) : null,
     );


### PR DESCRIPTION
Github ticket: https://github.com/EnsembleUI/ensemble/issues/1876
String Expressions was not being passed into ```ScopeManager.DataContext.eval()```.
Passing through it before rendering fixed the issue.
for this yaml code:
```
View:
  header:
    titleText: TaBBar Test
  onLoad: |
    ensemble.storage.activeOrders = [
      1,2,3,4,5
    ];
  body:
    TabBar:
      items:
        - label: Active ${ensemble.storage.activeOrders.length}
          widget:
            Text:
              text: ${ensemble.storage.activeOrders.length}

        - label: Completed ${ 1 + 2 }
          widget:
            Text:
              text: ${ 1 + 2 }
```
![image](https://github.com/user-attachments/assets/301257a4-7bc5-4540-b302-b54644a5839d)
