### PR TITLE
Footer height Requirement for Drawer

### DIFF
--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -457,7 +457,7 @@ class PageGroupState extends State<PageGroup> with MediaQueryCapability {
 
           // Optional footer section at bottom of drawer
           if (menu.footerModel != null)
-            _scopeManager.buildWidget(menu.footerModel!),
+            Expanded(child: _scopeManager.buildWidget(menu.footerModel!)),
         ],
       ),
     );

--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -457,7 +457,9 @@ class PageGroupState extends State<PageGroup> with MediaQueryCapability {
 
           // Optional footer section at bottom of drawer
           if (menu.footerModel != null)
-            Expanded(child: _scopeManager.buildWidget(menu.footerModel!)),
+            Expanded(
+                child: _scopeManager.buildWidget(menu.footerModel!)
+            ),
         ],
       ),
     );


### PR DESCRIPTION
Previously `footer` required height in `Drawer` Menu.
Wrapped it in `EXPANDED` so it may take the available space.