### PR TITLE
removed device changes to update its properties

### DIFF
--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -88,19 +88,15 @@ class DataContext implements Context {
       _contextMap['auth'] = GetIt.instance<AuthContextManager>();
     }
 
-    _addLegacyDataContext(buildContext);
+    _addLegacyDataContext();
   }
 
 
     // device is a common name. If user already uses that, don't override it
     // This is now in ensemble.device.*
-  void _addLegacyDataContext(BuildContext? newBuildContext) {
+  void _addLegacyDataContext() {
     if (_contextMap['device'] == null) {
-        _contextMap['device'] = Device(newBuildContext);
-    } else {
-      // If device exists, update its context
-      final device = _contextMap['device'];
-      device.updateContext(newBuildContext);
+        _contextMap['device'] = Device();
     }
   }
 
@@ -472,7 +468,7 @@ class NativeInvokable extends ActionInvokable {
       'user': () => UserInfo(),
       'formatter': () => Formatter(),
       'utils': () => _EnsembleUtils(),
-      'device': () => Device(buildContext),
+      'device': () => Device(),
       'version': () => _cache['version'],
     };
   }

--- a/modules/ensemble/lib/framework/device.dart
+++ b/modules/ensemble/lib/framework/device.dart
@@ -27,50 +27,11 @@ class Device
         DeviceInfoCapability,
         WidgetsBindingObserver {
   static final Device _instance = Device._internal();
-  static late BuildContext context;
 
-  Device._internal() {
-    WidgetsBinding.instance.addObserver(this);
-  }
+  Device._internal();
 
-  factory Device([BuildContext? buildContext]) {
-    if (buildContext != null) {
-      context = buildContext;
-    }
+  factory Device() {
     return _instance;
-  }
-
-  // method to update context
-  void updateContext(BuildContext? newContext) {
-    if (newContext != null) {
-      context = newContext;
-    }
-  }
-
-  @override
-  void didChangeMetrics() {
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _handleMediaQueryChange());
-  }
-
-  void _handleMediaQueryChange() {
-    final newData = MediaQuery.of(context);
-
-    // Compare with existing static data
-    if (MediaQueryCapability.data?.orientation != newData.orientation ||
-        MediaQueryCapability.data?.size != newData.size) {
-      MediaQueryCapability.data = newData;
-
-      // Dispatch individual property changes
-      ScreenController().dispatchDeviceChanges(context, 'width', screenWidth);
-      ScreenController().dispatchDeviceChanges(context, 'height', screenHeight);
-      ScreenController()
-          .dispatchDeviceChanges(context, 'orientation', screenOrientation);
-      ScreenController()
-          .dispatchDeviceChanges(context, 'safeAreaTop', safeAreaTop);
-      ScreenController()
-          .dispatchDeviceChanges(context, 'safeAreaBottom', safeAreaBottom);
-    }
   }
 
   @override


### PR DESCRIPTION
The root cause of the issue is that device changes (like screen dimensions) are being detected correctly and the events are being dispatched and reflected in the UI. This happens because the UI is being re-rendered, and when the UI gets re-rendered, the TextField loses focus and the keyboard gets dismissed.

I tried to get the context from `Utils.globalAppKey.currentContext` but that is not working with ScopeManager, so we might need to figure out a proper solution, which will be time-consuming. I'll create a ticket for it and dedicate time to solving it because it's a separate issue that isn't currently affecting any customers or being used by them.