### PR TITLE
Range slider

### DIFF
--- a/modules/ensemble/lib/widget/input/slider/slider.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider.dart
@@ -30,6 +30,9 @@ class EnsembleSlider extends StatefulWidget
       'value': () => _controller.value,
       'min': () => _controller.minValue,
       'max': () => _controller.maxValue,
+      'startValue': () => _controller.startValue,
+      'endValue': () => _controller.endValue,
+      'enableRange': () => _controller.enableRange,
       'trackStyle': () => _controller.trackStyle,
       'tickMarkStyle': () => _controller.tickMarkStyle,
       'thumbStyle': () => _controller.thumbStyle,
@@ -46,6 +49,9 @@ class EnsembleSlider extends StatefulWidget
   @override
   Map<String, Function> setters() {
     return {
+      'enableRange': (value) => _controller.enableRange = Utils.getBool(value, fallback: false),
+      'startValue': (value) => _controller.startValue = Utils.getDouble(value, fallback: 0.0),
+      'endValue': (value) => _controller.endValue = Utils.getDouble(value, fallback: 1.0),
       // Basic Properties
       'initialValue': (value) =>
           _controller.value = Utils.optionalDouble(value) ?? 0,

--- a/modules/ensemble/lib/widget/input/slider/slider_controller.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider_controller.dart
@@ -8,6 +8,10 @@ import 'composites/overlay_style.dart';
 import 'composites/value_indicator_style.dart';
 
 class SliderController extends FormFieldController {
+ // Range slider specific properties
+  bool enableRange = false;
+  double startValue = 0.0;
+  double endValue = 1.0;
   // Basic Values
   double value = 0.0;
   double minValue = 0.0;

--- a/modules/ensemble/lib/widget/input/slider/slider_state.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider_state.dart
@@ -18,8 +18,6 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
       widget: FormField<double>(
         key: validatorKey,
         validator: (value) {
-          print('slider required');
-          print(widget.controller.required);
           if (widget.controller.required) {
             if (widget.controller.enableRange) {
               if (widget.controller.startValue == widget.controller.minValue &&
@@ -28,7 +26,6 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
                     'ensemble.input.required', 'This field is required');
               }
             } else if (widget.controller.value == widget.controller.minValue) {
-              print('here--------');
               return Utils.translateWithFallback(
                   'ensemble.input.required', 'This field is required');
             }
@@ -89,52 +86,13 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
             valueIndicatorShape:
                 widget.controller.valueIndicatorStyle.getIndicatorShape(),
           );
-return Column(
-  crossAxisAlignment: CrossAxisAlignment.start,
-  mainAxisSize: MainAxisSize.min,
-  children: [
-    SliderTheme(
-      data: themeData,
-      child: widget.controller.enableRange ? _buildRangeSlider(context, decimalPlaces) :
-      Slider(
-        // Slider properties - keep these unchanged
-        value: widget.controller.value,
-        min: widget.controller.minValue,
-        max: widget.controller.maxValue,
-        divisions: widget.controller.divisions,
-        label: widget.controller.value.toStringAsFixed(decimalPlaces),
-        onChanged: isEnabled()
-            ? (value) {
-                setState(() {
-                  widget.controller.value = value;
-                  // Add this line to validate the field
-                  field.validate();
-                });
-                if (widget.controller.onChange != null) {
-                  ScreenController().executeAction(
-                    context,
-                    widget.controller.onChange!,
-                    event: EnsembleEvent(widget),
-                  );
-                }
-              }
-            : null,
-      ),
-    ),
-    // Add this section to display the error message
-    if (field.hasError)
-      Padding(
-        padding: const EdgeInsets.only(top: 4.0, left: 4.0),
-        child: Text(
-          field.errorText!,
-          style: TextStyle(
-            color: Theme.of(context).colorScheme.error,
-            fontSize: 12.0,
-          ),
-        ),
-      ),
-  ],
-);
+
+          return SliderTheme(
+            data: themeData,
+            child: widget.controller.enableRange
+                ? _buildRangeSlider(context, decimalPlaces)
+                : _buildSlider(context, decimalPlaces)
+          );
         },
       ),
     );
@@ -151,9 +109,11 @@ return Column(
 
     return decimalPlaces;
   }
- Widget _buildRangeSlider(BuildContext context, int decimalPlaces) {
+
+  Widget _buildRangeSlider(BuildContext context, int decimalPlaces) {
     return RangeSlider(
-      values: RangeValues(widget.controller.startValue, widget.controller.endValue),
+      values:
+          RangeValues(widget.controller.startValue, widget.controller.endValue),
       min: widget.controller.minValue,
       max: widget.controller.maxValue,
       divisions: widget.controller.divisions,
@@ -171,7 +131,35 @@ return Column(
                 ScreenController().executeAction(
                   context,
                   widget.controller.onChange!,
-                  event: EnsembleEvent(widget),
+                  event: EnsembleEvent(widget, data: {
+                    'startValue': widget.controller.startValue,
+                    'endValue': widget.controller.endValue
+                  }),
+                );
+              }
+            }
+          : null,
+    );
+  }
+
+  Widget _buildSlider(BuildContext context, int decimalPlaces) {
+    return Slider(
+      value: widget.controller.value,
+      min: widget.controller.minValue,
+      max: widget.controller.maxValue,
+      divisions: widget.controller.divisions,
+      label: widget.controller.value.toStringAsFixed(decimalPlaces),
+      onChanged: isEnabled()
+          ? (value) {
+              setState(() {
+                widget.controller.value = value;
+              });
+              if (widget.controller.onChange != null) {
+                ScreenController().executeAction(
+                  context,
+                  widget.controller.onChange!,
+                  event: EnsembleEvent(widget,
+                      data: {'value': widget.controller.value}),
                 );
               }
             }
@@ -179,3 +167,6 @@ return Column(
     );
   }
 }
+
+
+            // event: EnsembleEvent(null, data: {'user': currentUser}));

--- a/modules/ensemble/lib/widget/input/slider/slider_state.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider_state.dart
@@ -159,7 +159,8 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
                   context,
                   widget.controller.onChange!,
                   event: EnsembleEvent(widget,
-                      data: {'value': widget.controller.value}),
+                      data: {'value': widget.controller.value}
+                      ),
                 );
               }
             }
