### PR TITLE
added tabBar borderColor and borderWidth

### DIFF
--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -88,9 +88,18 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
 
     if (widget.controller.borderRadius != null) {
       final borderRadius = widget.controller.borderRadius?.getValue();
-      tabBar = ClipRRect(
-        borderRadius: borderRadius ?? BorderRadius.zero,
-        child: tabBar,
+      tabBar = Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: widget.controller.borderColor ?? Colors.transparent, // Customize as needed
+            width: (widget.controller.borderWidth ?? 0.0).toDouble(),
+          ),
+          borderRadius: borderRadius ?? BorderRadius.zero,
+        ),
+        child: ClipRRect(
+            borderRadius: borderRadius ?? BorderRadius.zero,
+            child: tabBar
+        ),
       );
     }
 


### PR DESCRIPTION
Github Ticket: https://github.com/EnsembleUI/ensemble/issues/1648

added support for borderColor and BorderWidth for tabBar

EDL
```yaml
        - TabBarOnly:
            selectedIndex: 0
            styles:
              tabAlignment: fill
              tabPosition: stretch
              tabPadding: 1
              indicatorThickness: 4
              borderRadius: 100      // border radius
              borderColor: blue      // border Color
              borderWidth: 2        // Width of Border
              activeTabColor: 0xff3a071d
              inactiveTabColor: black
              tabBackgroundColor: 0xffefefef
              tabFontSize: 14
              tabFontWeight: w500
            items:
              - label: Tab one
                widget: Placeholder

              - label: Tab Two
                widget: Placeholder

```
Screenshot:

![Screenshot 2025-03-17 194311](https://github.com/user-attachments/assets/84b76c79-4aae-4066-9e86-caf76e09d1b6)
