### PR TITLE
Added Textstyle property for date widget

### DIFF
--- a/modules/ensemble/lib/widget/input/form_date.dart
+++ b/modules/ensemble/lib/widget/input/form_date.dart
@@ -85,77 +85,78 @@ class DateState extends FormFieldWidgetState<Date> {
           .format(widget._controller.value!)
       : '';
 
-@override
-Widget buildWidget(BuildContext context) {
-  // Create a local TextStyle variable that we can modify
+  @override
+  Widget buildWidget(BuildContext context) {
+      // Create a local TextStyle variable that we can modify
   TextStyle dateTextStyle = formFieldTextStyle;
   
   // If textStyle is provided in DateController, apply it
-  if (widget._controller.textStyle != null) {
-    dateTextStyle = dateTextStyle.copyWith(
-      fontSize: widget._controller.textStyle?.fontSize,
-      overflow: widget._controller.textStyle?.overflow ?? TextOverflow.ellipsis,
-      color: widget._controller.textStyle?.color,
-      fontWeight: widget._controller.textStyle?.fontWeight,
-    );
+    if (widget._controller.textStyle != null) {
+      dateTextStyle = dateTextStyle.copyWith(
+        fontSize: widget._controller.textStyle?.fontSize,
+        overflow: widget._controller.textStyle?.overflow ?? TextOverflow.ellipsis,
+        color: widget._controller.textStyle?.color,
+        fontWeight: widget._controller.textStyle?.fontWeight,
+      );
+    }
+    
+    return InputWrapper(
+        type: Date.type,
+        controller: widget.controller,
+        widget: FormField<DateTime>(
+            key: validatorKey,
+            validator: (value) {
+              if (widget._controller.required &&
+                  widget._controller.value == null) {
+                return Utils.translateWithFallback(
+                    'ensemble.input.required', widget._controller.requiredMessage ?? 'This field is required');
+              }
+              return null;
+            },
+            builder: (FormFieldState<DateTime> field) {
+              Widget rtn = InkWell(
+                  onTap: isEnabled() ? () => _selectDate(context) : null,
+                  child: InputDecorator(
+                      isEmpty: widget._controller.value == null,
+                      decoration: inputDecoration.copyWith(
+                          errorText: field.errorText,
+                          errorStyle: widget._controller.errorStyle ?? Theme.of(context).inputDecorationTheme.errorStyle,
+                          hintText: widget._controller.placeholder ??
+                              widget._controller.hintText ??
+                              Utils.translateWithFallback(
+                                  'ensemble.input.date.placeholder',
+                                  'Select a date'),
+                          suffixIcon: widget._controller.showCalendarIcon !=
+                                  false
+                              ? Icon(Icons.calendar_month_rounded,
+                                  color:
+                                      dateTextStyle.color?.withOpacity(.5),
+                                  size: ThemeManager()
+                                      .getInputIconSize(context)
+                                      .toDouble())
+                              : null),
+                      child: widget._controller.showClearIcon != false
+                          ? ClearableInput(
+                              text: selectedValue,
+                              textStyle: dateTextStyle,
+                              enabled: widget._controller.enabled ?? true,
+                              onCleared: () {
+                                setState(() {
+                                  widget._controller.value = null;
+                                });
+                              })
+                          : Text(selectedValue, style: dateTextStyle)));
+
+              if (!isEnabled()) {
+                rtn = Opacity(
+                  opacity: .5,
+                  child: rtn,
+                );
+              }
+              return rtn;
+            }));
   }
 
-  return InputWrapper(
-      type: Date.type,
-      controller: widget.controller,
-      widget: FormField<DateTime>(
-          key: validatorKey,
-          validator: (value) {
-            if (widget._controller.required &&
-                widget._controller.value == null) {
-              return Utils.translateWithFallback(
-                  'ensemble.input.required', widget._controller.requiredMessage ?? 'This field is required');
-            }
-            return null;
-          },
-          builder: (FormFieldState<DateTime> field) {
-            Widget rtn = InkWell(
-                onTap: isEnabled() ? () => _selectDate(context) : null,
-                child: InputDecorator(
-                    isEmpty: widget._controller.value == null,
-                    decoration: inputDecoration.copyWith(
-                        errorText: field.errorText,
-                        errorStyle: widget._controller.errorStyle ?? Theme.of(context).inputDecorationTheme.errorStyle,
-                        hintText: widget._controller.placeholder ??
-                            widget._controller.hintText ??
-                            Utils.translateWithFallback(
-                                'ensemble.input.date.placeholder',
-                                'Select a date'),
-                        suffixIcon: widget._controller.showCalendarIcon !=
-                                false
-                            ? Icon(Icons.calendar_month_rounded,
-                                color:
-                                    dateTextStyle.color?.withOpacity(.5),  // Use dateTextStyle here
-                                size: ThemeManager()
-                                    .getInputIconSize(context)
-                                    .toDouble())
-                            : null),
-                    child: widget._controller.showClearIcon != false
-                        ? ClearableInput(
-                            text: selectedValue,
-                            textStyle: dateTextStyle,  // Use dateTextStyle here instead of formFieldTextStyle
-                            enabled: widget._controller.enabled ?? true,
-                            onCleared: () {
-                              setState(() {
-                                widget._controller.value = null;
-                              });
-                            })
-                        : Text(selectedValue, style: dateTextStyle,)));  // Use dateTextStyle here
-
-            if (!isEnabled()) {
-              rtn = Opacity(
-                opacity: .5,
-                child: rtn,
-              );
-            }
-            return rtn;
-          }));
-}
   void _selectDate(BuildContext context) async {
     // massage the dates to ensure initial date falls between firstDate and lastDate
     DateTime firstDate = widget._controller.firstDate ?? DateTime(1900);
@@ -201,4 +202,3 @@ Widget buildWidget(BuildContext context) {
     }
   }
 }
-

--- a/modules/ensemble/lib/widget/input/form_date.dart
+++ b/modules/ensemble/lib/widget/input/form_date.dart
@@ -56,7 +56,8 @@ class Date extends StatefulWidget
       'showCalendarIcon': (shouldShow) =>
           _controller.showCalendarIcon = Utils.optionalBool(shouldShow),
       'onChange': (definition) => _controller.onChange =
-          EnsembleAction.from(definition, initiator: this)
+          EnsembleAction.from(definition, initiator: this),
+      'textStyle': (value) => _controller.textStyle = Utils.getTextStyle(value),
     });
     return setters;
   }
