### PR TITLE
fix(notification_manager): initialize message handling on startup

### DIFF
--- a/modules/ensemble/lib/framework/notification_manager.dart
+++ b/modules/ensemble/lib/framework/notification_manager.dart
@@ -31,6 +31,7 @@ class NotificationManager {
     if (!_init) {
       _initListener(
           backgroundNotificationHandler: backgroundNotificationHandler);
+      initGetInitialMessage();
       _init = true;
     }
   }
@@ -78,7 +79,6 @@ class NotificationManager {
 
     /// This is when the app is in the foreground
     FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
-
       if (!isMoEngageNotification(message)) {
         // Handle regular FCM notifications as before
         Ensemble.externalDataContext.addAll({


### PR DESCRIPTION
Notifications are not functioning properly when the app is in a terminated state. The user receives the notification, but when they click on it, the app opens without passing any data. As a result, no action can be performed.