### PR TITLE
Screen Readers Accessibility

### DIFF
--- a/modules/ensemble/lib/framework/ensemble_widget.dart
+++ b/modules/ensemble/lib/framework/ensemble_widget.dart
@@ -10,6 +10,7 @@ import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 abstract class EnsembleWidget<C extends EnsembleController>
@@ -144,18 +145,24 @@ abstract class EnsembleWidgetState<W extends EnsembleWidget> extends State<W> {
       }
 
       if(widgetController.semantics != null){
-        Widget semanticsWidget = Semantics(
+        rtn = Semantics(
           label: widgetController.semantics!.label,
           hint: widgetController.semantics!.hint,
-          focusable: true,
-          child: rtn,
+          focusable: widgetController.semantics!.focusable,
+          child: FocusTraversalGroup(
+            policy: WidgetOrderTraversalPolicy(),
+            child: FocusableActionDetector(
+              enabled: widgetController.semantics!.focusable,
+              focusNode: FocusNode(
+                canRequestFocus: false,
+                descendantsAreFocusable: true,
+                descendantsAreTraversable: true,
+              ),
+              child: rtn,
+            ),
+          ),
         );
 
-        rtn = widgetController.semantics!.focusable
-            ? FocusableActionDetector(
-          enabled: true,
-          child: semanticsWidget,
-        ) : semanticsWidget;
       }
 
       return rtn;

--- a/modules/ensemble/lib/framework/menu.dart
+++ b/modules/ensemble/lib/framework/menu.dart
@@ -6,6 +6,7 @@ import 'package:ensemble/framework/theme_manager.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/utils.dart';
+import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:yaml/yaml.dart';
 
@@ -19,7 +20,8 @@ abstract class Menu extends Object with HasStyles, Invokable {
       List<String>? classList,
       this.headerModel,
       this.footerModel,
-      this.reloadView}) {
+      this.reloadView,
+      this.semantics}) {
     this.widgetType = widgetType;
     this.widgetTypeStyles = widgetTypeStyles;
     this.widgetId = widgetId;
@@ -32,6 +34,7 @@ abstract class Menu extends Object with HasStyles, Invokable {
   WidgetModel? headerModel;
   WidgetModel? footerModel;
   bool? reloadView = true;
+  EnsembleSemantics? semantics;
 
   static Menu fromYaml(
       dynamic menu, Map<String, dynamic>? customViewDefinitions) {
@@ -107,6 +110,9 @@ abstract class Menu extends Object with HasStyles, Invokable {
         throw LanguageError("Menu requires two or more menu items.");
       }
 
+      // semantics for Menu
+      final semantics = EnsembleSemantics.fromYaml(Utils.getMap(payload["semantics"]));
+
       // menu headers/footers
       WidgetModel? menuHeaderModel;
       if (payload['header'] != null) {
@@ -136,7 +142,8 @@ abstract class Menu extends Object with HasStyles, Invokable {
             idStyles: EnsembleThemeManager().currentTheme()?.getIDStyles(id),
             inlineStyles: styles,
             classList: classList,
-            reloadView: isReloadView);
+            reloadView: isReloadView,
+            semantics: semantics);
       } else if (menuType == MenuDisplay.Drawer ||
           menuType == MenuDisplay.EndDrawer) {
         return DrawerMenu(menuItems, menuType != MenuDisplay.EndDrawer,
@@ -150,7 +157,8 @@ abstract class Menu extends Object with HasStyles, Invokable {
             classList: classList,
             headerModel: menuHeaderModel,
             footerModel: menuFooterModel,
-            reloadView: isReloadView);
+            reloadView: isReloadView,
+            semantics: semantics);
       } else if (menuType == MenuDisplay.Sidebar ||
           menuType == MenuDisplay.EndSidebar) {
         return SidebarMenu(menuItems, menuType != MenuDisplay.EndSidebar,
@@ -164,7 +172,8 @@ abstract class Menu extends Object with HasStyles, Invokable {
             classList: classList,
             headerModel: menuHeaderModel,
             footerModel: menuFooterModel,
-            reloadView: isReloadView);
+            reloadView: isReloadView,
+            semantics: semantics);
       }
     }
     throw LanguageError("Invalid Menu type.",
@@ -188,7 +197,8 @@ class BottomNavBarMenu extends Menu {
       super.idStyles,
       super.inlineStyles,
       super.classList,
-      super.reloadView});
+      super.reloadView,
+      super.semantics});
 
   @override
   Map<String, Function> getters() {
@@ -216,7 +226,8 @@ class DrawerMenu extends Menu {
       super.classList,
       super.headerModel,
       super.footerModel,
-      super.reloadView});
+      super.reloadView,
+      super.semantics});
 
   // show the drawer at start (left for LTR languages) or at the end
   bool atStart = true;
