### PR TITLE
List view gap

### DIFF
--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -246,10 +246,12 @@ class ListViewState extends EWidgetState<ListView>
           }
         }
         if (itemWidget != null) {
-          return widget._controller.onItemTap == null
-              ? itemWidget
-              : flutter.InkWell(
-                  onTap: () => _onItemTapped(index), child: itemWidget);
+          return Padding(
+            padding: EdgeInsets.symmetric(vertical: Utils.getDouble(widget._controller.gap, fallback: 0)),
+            child: widget._controller.onItemTap == null
+                ? itemWidget
+                : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget),
+          );
         }
         return const SizedBox.shrink();
       },

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -246,8 +246,7 @@ class ListViewState extends EWidgetState<ListView>
           }
         }
         if (itemWidget != null) {
-          return (index < (widget._controller.children?.length ?? 0) +
-              (templatedDataList?.length ?? 0) - 1) ? Padding(
+          return index < (itemCount-1) ? Padding(
             padding: EdgeInsets.only(bottom: Utils.getDouble(widget._controller.gap, fallback: 0)),
             child: widget._controller.onItemTap == null
                 ? itemWidget

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -246,14 +246,16 @@ class ListViewState extends EWidgetState<ListView>
           }
         }
         if (itemWidget != null) {
-          return index < (itemCount-1) ? Padding(
-            padding: EdgeInsets.only(bottom: Utils.getDouble(widget._controller.gap, fallback: 0)),
-            child: widget._controller.onItemTap == null
-                ? itemWidget
-                : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget),
-          ): widget._controller.onItemTap == null
+          Widget wrappedItem = widget._controller.onItemTap == null
               ? itemWidget
               : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget);
+
+          return index < (itemCount - 1)
+              ? Padding(
+            padding: EdgeInsets.only(bottom: Utils.getDouble(widget._controller.gap, fallback: 0)),
+            child: wrappedItem,
+          )
+              : wrappedItem;
         }
         return const SizedBox.shrink();
       },

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -246,12 +246,15 @@ class ListViewState extends EWidgetState<ListView>
           }
         }
         if (itemWidget != null) {
-          return Padding(
+          return (index < (widget._controller.children?.length ?? 0) +
+              (templatedDataList?.length ?? 0) - 1) ? Padding(
             padding: EdgeInsets.only(bottom: Utils.getDouble(widget._controller.gap, fallback: 0)),
             child: widget._controller.onItemTap == null
                 ? itemWidget
                 : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget),
-          );
+          ): widget._controller.onItemTap == null
+              ? itemWidget
+              : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget);
         }
         return const SizedBox.shrink();
       },

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -247,7 +247,7 @@ class ListViewState extends EWidgetState<ListView>
         }
         if (itemWidget != null) {
           return Padding(
-            padding: EdgeInsets.symmetric(vertical: Utils.getDouble(widget._controller.gap, fallback: 0)),
+            padding: EdgeInsets.only(bottom: Utils.getDouble(widget._controller.gap, fallback: 0)),
             child: widget._controller.onItemTap == null
                 ? itemWidget
                 : flutter.InkWell(onTap: () => _onItemTapped(index), child: itemWidget),


### PR DESCRIPTION
Github ticket: https://github.com/EnsembleUI/ensemble/issues/1817

ListView `styles` has `gap` Property that adds vertical padding between children 
Note that property adds gap below the element except for the last item.

Yaml:
```
View:
  header:
    title: Listview
  onLoad:
    invokeAPI:
      name: getPeople

  body:
    ListView:
      id: listView
      styles:
        gap: 12
      item-template:
        data: ${getPeople.body.users}
        name: user
        template:
          Text:
            text: ${user.email}


API:
  getPeople:
    url: https://dummyjson.com/users
    method: GET

```
![image](https://github.com/user-attachments/assets/3cd9a8df-90eb-48e2-8c6f-899f3e390717)
