### PR TITLE
[Bug] fixed the double error in header

### DIFF
--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -930,7 +930,9 @@ class _AnimatedAppBarState extends State<AnimatedAppBar> {
 
     if (!widget.scrollController.hasClients) return;
 
-    double threshold = (widget.expandedBarHeight - widget.collapsedBarHeight).clamp(10, double.infinity);
+    double expandedHeight = (widget.expandedBarHeight ?? 0.0).toDouble();
+    double collapsedHeight = (widget.collapsedBarHeight ?? 0.0).toDouble();
+    double threshold = (expandedHeight - collapsedHeight).clamp(10.0, double.infinity);
     bool newState = widget.scrollController.offset > threshold;
 
 


### PR DESCRIPTION
When we have teh heder, while we are scrolling we were getting error `type 'int' is not a subtype of type 'double'`, because `clamp` fucnitno expect double value but we were giving the int value.