@@ -247,7 +258,8 @@ class SidebarMenu extends Menu {
       super.classList,
       super.headerModel,
       super.footerModel,
-      super.reloadView});
+      super.reloadView,
+      super.semantics});
 
   // show the sidebar at start (left for LTR languages) or at the end
   bool atStart = true;

--- a/modules/ensemble/lib/framework/menu.dart
+++ b/modules/ensemble/lib/framework/menu.dart
@@ -64,6 +64,13 @@ abstract class Menu extends Object with HasStyles, Invokable {
             throw LanguageError("Menu Item's 'page' attribute is required.");
           }
 
+          // semantics for MenuItem
+          EnsembleSemantics? itemSemantics = EnsembleSemantics(focusable: true);
+          if (item['semantics'] != null) {
+            itemSemantics =
+                EnsembleSemantics.fromYaml(Utils.getMap(item["semantics"]));
+          }
+
           // custom menu
           final YamlMap? customItem = item['customItem'];
           if (customItem != null) {
@@ -100,6 +107,7 @@ abstract class Menu extends Object with HasStyles, Invokable {
               onTapHaptic: Utils.optionalString(item['onTapHaptic']),
               isExternal: Utils.getBool(item['isExternal'], fallback: false),
               visible: item['visible'],
+              semantics: itemSemantics,
             ),
           );
           customIconModel = null; // Resetting custom icon model
@@ -110,8 +118,12 @@ abstract class Menu extends Object with HasStyles, Invokable {
         throw LanguageError("Menu requires two or more menu items.");
       }
 
-      // semantics for Menu
-      final semantics = EnsembleSemantics.fromYaml(Utils.getMap(payload["semantics"]));
+      // semantics for Menu for sidebar and drawer
+      EnsembleSemantics? semantics = EnsembleSemantics(focusable: true);
+      if (payload['semantics'] != null) {
+        semantics =
+            EnsembleSemantics.fromYaml(Utils.getMap(payload["semantics"]));
+      }
 
       // menu headers/footers
       WidgetModel? menuHeaderModel;
@@ -315,6 +327,7 @@ class MenuItem {
     this.onTapHaptic,
     required this.isExternal,
     this.visible = true,
+    this.semantics,
   });
 
   final String? label;
@@ -334,6 +347,7 @@ class MenuItem {
   final String? onTapHaptic;
   final bool isExternal;
   final dynamic visible;
+  EnsembleSemantics? semantics;
 
   bool isVisible(DataContext context) {
     if (visible == null) return true;

--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -267,7 +267,21 @@ class PageGroupState extends State<PageGroup> with MediaQueryCapability {
           icon: item.icon != null
               ? ensemble.Icon.fromModel(item.icon!)
               : const SizedBox.shrink(),
-          label: Text(Utils.translate(item.label ?? '', context))));
+          label: Semantics(
+            label: item.semantics!.label,
+            hint: item.semantics!.hint,
+            focusable: item.semantics!.focusable,
+            child: FocusTraversalGroup(
+                policy: WidgetOrderTraversalPolicy(),
+                child: FocusableActionDetector(
+                    enabled: item.semantics!.focusable,
+                    focusNode: FocusNode(
+                      canRequestFocus: false,
+                      descendantsAreFocusable: true,
+                      descendantsAreTraversable: true,
+                    ),
+                    child: Text(Utils.translate(item.label ?? '', context)))),
+          )));
     }
 
     // sidebar footer

