### PR TITLE
chore: update file_picker dependency to version 10.1.2

### DIFF
--- a/modules/file_manager/pubspec.yaml
+++ b/modules/file_manager/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
       url: https://github.com/EnsembleUI/ensemble.git
       ref: main
       path: modules/ensemble_ts_interpreter
-  file_picker: ^5.2.10
+  file_picker: ^10.1.2
   vision_gallery_saver: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
Build system is failing with this error, seems like file_ficker `5.2.10` is deprecated, upgrading it to the latest version

```
Package file_picker:windows references file_picker:windows as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of file_picker to either avoid referencing a default implementation via `platforms: windows: default_package: file_picker` or add an inline implementation to file_picker via `platforms: windows:` `pluginClass` or `dartPluginClass`.

Note: /Users/builder/.pub-cache/hosted/pub.dev/google_mlkit_face_detection-0.12.0/android/src/main/java/com/google_mlkit_face_detection/FaceDetector.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
/Users/builder/.pub-cache/hosted/pub.dev/file_picker-5.5.0/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java:120: error: cannot find symbol
    public static void registerWith(final io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
                                                                                 ^
  symbol:   class Registrar
  location: interface PluginRegistry
/Users/builder/.pub-cache/hosted/pub.dev/file_picker-5.5.0/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerPlugin.java:248: error: cannot find symbol
            final PluginRegistry.Registrar registrar,
                                ^
  symbol:   class Registrar
  location: interface PluginRegistry
2 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':file_picker:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --info option to get more log output.
> Run with --scan to get full insights.

BUILD FAILED in 6m 57s
Running Gradle task 'bundleRelease'...                            417.9s

┌─ Flutter Fix ───────────────────────────────────────────────────────────────────────────────────┐
│ [!] Consult the error logs above to identify any broken plugins, specifically those containing  │
│ "error: cannot find symbol..."                                                                  │
│ This issue is likely caused by v1 embedding removal and the plugin's continued usage of removed │
│ references to the v1 embedding.                                                                 │
│ To fix this error, please upgrade your current package's dependencies to latest versions by     │
│ running `flutter pub upgrade`.                                                                  │
│ If that does not work, please file an issue for the problematic plugin(s) here:                 │
│ https://github.com/flutter/flutter/issues                                                       │
└─────────────────────────────────────────────────────────────────────────────────────────────────┘
Gradle task bundleRelease failed with exit code 1


Build failed :|
Step 5 script `Build AAB` exited with status code 1
```