@@ -167,6 +168,3 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
     );
   }
 }
-
-
-            // event: EnsembleEvent(null, data: {'user': currentUser}));

--- a/modules/ensemble/lib/widget/input/slider/slider_state.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider_state.dart
@@ -18,11 +18,17 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
       widget: FormField<double>(
         key: validatorKey,
         validator: (value) {
-          if (widget.controller
-                  .required && // Changed from _controller to controller
-              widget.controller.value == widget.controller.minValue) {
-            return Utils.translateWithFallback(
-                'ensemble.input.required', 'This field is required');
+          if (widget.controller.required) {
+            if (widget.controller.enableRange) {
+              if (widget.controller.startValue == widget.controller.minValue &&
+                  widget.controller.endValue == widget.controller.minValue) {
+                return Utils.translateWithFallback(
+                    'ensemble.input.required', 'This field is required');
+              }
+            } else if (widget.controller.value == widget.controller.minValue) {
+              return Utils.translateWithFallback(
+                  'ensemble.input.required', 'This field is required');
+            }
           }
           return null;
         },
@@ -83,7 +89,8 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
 
           return SliderTheme(
             data: themeData,
-            child: Slider(
+            child: widget.controller.enableRange ? _buildRangeSlider(context, decimalPlaces):
+            Slider(
               value: widget.controller.value,
               min: widget.controller.minValue,
               max: widget.controller.maxValue,
@@ -120,5 +127,32 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
     }
 
     return decimalPlaces;
+  }
+ Widget _buildRangeSlider(BuildContext context, int decimalPlaces) {
+    return RangeSlider(
+      values: RangeValues(widget.controller.startValue, widget.controller.endValue),
+      min: widget.controller.minValue,
+      max: widget.controller.maxValue,
+      divisions: widget.controller.divisions,
+      labels: RangeLabels(
+        widget.controller.startValue.toStringAsFixed(decimalPlaces),
+        widget.controller.endValue.toStringAsFixed(decimalPlaces),
+      ),
+      onChanged: isEnabled()
+          ? (RangeValues values) {
+              setState(() {
+                widget.controller.startValue = values.start;
+                widget.controller.endValue = values.end;
+              });
+              if (widget.controller.onChange != null) {
+                ScreenController().executeAction(
+                  context,
+                  widget.controller.onChange!,
+                  event: EnsembleEvent(widget),
+                );
+              }
+            }
+          : null,
+    );
   }
 }

--- a/modules/ensemble/lib/widget/input/slider/slider_state.dart
+++ b/modules/ensemble/lib/widget/input/slider/slider_state.dart
@@ -18,6 +18,8 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
       widget: FormField<double>(
         key: validatorKey,
         validator: (value) {
+          print('slider required');
+          print(widget.controller.required);
           if (widget.controller.required) {
             if (widget.controller.enableRange) {
               if (widget.controller.startValue == widget.controller.minValue &&
@@ -26,6 +28,7 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
                     'ensemble.input.required', 'This field is required');
               }
             } else if (widget.controller.value == widget.controller.minValue) {
+              print('here--------');
               return Utils.translateWithFallback(
                   'ensemble.input.required', 'This field is required');
             }
@@ -86,32 +89,52 @@ class SliderState extends FormFieldWidgetState<EnsembleSlider> {
             valueIndicatorShape:
                 widget.controller.valueIndicatorStyle.getIndicatorShape(),
           );
-
-          return SliderTheme(
-            data: themeData,
-            child: widget.controller.enableRange ? _buildRangeSlider(context, decimalPlaces):
-            Slider(
-              value: widget.controller.value,
-              min: widget.controller.minValue,
-              max: widget.controller.maxValue,
-              divisions: widget.controller.divisions,
-              label: widget.controller.value.toStringAsFixed(decimalPlaces),
-              onChanged: isEnabled()
-                  ? (value) {
-                      setState(() {
-                        widget.controller.value = value;
-                      });
-                      if (widget.controller.onChange != null) {
-                        ScreenController().executeAction(
-                          context,
-                          widget.controller.onChange!,
-                          event: EnsembleEvent(widget),
-                        );
-                      }
-                    }
-                  : null,
-            ),
-          );
+return Column(
+  crossAxisAlignment: CrossAxisAlignment.start,
+  mainAxisSize: MainAxisSize.min,
+  children: [
+    SliderTheme(
+      data: themeData,
+      child: widget.controller.enableRange ? _buildRangeSlider(context, decimalPlaces) :
+      Slider(
+        // Slider properties - keep these unchanged
+        value: widget.controller.value,
+        min: widget.controller.minValue,
+        max: widget.controller.maxValue,
+        divisions: widget.controller.divisions,
+        label: widget.controller.value.toStringAsFixed(decimalPlaces),
+        onChanged: isEnabled()
+            ? (value) {
+                setState(() {
+                  widget.controller.value = value;
+                  // Add this line to validate the field
+                  field.validate();
+                });
+                if (widget.controller.onChange != null) {
+                  ScreenController().executeAction(
+                    context,
+                    widget.controller.onChange!,
+                    event: EnsembleEvent(widget),
+                  );
+                }
+              }
+            : null,
+      ),
+    ),
+    // Add this section to display the error message
+    if (field.hasError)
+      Padding(
+        padding: const EdgeInsets.only(top: 4.0, left: 4.0),
+        child: Text(
+          field.errorText!,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.error,
+            fontSize: 12.0,
+          ),
+        ),
+      ),
+  ],
+);
         },
       ),
     );


### PR DESCRIPTION
**Overview:**

This PR adds range slider functionality to the existing EnsembleSlider widget, allowing users to select both a lower and upper value within a specified range. This implementation preserves all existing functionality while adding new capabilities with minimal API changes.

**Features**

- Toggle between single-value and range-slider modes using the enableRange property
- Support for setting start and end values individually or via a single initialRangeValues property
- Compatibility with existing styling composites (track, thumb, tick marks, overlay, value indicators)
- Uses the existing onChange event handler for both slider types for API consistency

Sample EDL & Emulator Output:
![image](https://github.com/user-attachments/assets/6ad0d34e-60e8-4534-93f6-10ee583824d6)
![image](https://github.com/user-attachments/assets/f10a2f53-3d6f-43ca-aa8d-13d9aeea4eb5)