@@ -68,6 +69,7 @@ class DateController extends FormFieldController with HasTextPlaceholder {
   // first and last available dates to be selected
   DateTime? firstDate;
   DateTime? lastDate;
+  TextStyle? textStyle;
 
   bool? showClearIcon;
   bool? showCalendarIcon;
@@ -186,4 +188,14 @@ class DateState extends FormFieldWidgetState<Date> {
       }
     }
   }
+    TextStyle get formFieldTextStyle {
+    TextStyle textStyle = const TextStyle();
+      return textStyle.copyWith(
+        fontSize: widget._controller.textStyle?.fontSize,
+        overflow: widget._controller.textStyle?.overflow ?? TextOverflow.ellipsis,
+        color: widget._controller.textStyle?.color,
+        fontWeight: widget._controller.textStyle?.fontWeight,
+      );
+  }
 }
+

--- a/modules/ensemble/lib/widget/input/form_date.dart
+++ b/modules/ensemble/lib/widget/input/form_date.dart
@@ -85,65 +85,77 @@ class DateState extends FormFieldWidgetState<Date> {
           .format(widget._controller.value!)
       : '';
 
-  @override
-  Widget buildWidget(BuildContext context) {
-    return InputWrapper(
-        type: Date.type,
-        controller: widget.controller,
-        widget: FormField<DateTime>(
-            key: validatorKey,
-            validator: (value) {
-              if (widget._controller.required &&
-                  widget._controller.value == null) {
-                return Utils.translateWithFallback(
-                    'ensemble.input.required', widget._controller.requiredMessage ?? 'This field is required');
-              }
-              return null;
-            },
-            builder: (FormFieldState<DateTime> field) {
-              Widget rtn = InkWell(
-                  onTap: isEnabled() ? () => _selectDate(context) : null,
-                  child: InputDecorator(
-                      isEmpty: widget._controller.value == null,
-                      decoration: inputDecoration.copyWith(
-                          errorText: field.errorText,
-                          errorStyle: widget._controller.errorStyle ?? Theme.of(context).inputDecorationTheme.errorStyle,
-                          hintText: widget._controller.placeholder ??
-                              widget._controller.hintText ??
-                              Utils.translateWithFallback(
-                                  'ensemble.input.date.placeholder',
-                                  'Select a date'),
-                          suffixIcon: widget._controller.showCalendarIcon !=
-                                  false
-                              ? Icon(Icons.calendar_month_rounded,
-                                  color:
-                                      formFieldTextStyle.color?.withOpacity(.5),
-                                  size: ThemeManager()
-                                      .getInputIconSize(context)
-                                      .toDouble())
-                              : null),
-                      child: widget._controller.showClearIcon != false
-                          ? ClearableInput(
-                              text: selectedValue,
-                              textStyle: formFieldTextStyle,
-                              enabled: widget._controller.enabled ?? true,
-                              onCleared: () {
-                                setState(() {
-                                  widget._controller.value = null;
-                                });
-                              })
-                          : Text(selectedValue, style: formFieldTextStyle)));
-
-              if (!isEnabled()) {
-                rtn = Opacity(
-                  opacity: .5,
-                  child: rtn,
-                );
-              }
-              return rtn;
-            }));
+@override
+Widget buildWidget(BuildContext context) {
+  // Create a local TextStyle variable that we can modify
+  TextStyle dateTextStyle = formFieldTextStyle;
+  
+  // If textStyle is provided in DateController, apply it
+  if (widget._controller.textStyle != null) {
+    dateTextStyle = dateTextStyle.copyWith(
+      fontSize: widget._controller.textStyle?.fontSize,
+      overflow: widget._controller.textStyle?.overflow ?? TextOverflow.ellipsis,
+      color: widget._controller.textStyle?.color,
+      fontWeight: widget._controller.textStyle?.fontWeight,
+    );
   }
 
+  return InputWrapper(
+      type: Date.type,
+      controller: widget.controller,
+      widget: FormField<DateTime>(
+          key: validatorKey,
+          validator: (value) {
+            if (widget._controller.required &&
+                widget._controller.value == null) {
+              return Utils.translateWithFallback(
+                  'ensemble.input.required', widget._controller.requiredMessage ?? 'This field is required');
+            }
+            return null;
+          },
+          builder: (FormFieldState<DateTime> field) {
+            Widget rtn = InkWell(
+                onTap: isEnabled() ? () => _selectDate(context) : null,
+                child: InputDecorator(
+                    isEmpty: widget._controller.value == null,
+                    decoration: inputDecoration.copyWith(
+                        errorText: field.errorText,
+                        errorStyle: widget._controller.errorStyle ?? Theme.of(context).inputDecorationTheme.errorStyle,
+                        hintText: widget._controller.placeholder ??
+                            widget._controller.hintText ??
+                            Utils.translateWithFallback(
+                                'ensemble.input.date.placeholder',
+                                'Select a date'),
+                        suffixIcon: widget._controller.showCalendarIcon !=
+                                false
+                            ? Icon(Icons.calendar_month_rounded,
+                                color:
+                                    dateTextStyle.color?.withOpacity(.5),  // Use dateTextStyle here
+                                size: ThemeManager()
+                                    .getInputIconSize(context)
+                                    .toDouble())
+                            : null),
+                    child: widget._controller.showClearIcon != false
+                        ? ClearableInput(
+                            text: selectedValue,
+                            textStyle: dateTextStyle,  // Use dateTextStyle here instead of formFieldTextStyle
+                            enabled: widget._controller.enabled ?? true,
+                            onCleared: () {
+                              setState(() {
+                                widget._controller.value = null;
+                              });
+                            })
+                        : Text(selectedValue, style: dateTextStyle,)));  // Use dateTextStyle here
+
+            if (!isEnabled()) {
+              rtn = Opacity(
+                opacity: .5,
+                child: rtn,
+              );
+            }
+            return rtn;
+          }));
+}
   void _selectDate(BuildContext context) async {
     // massage the dates to ensure initial date falls between firstDate and lastDate
     DateTime firstDate = widget._controller.firstDate ?? DateTime(1900);
@@ -187,15 +199,6 @@ class DateState extends FormFieldWidgetState<Date> {
         }
       }
     }
-  }
-    TextStyle get formFieldTextStyle {
-    TextStyle textStyle = const TextStyle();
-      return textStyle.copyWith(
-        fontSize: widget._controller.textStyle?.fontSize,
-        overflow: widget._controller.textStyle?.overflow ?? TextOverflow.ellipsis,
-        color: widget._controller.textStyle?.color,
-        fontWeight: widget._controller.textStyle?.fontWeight,
-      );
   }
 }
 


### PR DESCRIPTION
This PR introduces a new textStyle property to style the selected date value in the date widget. To maintain backwards compatibility, the implementation includes logic to fall back to using labelStyle for styling date values when textStyle is not specified. This ensures existing applications continue to work as expected without modifications.

Sample EDL and output
![image](https://github.com/user-attachments/assets/b209153b-e698-48bf-baee-27d3798eaf54)
![image](https://github.com/user-attachments/assets/2a6a333a-8f24-46d1-af99-e91644bf7e69)
