### PR TITLE
[1874] Added key to widgets

### DIFF
--- a/modules/ensemble/lib/framework/ensemble_widget.dart
+++ b/modules/ensemble/lib/framework/ensemble_widget.dart
@@ -55,6 +55,15 @@ abstract class EnsembleWidgetState<W extends EnsembleWidget> extends State<W> {
 
       Widget rtn = buildWidget(context);
 
+      // Add KeyedSubtree with ValueKey based on testId to make widget findable in tests using find.byKey()
+      if (widgetController.testId != null &&
+          widgetController.testId!.isNotEmpty) {
+        rtn = KeyedSubtree(
+          key: ValueKey(widgetController.testId!),
+          child: rtn,
+        );
+      }
+
       if (widgetController.textDirection != null) {
         rtn = Directionality(
             textDirection: widgetController.textDirection!, child: rtn);

--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -62,6 +62,15 @@ abstract class EWidgetState<W extends HasController>
     if (widget.controller is WidgetController) {
       WidgetController widgetController = widget.controller as WidgetController;
 
+      // Add KeyedSubtree with ValueKey based on testId to make widget findable in tests using find.byKey()
+      if (widgetController.testId != null &&
+          widgetController.testId!.isNotEmpty) {
+        rtn = KeyedSubtree(
+          key: ValueKey(widgetController.testId!),
+          child: rtn,
+        );
+      }
+
       if (widgetController.textDirection != null) {
         rtn = Directionality(
             textDirection: widgetController.textDirection!, child: rtn);


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1874

- Used existing `testId` property in Ensemble widgets.
- Wrap returned widget with [KeyedSubtree](http://api.flutter.dev/flutter/widgets/KeyedSubtree-class.html), using `testId` as its key.

Example EDL:
```yaml
Button:
  testId: navigate_button
  label: Navigate to Goodbye Screen
  onTap:
    navigateScreen:
      name: Goodbye
```
Example Flutter Test code:
```dart
final navigateButtonFinder = find.byKey(
          ValueKey('navigate_button'), 
          skipOffstage: false
        );
```
https://github.com/user-attachments/assets/e11ccf42-a6fb-4f5c-a6e6-c22c71f6b211

