### PR TITLE
added correctlyInstalled property in deviceSecurity action

### DIFF
--- a/modules/ensemble/lib/action/device_security.dart
+++ b/modules/ensemble/lib/action/device_security.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:root_jailbreak_sniffer/rjsniffer.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter_security_checker/flutter_security_checker.dart';
 import 'package:ensemble/framework/event.dart';
 
 class DeviceSecurity extends EnsembleAction with Invokable {
@@ -19,7 +20,7 @@ class DeviceSecurity extends EnsembleAction with Invokable {
   @override
   Future<void> execute(BuildContext context, ScopeManager scopeManager) async {
     if (kIsWeb) {
-      _handleSuccess(context, false, false, false,
+      _handleSuccess(context, false, false, false,false,
           'This information is not available on the web');
       return;
     }
@@ -29,15 +30,16 @@ class DeviceSecurity extends EnsembleAction with Invokable {
       bool isRooted = await Rjsniffer.amICompromised() ?? false;
       bool isDebugged = await Rjsniffer.amIDebugged() ?? false;
       bool isEmulator = await Rjsniffer.amIEmulator() ?? false;
+      bool hasCorrectlyInstalled = await FlutterSecurityChecker.hasCorrectlyInstalled;
 
-      _handleSuccess(context, isRooted, isDebugged, isEmulator, 'success');
+      _handleSuccess(context, isRooted, isDebugged, isEmulator, hasCorrectlyInstalled, 'success');
     } catch (e) {
       _handleError(context, e);
     }
   }
 
   void _handleSuccess(BuildContext context, bool isRooted, bool isDebugged,
-      bool isEmulator, String message) {
+      bool isEmulator, bool hasCorrectlyInstalled, String message) {
     if (onSuccess != null) {
       ScreenController().executeAction(
         context,
@@ -48,6 +50,7 @@ class DeviceSecurity extends EnsembleAction with Invokable {
             'debugged': isDebugged,
             'rooted': isRooted,
             'emulator': isEmulator,
+            'tampered': !hasCorrectlyInstalled, // if not correctly installed, then it's tempered
             'message': message,
           },
         ),

--- a/modules/ensemble/lib/action/device_security.dart
+++ b/modules/ensemble/lib/action/device_security.dart
@@ -50,7 +50,7 @@ class DeviceSecurity extends EnsembleAction with Invokable {
             'debugged': isDebugged,
             'rooted': isRooted,
             'emulator': isEmulator,
-            'tampered': !hasCorrectlyInstalled, // if not correctly installed, then it's tempered
+            'correctlyInstalled': hasCorrectlyInstalled,
             'message': message,
           },
         ),

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -148,6 +148,7 @@ dependencies:
   accordion: ^2.6.0
   session_storage: ^0.0.1
   connectivity_plus: ^6.1.3
+  flutter_security_checker: ^3.2.1
 
 dependency_overrides:
   http: ^0.13.5


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1898

Added `correctlyInstalled` property in `deviceSecurity` action to check whether the app is downloaded from official sources.

Testing EDL:
```
Button:
            label: Check Device Security
            onTap:
              deviceSecurity:
                onSuccess:
                   executeCode:
                      body: |-
                        console.log('Device is tempered: ' + event.data.correctlyInstalled);
```

Note: I tested in debug mode so I will always get `false` in response, We can test this property correctly on deployed apps.
CC: @sharjeelyunus 