### PR TITLE
[Feat] Added new widget `ExternalWidget`

### DIFF
--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -62,6 +62,10 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
   }
 
   Map<String, Function> externalMethods = {};
+  Map<String, CustomBuilder> externalWidgets = {};
+
+  void setExternalWidgets(Map<String, CustomBuilder> widgets) =>
+    externalWidgets = widgets;
 
   void setExternalMethods(Map<String, Function> methods) =>
       externalMethods = methods;

--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -101,6 +101,7 @@ class EnsembleApp extends StatefulWidget {
     this.screenPayload,
     this.ensembleConfig,
     this.externalMethods,
+    this.externalWidgets,
     this.isPreview = false,
     this.placeholderBackgroundColor,
     this.onAppLoad,
@@ -117,6 +118,11 @@ class EnsembleApp extends StatefulWidget {
   final EnsembleConfig? ensembleConfig;
   final bool isPreview;
   final Map<String, Function>? externalMethods;
+
+  // use this to pass in custom widgets that are not part of the Ensemble
+  // framework. The key is the name of the widget and the value is a
+  // function that returns a widget.
+  final Map<String, CustomBuilder>? externalWidgets;
 
   // use this if you want to pass in a child widget instead of a screen
   final Widget? child; 
@@ -238,6 +244,10 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
 
     if (widget.externalMethods != null) {
       Ensemble().setExternalMethods(widget.externalMethods!);
+    }
+
+    if (widget.externalWidgets != null) {
+      Ensemble().setExternalWidgets(widget.externalWidgets!);
     }
 
     // use the config if passed in

--- a/modules/ensemble/lib/widget/external_widget.dart
+++ b/modules/ensemble/lib/widget/external_widget.dart
@@ -1,0 +1,88 @@
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/ensemble_widget.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:ensemble/widget/helpers/controllers.dart';
+import 'package:flutter/material.dart';
+import 'package:ensemble/ensemble.dart';
+
+class ExternalWidget extends EnsembleWidget<ExternalWidgetController> {
+  static const type = 'ExternalWidget';
+
+  const ExternalWidget._(super.controller, {super.key});
+
+  factory ExternalWidget.build([dynamic controller]) =>
+      ExternalWidget._(controller is ExternalWidgetController
+          ? controller
+          : ExternalWidgetController());
+
+  @override
+  State<StatefulWidget> createState() => ExternalWidgetState();
+}
+
+class ExternalWidgetController extends EnsembleWidgetController {
+  String name = '';
+  Map<String, dynamic>? payload;
+  Map<String, EnsembleAction?> events = {};
+
+  @override
+  Map<String, Function> getters() => {
+        'name': () => name,
+        'payload': () => payload,
+        ...events.map((key, _) => MapEntry(key, () => events[key])),
+      };
+
+  @override
+  Map<String, Function> setters() => Map<String, Function>.from(super.setters())
+    ..addAll({
+      'name': (value) => name = Utils.getString(value, fallback: ''),
+      'payload': (value) => payload = Utils.getMap(value),
+      'events': (value) {
+        if (value is Map) {
+          value.forEach((key, actionValue) {
+            if (key is String) {
+              events[key] = EnsembleAction.from(actionValue, initiator: this);
+            }
+          });
+        }
+      },
+    });
+}
+
+class ExternalWidgetState extends EnsembleWidgetState<ExternalWidget> {
+  @override
+  Widget buildWidget(BuildContext context) {
+    final controller = widget.controller;
+
+    if (controller.name.isEmpty) {
+      throw RuntimeError("ExternalWidget requires a 'name' property");
+    }
+
+    final builder = Ensemble().externalWidgets[controller.name];
+    if (builder == null) {
+      throw RuntimeError("External widget '${controller.name}' not found");
+    }
+
+    final payload = Map<String, dynamic>.from(controller.payload ?? {});
+
+    // Add all event handlers to the payload
+    // This allows the external widget to call back into Ensemble
+    controller.events.forEach((eventName, action) {
+      if (action != null) {
+        payload[eventName] = (dynamic value) {
+          if (mounted) {
+            ScreenController().executeAction(
+              context,
+              action,
+              event: EnsembleEvent(widget.controller, data: {'value': value}),
+            );
+          }
+        };
+      }
+    });
+
+    return builder(context, payload);
+  }
+}

--- a/modules/ensemble/lib/widget/external_widget.dart
+++ b/modules/ensemble/lib/widget/external_widget.dart
@@ -24,13 +24,13 @@ class ExternalWidget extends EnsembleWidget<ExternalWidgetController> {
 
 class ExternalWidgetController extends EnsembleWidgetController {
   String name = '';
-  Map<String, dynamic>? payload;
+  Map<String, dynamic>? inputs;
   Map<String, EnsembleAction?> events = {};
 
   @override
   Map<String, Function> getters() => {
         'name': () => name,
-        'payload': () => payload,
+        'inputs': () => inputs,
         ...events.map((key, _) => MapEntry(key, () => events[key])),
       };
 
@@ -38,7 +38,7 @@ class ExternalWidgetController extends EnsembleWidgetController {
   Map<String, Function> setters() => Map<String, Function>.from(super.setters())
     ..addAll({
       'name': (value) => name = Utils.getString(value, fallback: ''),
-      'payload': (value) => payload = Utils.getMap(value),
+      'inputs': (value) => inputs = Utils.getMap(value),
       'events': (value) {
         if (value is Map) {
           value.forEach((key, actionValue) {
@@ -65,13 +65,13 @@ class ExternalWidgetState extends EnsembleWidgetState<ExternalWidget> {
       throw RuntimeError("External widget '${controller.name}' not found");
     }
 
-    final payload = Map<String, dynamic>.from(controller.payload ?? {});
+    final inputs = Map<String, dynamic>.from(controller.inputs ?? {});
 
     // Add all event handlers to the payload
     // This allows the external widget to call back into Ensemble
     controller.events.forEach((eventName, action) {
       if (action != null) {
-        payload[eventName] = (dynamic value) {
+        inputs[eventName] = (dynamic value) {
           if (mounted) {
             ScreenController().executeAction(
               context,
@@ -83,6 +83,6 @@ class ExternalWidgetState extends EnsembleWidgetState<ExternalWidget> {
       }
     });
 
-    return builder(context, payload);
+    return builder(context, inputs);
   }
 }

--- a/modules/ensemble/lib/widget/widget_registry.dart
+++ b/modules/ensemble/lib/widget/widget_registry.dart
@@ -24,6 +24,7 @@ import 'package:ensemble/widget/button.dart';
 import 'package:ensemble/widget/calendar.dart';
 import 'package:ensemble/widget/checkbox.dart';
 import 'package:ensemble/widget/countdown.dart';
+import 'package:ensemble/widget/external_widget.dart';
 import 'package:ensemble/widget/radio/radio_button.dart';
 import 'package:ensemble/widget/radio/radio_group.dart';
 import 'package:ensemble/widget/static_map.dart';
@@ -88,6 +89,7 @@ class WidgetRegistry {
     Shape.type: Shape.build,
     StaticMap.type: StaticMap.build,
     EnsembleSignature.type: EnsembleSignature.build,
+    ExternalWidget.type: ExternalWidget.build, 
   };
 
   /// register or override a widget


### PR DESCRIPTION
User launches a Flutter widget from within an Ensemble screen.

Flow:
- User Register Native Flutter widget with EnsembleApp passing it to new property `externalWidgets`
- Use `ExternalWidget` in Ensemble screen, with the name of the Flutter widget with which they register it.
- Pass the values from Ensemble to Flutter widget using `Inputs`.
- Define events to get back value sform Flutter widgets to Ensemble screen using these callbacks