### PR TITLE
Fixed config initialization error 

### DIFF
--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -185,10 +185,12 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
       final configString =
           await rootBundle.loadString('${path}/config/appConfig.json');
       final Map<String, dynamic> configMap = json.decode(configString);
-      // Loop through the envVariables from appConfig.json file and add them to the envOverrides
-      configMap["envVariables"].forEach((key, value) {
-        envOverrides![key] = value;
-      });
+      if (configMap["envVariables"] != null) {
+        // Loop through the envVariables from appConfig.json file and add them to the envOverrides
+        configMap["envVariables"].forEach((key, value) {
+          envOverrides![key] = value;
+        });
+      }
     } catch (e) {
       debugPrint("appConfig.json file doesn't exist");
     }

--- a/modules/ensemble/lib/framework/definition_providers/local_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/local_provider.dart
@@ -38,7 +38,7 @@ class LocalDefinitionProvider extends FileDefinitionProvider {
     // Note: Web with local definition caches even if we disable browser cache
     // so you may need to re-run the app on definition changes
     var pageStr = await rootBundle
-        .loadString('${path}screens/${screenId ?? screenName ?? appHome}.yaml');
+        .loadString('${path}/screens/${screenId ?? screenName ?? appHome}.yaml');
     if (pageStr.isEmpty) {
       return ScreenDefinition(YamlMap());
     }

--- a/modules/ensemble/lib/framework/definition_providers/local_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/local_provider.dart
@@ -38,7 +38,7 @@ class LocalDefinitionProvider extends FileDefinitionProvider {
     // Note: Web with local definition caches even if we disable browser cache
     // so you may need to re-run the app on definition changes
     var pageStr = await rootBundle
-        .loadString('${path}/screens/${screenId ?? screenName ?? appHome}.yaml');
+        .loadString('${path}screens/${screenId ?? screenName ?? appHome}.yaml');
     if (pageStr.isEmpty) {
       return ScreenDefinition(YamlMap());
     }


### PR DESCRIPTION
@Umair-Manzoor-47 Here's the correct fix for config initialization issue, basically the error occurred because the config map didn't find `envVariables` key in appConfig.json and upon that, it threw an error. 

Following is PR didn't fix this issue:
https://github.com/EnsembleUI/ensemble/pull/1914

CC: @Umair-Manzoor-47 @amin-nas 