### PR TITLE
[Bug] Fixed `null check operator` error upon loading assets

### DIFF
--- a/modules/ensemble/lib/ensemble.dart
+++ b/modules/ensemble/lib/ensemble.dart
@@ -65,7 +65,7 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
   Map<String, CustomBuilder> externalWidgets = {};
 
   void setExternalWidgets(Map<String, CustomBuilder> widgets) =>
-    externalWidgets = widgets;
+      externalWidgets = widgets;
 
   void setExternalMethods(Map<String, Function> methods) =>
       externalMethods = methods;
@@ -191,9 +191,12 @@ class Ensemble extends WithEnsemble with EnsembleRouteObserver {
           await rootBundle.loadString('${path}/config/appConfig.json');
       final Map<String, dynamic> configMap = json.decode(configString);
       // Loop through the envVariables from appConfig.json file and add them to the envOverrides
-      configMap["envVariables"].forEach((key, value) {
-        envOverrides![key] = value;
-      });
+      if (configMap["envVariables"] != null) {
+        // Loop through the envVariables from appConfig.json file and add them to the envOverrides
+        configMap["envVariables"].forEach((key, value) {
+          envOverrides![key] = value;
+        });
+      }
     } catch (e) {
       debugPrint("appConfig.json file doesn't exist");
     }

--- a/modules/ensemble/lib/framework/assets_service.dart
+++ b/modules/ensemble/lib/framework/assets_service.dart
@@ -9,19 +9,21 @@ class LocalAssetsService {
   static Future<void> initialize(
       Map<String, dynamic>? envVariables, YamlMap definations) async {
     List<String> foundAssets = [];
+    if (envVariables != null) {
+      for (var entry in envVariables.entries) {
+        String assetName =
+            Utils.getAssetName(entry.value); // Get the asset name
+        String provider = definations['definitions']?['from'];
+        String path = definations['definitions']?['local']['path'];
+        String assetPath = provider == 'local'
+            ? "$path/assets/$assetName"
+            : "ensemble/assets/$assetName"; // Construct the full path
 
-    for (var entry in envVariables!.entries) {
-      String assetName = Utils.getAssetName(entry.value); // Get the asset name
-      String provider = definations['definitions']?['from'];
-      String path = definations['definitions']?['local']['path'];
-      String assetPath = provider == 'local'
-          ? "$path/assets/$assetName"
-          : "ensemble/assets/$assetName"; // Construct the full path
+        bool exists = await _assetExists(assetPath); // Check if asset exists
 
-      bool exists = await _assetExists(assetPath); // Check if asset exists
-
-      if (exists) {
-        foundAssets.add(assetName); // Store only existing assets
+        if (exists) {
+          foundAssets.add(assetName); // Store only existing assets
+        }
       }
     }
 


### PR DESCRIPTION
When pointing towards `local`
- the config map didn't find the `envVariables` key in `appConfig.json` and upon that, it threw an error `the appConfig.json file not found`. fixing it using a condition

When pointing towards `ensemble`
- If we create a new application on Studio, and it doesn't have any environment variables available in it, it will throw a screen error `Null check operator used on a null value`