### PR TITLE
Making rendering of the screen optional in ensembleApp

### DIFF
--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -379,6 +379,7 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
         appProvider: AppProvider(definitionProvider: config.definitionProvider),
         screenPayload: widget.screenPayload,
         apiProviders: APIProviders.clone(config.apiProviders ?? {}),
+        placeholderBackgroundColor: widget.placeholderBackgroundColor,
       );
       
       // Wrap the Screen in a Scaffold when not using child mode

--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -105,6 +105,7 @@ class EnsembleApp extends StatefulWidget {
     this.placeholderBackgroundColor,
     this.onAppLoad,
     this.forcedLocale,
+    this.child,  
     GlobalKey<NavigatorState>? navigatorKey,
     ScrollController? screenScroller,
   }) {
@@ -116,6 +117,9 @@ class EnsembleApp extends StatefulWidget {
   final EnsembleConfig? ensembleConfig;
   final bool isPreview;
   final Map<String, Function>? externalMethods;
+
+  // use this if you want to pass in a child widget instead of a screen
+  final Widget? child; 
 
   // for integration with external Flutter code
   final Function? onAppLoad;
@@ -364,11 +368,29 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
       notifiedAppLoad = true;
     }
 
-    Widget screen = Screen(
-      appProvider: AppProvider(definitionProvider: config.definitionProvider),
-      screenPayload: widget.screenPayload,
-      apiProviders: APIProviders.clone(config.apiProviders ?? {}),
-    );
+    // Determine the content based on whether a child was provided
+    Widget content;
+    if (widget.child != null) {
+      // Use the provided child directly
+      content = widget.child!;
+    } else {
+      // Create a Screen widget
+      content = Screen(
+        appProvider: AppProvider(definitionProvider: config.definitionProvider),
+        screenPayload: widget.screenPayload,
+        apiProviders: APIProviders.clone(config.apiProviders ?? {}),
+      );
+      
+      // Wrap the Screen in a Scaffold when not using child mode
+      content = Scaffold(
+        // This outer scaffold is where the background image would be (if specified)
+        // We do not want it to resize on keyboard popping up
+        // The Page's Scaffold can handle the resizing
+        resizeToAvoidBottomInset: false,
+        body: content
+      );
+    }
+
     ThemeData? theme;
     //if we have defined legacy themes at the root level or if thre is no Styles at the root level, we use the app level theme
     if (config.hasLegacyCustomAppTheme() ||
@@ -395,12 +417,7 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
             definitionProvider: config.definitionProvider);
         return Ensemble().locale;
       },
-      home: Scaffold(
-        // this outer scaffold is where the background image would be (if
-        // specified). We do not want it to resize on keyboard popping up.
-        // The Page's Scaffold can handle the resizing.
-          resizeToAvoidBottomInset: false,
-          body: screen),
+      home: content,
       useInheritedMediaQuery: widget.isPreview,
       builder: (context, child) => widget.isPreview
           ? DevicePreview.appBuilder(context, child)

--- a/modules/ensemble/lib/framework/widget/screen.dart
+++ b/modules/ensemble/lib/framework/widget/screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:ensemble/ensemble.dart';
+import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/apiproviders/api_provider.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
@@ -22,11 +23,16 @@ class Screen extends StatefulWidget {
       {super.key,
       required this.appProvider,
       this.screenPayload,
-      required this.apiProviders});
+      required this.apiProviders,
+      this.navigatorKey,
+      this.placeholderBackgroundColor});
 
   final AppProvider appProvider;
   final ScreenPayload? screenPayload;
   final Map<String, APIProvider> apiProviders;
+  // If we are using only screen widget to render screen, we need to pass navigator key from host app to work with external screens
+  final GlobalKey<NavigatorState>? navigatorKey;
+  final Color? placeholderBackgroundColor;
 
   @override
   State<Screen> createState() => _ScreenState();
@@ -39,6 +45,12 @@ class _ScreenState extends State<Screen> {
   @override
   void initState() {
     super.initState();
+
+    // this external app navigate key is used to navigate to external screens in screen controller
+    if (widget.navigatorKey != null) {
+      externalAppNavigateKey = widget.navigatorKey;
+    }
+
     if (widget.screenPayload?.isExternal ?? false) {
       if (widget.screenPayload?.screenName == null) {
         throw LanguageError('ScreenName is mandatory, when external is true');
@@ -67,9 +79,10 @@ class _ScreenState extends State<Screen> {
               // show progress bar
               else if (!snapshot.hasData) {
                 return Scaffold(
-                    backgroundColor: Theme.of(context)
-                        .extension<EnsembleThemeExtension>()
-                        ?.loadingScreenBackgroundColor,
+                    backgroundColor: widget.placeholderBackgroundColor ??
+                        Theme.of(context)
+                            .extension<EnsembleThemeExtension>()
+                            ?.loadingScreenBackgroundColor,
                     resizeToAvoidBottomInset: false,
                     body: Center(
                         child: CircularProgressIndicator(


### PR DESCRIPTION
A solution to the duplicate GlobalKey error when using 2 EnsembleApp in a native flutter app.
Discord discussion: https://discord.com/channels/1031982848485359626/1351798223781625926/1351798223781625926

The approach we are now using is:
- making the rendering of the screen in `EnsembleApp` optional by passing a child widget from the host app, so that we do all the initialization for ensemble and return that widget back to the host app, so that it works as it is.
- And then just use `Screen` widget at multiple places as many times we want for specific Ensemble screens without the duplicate globalKey error.

Below is a recording with multiple EnsembleApp.
- From home tab going to media details screen that shows match stats in ensemble `Screen`
- From sports tab, we are opening Ensemble `Screen` and then going to the media screen as well that has another ensemble `Screen`.

Recording: https://drive.google.com/file/d/1WQLx8G9EYJyDA-CMvaIjJx4dLPj0uQcH/view?usp=sharing