### PR TITLE
Fix: dispose existing camera controller before initializing a new one

### DIFF
--- a/modules/camera/lib/camera.dart
+++ b/modules/camera/lib/camera.dart
@@ -351,6 +351,12 @@ class CameraState extends EWidgetState<Camera> with WidgetsBindingObserver {
   }
 
   Future<void> setCamera({CameraDescription? cameraDescription}) async {
+    // If a camera controller has already been initialized, dispose it.
+    if (widget._controller.cameraController != null) {
+      await widget._controller.cameraController!.dispose();
+      widget._controller.cameraController = null;
+    }
+
     CameraDescription targetCamera = cameraDescription ?? cameras[0];
 
     widget._controller.cameraController = CameraController(


### PR DESCRIPTION
Basically the issue was, when we open camera first time, and then closing it, it wasn't disposing the camera, so when we open it again the camera was locked so it was throwing error. This is happening only on android web, and only in release mode.

REF: https://discord.com/channels/1031982848485359626/1345056316141600798