--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -296,26 +296,41 @@ class PageGroupState extends State<PageGroup> with MediaQueryCapability {
     int minWidth =
         Utils.optionalInt(menu.runtimeStyles?['minWidth'], min: minGap) ?? 200;
 
-    return ListenableBuilder(
-      listenable: viewGroupNotifier,
-      builder: (context, _) {
-        return NavigationRail(
-          extended: itemDisplay == MenuItemDisplay.sideBySide ? true : false,
-          minExtendedWidth: minWidth.toDouble(),
-          minWidth: minGap.toDouble(),
-          // this is important for optimal default item spacing
-          labelType: itemDisplay != MenuItemDisplay.sideBySide
-              ? NavigationRailLabelType.all
-              : null,
-          backgroundColor: menuBackground,
-          leading: menuHeader,
-          destinations: navItems,
-          trailing: menuFooter,
-          selectedIndex: viewGroupNotifier.viewIndex,
-          onDestinationSelected: viewGroupNotifier.updatePage,
-        );
-      },
-    );
+    return Semantics(
+        label: widget.menu.semantics!.label ?? '',
+        hint: widget.menu.semantics!.hint ?? '',
+        focusable: widget.menu.semantics!.focusable,
+        child: FocusTraversalGroup(
+        policy: WidgetOrderTraversalPolicy(),
+      child: FocusableActionDetector(
+        enabled: widget.menu.semantics!.focusable,
+        focusNode: FocusNode(
+          canRequestFocus: true,
+          descendantsAreFocusable: true,
+          descendantsAreTraversable: true,
+        ),
+        child: ListenableBuilder(
+          listenable: viewGroupNotifier,
+          builder: (context, _) {
+            return NavigationRail(
+              extended: itemDisplay == MenuItemDisplay.sideBySide ? true : false,
+              minExtendedWidth: minWidth.toDouble(),
+              minWidth: minGap.toDouble(),
+              // this is important for optimal default item spacing
+              labelType: itemDisplay != MenuItemDisplay.sideBySide
+                  ? NavigationRailLabelType.all
+                  : null,
+              backgroundColor: menuBackground,
+              leading: menuHeader,
+              destinations: navItems,
+              trailing: menuFooter,
+              selectedIndex: viewGroupNotifier.viewIndex,
+              onDestinationSelected: viewGroupNotifier.updatePage,
+            );
+          },
+        ),
+      ),
+    ));
   }
 
   Widget? _buildSidebarSeparator(Menu menu) {

--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -17,6 +17,7 @@ import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble/widget/helpers/widgets.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:yaml/yaml.dart';
 
@@ -177,18 +178,24 @@ abstract class EWidgetState<W extends HasController>
         );
       }
       if(widgetController.semantics != null){
-        Widget semanticsWidget = Semantics(
+        rtn = Semantics(
           label: widgetController.semantics!.label,
           hint: widgetController.semantics!.hint,
-          focusable: true,
-          child: rtn,
+          focusable: widgetController.semantics!.focusable,
+          child: FocusTraversalGroup(
+            policy: WidgetOrderTraversalPolicy(),
+            child: FocusableActionDetector(
+              enabled: widgetController.semantics!.focusable,
+              focusNode: FocusNode(
+                canRequestFocus: false, // Ensures focusability
+                descendantsAreFocusable: true,
+                descendantsAreTraversable: true,
+              ),
+              child: rtn,
+            ),
+          ),
         );
 
-        rtn = widgetController.semantics!.focusable
-            ? FocusableActionDetector(
-          enabled: true,
-          child: semanticsWidget,
-        ) : semanticsWidget;
       }
     }
     return rtn;

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -95,9 +95,11 @@ abstract class BaseTabBar extends StatefulWidget
 }
 
 class TabBarState extends BaseTabBarState {
+  late final List<FocusNode> _contentFocusNodes;
   @override
   void initState() {
     super.initState();
+    _contentFocusNodes = List.generate(widget.controller.items.length, (_) => FocusNode());
     _initializeTabController();
   }
 
@@ -219,6 +221,7 @@ class TabBarState extends BaseTabBarState {
     setState(() {
       widget.controller.selectedIndex = index;
     });
+    FocusScope.of(context).requestFocus(_contentFocusNodes[index]);
     if (widget.controller.onTabSelection != null) {
       if (widget.controller.onTabSelectionHaptic != null) {
         ScreenController().executeAction(
@@ -316,7 +319,9 @@ class TabBarState extends BaseTabBarState {
     if (scopeManager != null) {
       TabItem selectedTab =
           widget._controller.items[widget._controller.selectedIndex];
-      return scopeManager.buildWidgetFromDefinition(selectedTab.bodyWidget);
+      return Focus(
+          focusNode: _contentFocusNodes[widget._controller.selectedIndex],
+          child: scopeManager.buildWidgetFromDefinition(selectedTab.bodyWidget));
     }
     return const Text("Unknown widget for this Tab");
   }

--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -590,7 +590,6 @@ class EnsembleSemantics {
   String? label;
   String? hint;
 
-  // Convert to named parameters
   EnsembleSemantics({this.label, this.hint,required this.focusable});
 
   // Factory constructor to map from YAML


### PR DESCRIPTION
Added Semantics Map on `Widget` level for `Accessibility` Support for screen readers.
Some Other Enhancements like SideBar being Able to hold Semantics too.
TabBar focuses on Active Tab Automatically when we press `Enter`.

This is Continuation or PR: https://github.com/EnsembleUI/ensemble/pull/1934