### PR TITLE
Fix: Opacity Crashing for integer value

### DIFF
--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -100,7 +100,7 @@ abstract class EWidgetState<W extends HasController>
         rtn = AnimatedOpacity(
             // If visible, apply opacity if specified, else default to 1
             opacity: widgetController.visible != false
-                ? (Utils.getValidOpacity(widgetController.opacity ?? 1) ?? 1)
+                ? (Utils.optionalDouble(widgetController.opacity ?? 1, min: 0, max: 1.0) ?? 1)
                 : 0,
             duration: widgetController.visibilityTransitionDuration!,
             child: rtn);
@@ -116,7 +116,7 @@ abstract class EWidgetState<W extends HasController>
       if (widgetController.visibilityTransitionDuration == null &&
           widgetController.opacity != null) {
         rtn = Opacity(
-          opacity: Utils.getValidOpacity(widgetController.opacity!) ?? 1,
+          opacity: Utils.optionalDouble(widgetController.opacity!, min: 0, max: 1.0) ?? 1.0,
           child: rtn,
         );
       }

--- a/modules/ensemble/lib/util/utils.dart
+++ b/modules/ensemble/lib/util/utils.dart
@@ -694,13 +694,6 @@ class Utils {
     return textAlign;
   }
 
-  static double? getValidOpacity(double opacity) {
-    if (opacity < 0 || opacity > 1) {
-      return 1;
-    } else {
-      return opacity;
-    }
-  }
 
   static Curve? getCurve(String? curveType) {
     Curve? curve;

--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -261,7 +261,7 @@ abstract class WidgetController extends Controller with HasStyles {
       'flex': (value) => flex = Utils.optionalInt(value, min: 1),
       'expanded': (value) => expanded = Utils.getBool(value, fallback: false),
       'visible': (value) => visible = Utils.getBool(value, fallback: true),
-      'opacity': (value) => opacity = Utils.getValidOpacity(value),
+      'opacity': (value) => opacity = Utils.optionalDouble(value, min: 0, max: 1),
       'visibilityTransitionDuration': (value) =>
           visibilityTransitionDuration = Utils.getDuration(value),
       'elevation': (value) =>
@@ -487,7 +487,7 @@ abstract class EnsembleWidgetController extends EnsembleController
       'flexMode': (value) => flexMode = FlexMode.values.from(value),
       'flex': (value) => flex = Utils.optionalInt(value, min: 1),
       'visible': (value) => visible = Utils.getBool(value, fallback: true),
-      'opacity': (value) => opacity = Utils.getValidOpacity(value),
+      'opacity': (value) => opacity = Utils.optionalDouble(value, min: 0, max: 1),
       'visibilityTransitionDuration': (value) =>
           visibilityTransitionDuration = Utils.getDuration(value),
       'textDirection': (value) => textDirection = Utils.getTextDirection(value),


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1841

Testing Schema:
- For double opacity:
```
- Form:
            id: getStartedForm
            onSubmit:
              executeCode:
                body: |
                    console.log(test.value);
            styles:
              gap: 24
            children:
              - TextInput:
                  opacity: 0.3
                  styles: 
                  id: test
                  label: hello
              - TextInput:
                  id: test1
                  label: world
              - Button: 
                  label: submit
                  submitForm: true
```
<img src="https://github.com/user-attachments/assets/6f519187-86f7-4c00-931d-19adb638bde4" width="250px" />

- For Integer Opacity:
```
- Form:
            id: getStartedForm
            onSubmit:
              executeCode:
                body: |
                    console.log(test.value);
            styles:
              gap: 24
            children:
              - TextInput:
                  opacity: 1
                  styles: 
                  id: test
                  label: hello
              - TextInput:
                  id: test1
                  label: world
              - Button: 
                  label: submit
                  submitForm: true
```
<img src="https://github.com/user-attachments/assets/ee1ed001-fae3-4cbc-bf5e-9f7306ea3883" width="250px" />

CC: @ridsashabbir @sharjeelyunus 

