### PR TITLE
added `language` property to get current selected language

### DIFF
--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -364,7 +364,16 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
 
   Object? getSelectedLanguage() {
     UserLocale? userLocale = UserLocale.from(Ensemble().getLocale());
-    String languageCode = userLocale!.languageCode;
+    // Check if userLocale is null before accessing languageCode
+    if (userLocale == null) {
+      return {
+        "languageCode": "Unknown",
+        "name": "Unknown",
+        "nativeName": "Unknown"
+      };
+    }
+
+    String languageCode = userLocale.languageCode;
     var localeNames = LocaleNames.of(Utils.globalAppKey.currentContext!);
     return {
       "languageCode": languageCode,

--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -28,6 +28,7 @@ import 'package:ensemble/page_model.dart';
 import 'package:ensemble/framework/definition_providers/provider.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/UserLocale.dart';
 import 'package:ensemble_ts_interpreter/parser/newjs_interpreter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -359,6 +360,24 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
           .toList();
     }
     return null;
+  }
+
+  Object? getSelectedLanguage() {
+    UserLocale? userLocale = UserLocale.from(Ensemble().getLocale());
+    String languageCode = userLocale!.languageCode;
+    var localeNames = LocaleNames.of(Utils.globalAppKey.currentContext!);
+    return {
+      "languageCode": languageCode,
+      // the language name based on the current context (fr is French (in English) or Francés (in Spanish))
+      // Note that this maybe null if the LocaleNamesLocalizationsDelegate is not loaded, in which case fallback to nativeName
+      "name": localeNames?.nameOf(languageCode) ??
+          LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
+          'Unknown',
+      // the language in their native name (fr is Français and en is English). These are always the same regardless of the current language.
+      "nativeName":
+          LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
+              'Unknown'
+    };
   }
 
   void notifyAppLifecycleStateChanged(AppLifecycleState state) {

--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -365,28 +365,23 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
   Object? getSelectedLanguage() {
     UserLocale? userLocale = UserLocale.from(Ensemble().getLocale());
     // Check if userLocale is null before accessing languageCode
-    if (userLocale == null) {
+    if (userLocale != null) {
+      String languageCode = userLocale.languageCode;
+      var localeNames = LocaleNames.of(Utils.globalAppKey.currentContext!);
       return {
-        "languageCode": "Unknown",
-        "name": "Unknown",
-        "nativeName": "Unknown"
+        "languageCode": languageCode,
+        // the language name based on the current context (fr is French (in English) or Francés (in Spanish))
+        // Note that this maybe null if the LocaleNamesLocalizationsDelegate is not loaded, in which case fallback to nativeName
+        "name": localeNames?.nameOf(languageCode) ??
+            LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
+            'Unknown',
+        // the language in their native name (fr is Français and en is English). These are always the same regardless of the current language.
+        "nativeName":
+            LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
+                'Unknown'
       };
     }
-
-    String languageCode = userLocale.languageCode;
-    var localeNames = LocaleNames.of(Utils.globalAppKey.currentContext!);
-    return {
-      "languageCode": languageCode,
-      // the language name based on the current context (fr is French (in English) or Francés (in Spanish))
-      // Note that this maybe null if the LocaleNamesLocalizationsDelegate is not loaded, in which case fallback to nativeName
-      "name": localeNames?.nameOf(languageCode) ??
-          LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
-          'Unknown',
-      // the language in their native name (fr is Français and en is English). These are always the same regardless of the current language.
-      "nativeName":
-          LocaleNamesLocalizationsDelegate.nativeLocaleNames[languageCode] ??
-              'Unknown'
-    };
+    return null;
   }
 
   void notifyAppLifecycleStateChanged(AppLifecycleState state) {

--- a/modules/ensemble/lib/framework/config.dart
+++ b/modules/ensemble/lib/framework/config.dart
@@ -31,6 +31,7 @@ class AppConfig with Invokable {
       'theme': () => EnsembleThemeManager().currentThemeName,
       'themes': () => EnsembleThemeManager().getThemeNames(),
       'languages': () => Ensemble().getSupportedLanguages(context),
+      'language': () => Ensemble().getSelectedLanguage(),
       // note the ts_interpreter package expects the locale at "app.locale",
       // so if you need to move this, update the package also.
       'locale': () => UserLocale.from(Ensemble().getLocale()),


### PR DESCRIPTION
Now `app.language` can be used to get the current selected language of the phone.

Example Usage:
```
View:
  styles:
    useSafeArea: true

  # Optional - set the header for the screen
  header:
    titleText: Home
  onLoad:
    executeCode:
      body: |
        console.log(app.languages)
        console.log(app.language)
  # Specify the body of the screen
  body:
    Column:
      styles:
        padding: 24
        gap: 8
      children:
        - Text:
            text: App Languages
            styles:
              textStyle:
                fontSize: 20
        - Text:
            text: ${app.languages}
        - Text:
            text: App Language
            styles:
              textStyle:
                fontSize: 20
        - Text:
            text: ${app.language}

```

Screenshot Result:
![Screenshot 2025-03-19 at 9 14 20 PM](https://github.com/user-attachments/assets/43d645e8-fb80-4944-ae56-ab781ed5c5f3)

CC: @kmahmood74 