### PR TITLE
[Feat] Add secureStorage actions

### DIFF
--- a/modules/ensemble/lib/action/action_invokable.dart
+++ b/modules/ensemble/lib/action/action_invokable.dart
@@ -59,6 +59,8 @@ abstract class ActionInvokable with Invokable {
       ActionType.bluetoothDisconnect,
       ActionType.bluetoothSubscribeCharacteristic,
       ActionType.bluetoothUnsubscribeCharacteristic,
+      ActionType.setSecureStorage,
+      ActionType.clearSecureStorage,
     ]);
   }
 

--- a/modules/ensemble/lib/action/key_chain_actions.dart
+++ b/modules/ensemble/lib/action/key_chain_actions.dart
@@ -71,12 +71,12 @@ class SaveKeychain extends EnsembleAction {
 class ReadKeychain extends EnsembleAction {
   ReadKeychain({
     required this.key,
-    this.onSuccess,
+    this.onComplete,
     this.onError,
   });
 
   final String key;
-  final EnsembleAction? onSuccess;
+  final EnsembleAction? onComplete;
   final EnsembleAction? onError;
 
   factory ReadKeychain.fromYaml({Map? payload}) {
@@ -85,7 +85,7 @@ class ReadKeychain extends EnsembleAction {
     }
     return ReadKeychain(
       key: payload['key'],
-      onSuccess: EnsembleAction.from(payload['onSuccess']),
+      onComplete: EnsembleAction.from(payload['onComplete']),
       onError: EnsembleAction.from(payload['onError']),
     );
   }
@@ -100,11 +100,11 @@ class ReadKeychain extends EnsembleAction {
     if (storageKey != null) {
       try {
         dynamic value = await StorageManager().readSecurely(storageKey);
-        // dispatch onSuccess with the retrieved value
-        if (onSuccess != null && value != null) {
-          ScreenController().executeAction(context, onSuccess!,
+        // dispatch onComplete with the retrieved value
+        if (onComplete != null && value != null) {
+          ScreenController().executeAction(context, onComplete!,
               event: EnsembleEvent(null, data: value));
-        } else if (onSuccess != null && value == null) {
+        } else if (onComplete != null && value == null) {
           // Key exists but value is null
           errorReason = 'No value found for key: $storageKey';
         }

--- a/modules/ensemble/lib/action/key_chain_actions.dart
+++ b/modules/ensemble/lib/action/key_chain_actions.dart
@@ -1,0 +1,177 @@
+
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/data_context.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/keychain_manager.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/storage_manager.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:flutter/widgets.dart';
+
+class SaveKeychain extends EnsembleAction {
+  SaveKeychain({
+    required this.key,
+    this.value,
+    this.onComplete,
+    this.onError,
+  });
+
+  final String key;
+  final dynamic value;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory SaveKeychain.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('${ActionType.saveKeychain} requires a key.');
+    }
+    return SaveKeychain(
+      key: payload['key'],
+      value: payload['value'],
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    String? storageKey =
+        Utils.optionalString(scopeManager.dataContext.eval(key));
+    String? errorReason;
+
+    if (storageKey != null) {
+      try {
+        final datas = {'key': key, 'value': value};
+        await KeychainManager().saveToKeychain(datas);
+        // dispatch onComplete
+        if (onComplete != null) {
+          ScreenController().executeAction(context, onComplete!);
+        }
+      } catch (e) {
+        errorReason = e.toString();
+      }
+    } else {
+      errorReason = '${ActionType.saveKeychain} requires a key.';
+    }
+
+    if (onError != null && errorReason != null) {
+      ScreenController().executeAction(context, onError!,
+          event: EnsembleEvent(null, error: errorReason));
+    }
+    return Future.value(null);
+  }
+}
+
+// The ReadKeychain action retrieves a value from the keychain using the provided key.
+// It is only available in YAML, as this calls a async function whose return type is Future and we use callbacks to handle the result.
+// Our JS is sync and we cannot use async/await in JS. 
+class ReadKeychain extends EnsembleAction {
+  ReadKeychain({
+    required this.key,
+    this.onSuccess,
+    this.onError,
+  });
+
+  final String key;
+  final EnsembleAction? onSuccess;
+  final EnsembleAction? onError;
+
+  factory ReadKeychain.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('${ActionType.readKeychain} requires a key.');
+    }
+    return ReadKeychain(
+      key: payload['key'],
+      onSuccess: EnsembleAction.from(payload['onSuccess']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    String? storageKey =
+        Utils.optionalString(scopeManager.dataContext.eval(key));
+    String? errorReason;
+
+    if (storageKey != null) {
+      try {
+        dynamic value = await StorageManager().readSecurely(storageKey);
+        // dispatch onSuccess with the retrieved value
+        if (onSuccess != null && value != null) {
+          ScreenController().executeAction(context, onSuccess!,
+              event: EnsembleEvent(null, data: value));
+        } else if (onSuccess != null && value == null) {
+          // Key exists but value is null
+          errorReason = 'No value found for key: $storageKey';
+        }
+      } catch (e) {
+        errorReason = e.toString();
+      }
+    } else {
+      errorReason = '${ActionType.readKeychain} requires a key.';
+    }
+
+    if (onError != null && errorReason != null) {
+      ScreenController().executeAction(context, onError!,
+          event: EnsembleEvent(null, error: errorReason));
+    }
+    return Future.value(null);
+  }
+}
+
+
+class ClearKeychain extends EnsembleAction {
+  ClearKeychain({
+    required this.key,
+    this.onComplete,
+    this.onError,
+  });
+
+  final String key;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory ClearKeychain.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('${ActionType.clearKeychain} requires a key.');
+    }
+    return ClearKeychain(
+      key: payload['key'],
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    String? storageKey =
+        Utils.optionalString(scopeManager.dataContext.eval(key));
+    String? errorReason;
+
+    if (storageKey != null) {
+      try {
+        final datas = {'key': key};
+        await KeychainManager().clearKeychain(datas);
+        // dispatch onComplete
+        if (onComplete != null) {
+          ScreenController().executeAction(context, onComplete!);
+        }
+      } catch (e) {
+        errorReason = e.toString();
+      }
+    } else {
+      errorReason = '${ActionType.clearKeychain} requires a key.';
+    }
+
+    if (onError != null && errorReason != null) {
+      ScreenController().executeAction(context, onError!,
+          event: EnsembleEvent(null, error: errorReason));
+    }
+    return Future.value(null);
+  }
+}

--- a/modules/ensemble/lib/action/secure_storage.dart
+++ b/modules/ensemble/lib/action/secure_storage.dart
@@ -64,12 +64,12 @@ class SetSecureStorage extends EnsembleAction {
 class GetSecureStorage extends EnsembleAction {
   GetSecureStorage({
     required this.key,
-    this.onSuccess,
+    this.onComplete,
     this.onError,
   });
 
   final String key;
-  final EnsembleAction? onSuccess;
+  final EnsembleAction? onComplete;
   final EnsembleAction? onError;
 
   factory GetSecureStorage.fromYaml({Map? payload}) {
@@ -78,7 +78,7 @@ class GetSecureStorage extends EnsembleAction {
     }
     return GetSecureStorage(
       key: payload['key'],
-      onSuccess: EnsembleAction.from(payload['onSuccess']),
+      onComplete: EnsembleAction.from(payload['onComplete']),
       onError: EnsembleAction.from(payload['onError']),
     );
   }
@@ -94,8 +94,8 @@ class GetSecureStorage extends EnsembleAction {
       
       final value = EncryptedStorageManager.getSecureStorage(inputs);
       
-      if (onSuccess != null) {
-        ScreenController().executeAction(context, onSuccess!,
+      if (onComplete != null) {
+        ScreenController().executeAction(context, onComplete!,
             event: EnsembleEvent(null, data: value));
       }
     } catch (e) {

--- a/modules/ensemble/lib/action/secure_storage.dart
+++ b/modules/ensemble/lib/action/secure_storage.dart
@@ -1,0 +1,155 @@
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/data_context.dart';
+import 'package:ensemble/framework/encrypted_storage_manager.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:ensemble/util/utils.dart';
+
+class SetSecureStorage extends EnsembleAction {
+  SetSecureStorage({
+    required this.key,
+    this.value,
+    this.onComplete,
+    this.onError,
+  });
+
+  final String key;
+  final dynamic value;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory SetSecureStorage.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('setSecureStorage requires a key.');
+    }
+    return SetSecureStorage(
+      key: payload['key'],
+      value: payload['value'],
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    try {
+      final evaluatedKey = scopeManager.dataContext.eval(key);
+      final evaluatedValue = scopeManager.dataContext.eval(value);
+      
+      // Create inputs in the format expected by EncryptedStorageManager
+      final inputs = {
+        'key': evaluatedKey,
+        'value': evaluatedValue,
+      };
+      
+      EncryptedStorageManager.setSecureStorage(inputs);
+      
+      if (onComplete != null) {
+        ScreenController().executeAction(context, onComplete!);
+      }
+    } catch (e) {
+      if (onError != null) {
+        ScreenController().executeAction(context, onError!,
+            event: EnsembleEvent(null, error: e.toString()));
+      }
+    }
+    return Future.value(null);
+  }
+}
+
+class GetSecureStorage extends EnsembleAction {
+  GetSecureStorage({
+    required this.key,
+    this.onSuccess,
+    this.onError,
+  });
+
+  final String key;
+  final EnsembleAction? onSuccess;
+  final EnsembleAction? onError;
+
+  factory GetSecureStorage.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('getSecureStorage requires a key.');
+    }
+    return GetSecureStorage(
+      key: payload['key'],
+      onSuccess: EnsembleAction.from(payload['onSuccess']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    try {
+      final evaluatedKey = scopeManager.dataContext.eval(key);
+      
+      // Create inputs in the format expected by EncryptedStorageManager
+      final inputs = {'key': evaluatedKey};
+      
+      final value = EncryptedStorageManager.getSecureStorage(inputs);
+      
+      if (onSuccess != null) {
+        ScreenController().executeAction(context, onSuccess!,
+            event: EnsembleEvent(null, data: value));
+      }
+    } catch (e) {
+      if (onError != null) {
+        ScreenController().executeAction(context, onError!,
+            event: EnsembleEvent(null, error: e.toString()));
+      }
+    }
+    return Future.value(null);
+  }
+}
+
+class ClearSecureStorage extends EnsembleAction {
+  ClearSecureStorage({
+    required this.key,
+    this.onComplete,
+    this.onError,
+  });
+
+  final String key;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory ClearSecureStorage.fromYaml({Map? payload}) {
+    if (payload == null || payload['key'] == null) {
+      throw ConfigError('clearSecureStorage requires a key.');
+    }
+    return ClearSecureStorage(
+      key: payload['key'],
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future execute(BuildContext context, ScopeManager scopeManager,
+      {DataContext? dataContext}) async {
+    try {
+      final evaluatedKey = scopeManager.dataContext.eval(key);
+      
+      // Create inputs in the format expected by EncryptedStorageManager
+      final inputs = {'key': evaluatedKey};
+      
+      EncryptedStorageManager.clearSecureStorage(inputs);
+      
+      if (onComplete != null) {
+        ScreenController().executeAction(context, onComplete!);
+      }
+    } catch (e) {
+      if (onError != null) {
+        ScreenController().executeAction(context, onError!,
+            event: EnsembleEvent(null, error: e.toString()));
+      }
+    }
+    return Future.value(null);
+  }
+}

--- a/modules/ensemble/lib/action/secure_storage.dart
+++ b/modules/ensemble/lib/action/secure_storage.dart
@@ -86,13 +86,14 @@ class GetSecureStorage extends EnsembleAction {
   @override
   Future execute(BuildContext context, ScopeManager scopeManager,
       {DataContext? dataContext}) async {
+        var value;
     try {
       final evaluatedKey = scopeManager.dataContext.eval(key);
       
       // Create inputs in the format expected by EncryptedStorageManager
       final inputs = {'key': evaluatedKey};
       
-      final value = EncryptedStorageManager.getSecureStorage(inputs);
+      value = EncryptedStorageManager.getSecureStorage(inputs);
       
       if (onComplete != null) {
         ScreenController().executeAction(context, onComplete!,
@@ -104,7 +105,7 @@ class GetSecureStorage extends EnsembleAction {
             event: EnsembleEvent(null, error: e.toString()));
       }
     }
-    return Future.value(null);
+    return Future.value(value);
   }
 }
 

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -19,6 +19,7 @@ import 'package:ensemble/framework/apiproviders/http_api_provider.dart';
 import 'package:ensemble/framework/config.dart';
 import 'package:ensemble/framework/data_utils.dart';
 import 'package:ensemble/framework/device.dart';
+import 'package:ensemble/framework/encrypted_storage_manager.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/keychain_manager.dart';
 import 'package:ensemble/framework/app_info.dart';
@@ -91,12 +92,11 @@ class DataContext implements Context {
     _addLegacyDataContext();
   }
 
-
-    // device is a common name. If user already uses that, don't override it
-    // This is now in ensemble.device.*
+  // device is a common name. If user already uses that, don't override it
+  // This is now in ensemble.device.*
   void _addLegacyDataContext() {
     if (_contextMap['device'] == null) {
-        _contextMap['device'] = Device();
+      _contextMap['device'] = Device();
     }
   }
 
@@ -551,6 +551,12 @@ class NativeInvokable extends ActionInvokable {
         final evalMessage = scope?.dataContext.eval(message);
         messageSocket(socketName, evalMessage);
       },
+      ActionType.setSecureStorage.name: (dynamic inputs) =>
+          EncryptedStorageManager.setSecureStorage(inputs),
+      ActionType.getSecureStorage.name: (dynamic inputs) =>
+          EncryptedStorageManager.getSecureStorage(inputs),
+      ActionType.clearSecureStorage.name: (dynamic inputs) =>
+          EncryptedStorageManager.clearSecureStorage(inputs),
       ActionType.dispatchEvent.name: (inputs) =>
           ScreenController().executeAction(
             buildContext,

--- a/modules/ensemble/lib/framework/data_context.dart
+++ b/modules/ensemble/lib/framework/data_context.dart
@@ -551,12 +551,10 @@ class NativeInvokable extends ActionInvokable {
         final evalMessage = scope?.dataContext.eval(message);
         messageSocket(socketName, evalMessage);
       },
-      ActionType.setSecureStorage.name: (dynamic inputs) =>
-          EncryptedStorageManager.setSecureStorage(inputs),
+      // Have to use getSecureStorage from here, as action_invokables return future value,
+      // and we don't want to wait for it.
       ActionType.getSecureStorage.name: (dynamic inputs) =>
           EncryptedStorageManager.getSecureStorage(inputs),
-      ActionType.clearSecureStorage.name: (dynamic inputs) =>
-          EncryptedStorageManager.clearSecureStorage(inputs),
       ActionType.dispatchEvent.name: (inputs) =>
           ScreenController().executeAction(
             buildContext,

--- a/modules/ensemble/lib/framework/encrypted_storage_manager.dart
+++ b/modules/ensemble/lib/framework/encrypted_storage_manager.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+import 'package:encrypt/encrypt.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/storage_manager.dart';
+import 'package:ensemble/framework/secrets.dart';
+import 'package:ensemble/util/utils.dart';
+
+class EncryptedStorageManager {
+  static final EncryptedStorageManager _instance =
+      EncryptedStorageManager._internal();
+  static Key? _key;
+  static Encrypter? _encrypter;
+  static const String PREFIX = 'enc_';
+
+  EncryptedStorageManager._internal();
+
+  factory EncryptedStorageManager() => _instance;
+
+  static void _ensureInitialized() {
+    if (_encrypter != null) return;
+
+    final keyString = SecretsStore().getProperty('encryptionKey');
+
+    if (keyString == null) {
+      throw LanguageError(
+          'Encryption key not found in secrets. Please add "encryptionKey" to your secrets configuration.');
+    }
+
+    if (keyString.length != 32) {
+      throw LanguageError(
+          'Encryption key must be exactly 32 characters. Current length: ${keyString.length}');
+    }
+
+    _key = Key.fromUtf8(keyString);
+    _encrypter = Encrypter(AES(_key!, mode: AESMode.cbc));
+  }
+
+  static void setSecureStorage(dynamic inputs) {
+    String key;
+    dynamic val;
+
+    // Handle different input formats
+    if (inputs is Map) {
+      key = _extractKey(inputs, 'setSecureStorage');
+      val = inputs['value'];
+    } else if (inputs is String) {
+      key = inputs;
+      val = null;
+    } else {
+      throw LanguageError(
+          'Invalid inputs for setSecureStorage. Expected Map or String.');
+    }
+
+    if (val == null) {
+      StorageManager().remove(PREFIX + key);
+      return;
+    }
+
+    try {
+      final encryptedValue = _encryptValue(val);
+      print('original value: $val');
+      print('Encrypted value: $encryptedValue');
+      StorageManager().write(PREFIX + key, encryptedValue);
+    } catch (e) {
+      throw LanguageError('Failed to encrypt and store value: ${e.toString()}');
+    }
+  }
+
+  static dynamic getSecureStorage(dynamic inputs) {
+    final key = _extractKey(inputs, 'getSecureStorage');
+
+    try {
+      final storedValue = StorageManager().read(PREFIX + key);
+      if (storedValue == null) return null;
+
+      return _decryptValue(storedValue);
+    } catch (e) {
+      // Log error for debugging but return null to avoid breaking the app
+      print('Error getting secure storage for key $key: $e');
+      return null;
+    }
+  }
+
+  static void clearSecureStorage(dynamic inputs) {
+    final key = _extractKey(inputs, 'clearSecureStorage');
+    StorageManager().remove(PREFIX + key);
+  }
+
+  // Utility function to extract key from various input formats
+  static String _extractKey(dynamic inputs, String functionName) {
+    String key;
+
+    if (inputs is Map) {
+      key = Utils.optionalString(inputs['key']) ?? '';
+    } else if (inputs is String) {
+      key = inputs;
+    } else {
+      throw LanguageError(
+          'Invalid inputs for $functionName. Expected Map or String.');
+    }
+
+    if (key.isEmpty) {
+      throw LanguageError('Storage key cannot be empty');
+    }
+
+    return key;
+  }
+
+  // Utility function to convert value to encrypted string
+  static String _encryptValue(dynamic value) {
+    _ensureInitialized();
+
+    String plainText;
+    if (value is String) {
+      plainText = value;
+    } else if (value is Map || value is List) {
+      plainText = json.encode(value);
+    } else {
+      plainText = value.toString();
+    }
+
+    if (plainText.isEmpty) {
+      plainText = " "; // Handle empty strings
+    }
+
+    final iv = IV.fromSecureRandom(16);
+    final encrypted = _encrypter!.encrypt(plainText, iv: iv);
+    return iv.base64 + ':' + encrypted.base64;
+  }
+
+  // Utility function to decrypt value from stored string
+  static dynamic _decryptValue(String storedValue) {
+    _ensureInitialized();
+
+    final parts = storedValue.split(':');
+    if (parts.length != 2) {
+      // Invalid format, possibly corrupted data
+      return null;
+    }
+
+    final iv = IV.fromBase64(parts[0]);
+    final encrypted = Encrypted.fromBase64(parts[1]);
+
+    final decrypted = _encrypter!.decrypt(encrypted, iv: iv);
+
+    // Handle empty string placeholder
+    if (decrypted == " ") {
+      return "";
+    }
+
+    // Try to parse as JSON if it looks like JSON
+    if ((decrypted.startsWith('{') && decrypted.endsWith('}')) ||
+        (decrypted.startsWith('[') && decrypted.endsWith(']'))) {
+      try {
+        return json.decode(decrypted);
+      } catch (e) {
+        // Not valid JSON, return as string
+      }
+    }
+
+    return decrypted;
+  }
+}

--- a/modules/ensemble/lib/framework/encrypted_storage_manager.dart
+++ b/modules/ensemble/lib/framework/encrypted_storage_manager.dart
@@ -43,6 +43,8 @@ class EncryptedStorageManager {
     if (inputs is Map) {
       key = _extractKey(inputs, 'setSecureStorage');
       val = inputs['value'];
+      print('Value to store: $val');
+
     } else if (inputs is String) {
       key = inputs;
       val = null;
@@ -56,21 +58,25 @@ class EncryptedStorageManager {
       return;
     }
 
+
+
     try {
       final encryptedValue = _encryptValue(val);
-      print('original value: $val');
       print('Encrypted value: $encryptedValue');
       StorageManager().write(PREFIX + key, encryptedValue);
     } catch (e) {
+      print('Error encrypting value: $e');
       throw LanguageError('Failed to encrypt and store value: ${e.toString()}');
     }
   }
 
   static dynamic getSecureStorage(dynamic inputs) {
+    print('getSecureStorage called with inputs: $inputs');
     final key = _extractKey(inputs, 'getSecureStorage');
-
+    print('Extracted key: $key');
     try {
       final storedValue = StorageManager().read(PREFIX + key);
+      print('Stored value: $storedValue');
       if (storedValue == null) return null;
 
       return _decryptValue(storedValue);

--- a/modules/ensemble/lib/framework/keychain_manager.dart
+++ b/modules/ensemble/lib/framework/keychain_manager.dart
@@ -19,6 +19,15 @@ class KeychainManager {
     }
   }
 
+  Future<dynamic> getFromKeychain(dynamic inputs) async {
+    try {
+      final key = inputs?['key'] as String;
+      return await StorageManager().readSecurely(key);
+    } catch (e) {
+      throw LanguageError('Failed to retrieve value. Reason: ${e.toString()}');
+    }
+  }
+
   Future<void> clearKeychain(dynamic inputs) async {
     try {
       final key = inputs?['key'] as String;

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -100,6 +100,7 @@ dependencies:
   flutter_i18n: ^0.35.1
   pointer_interceptor: ^0.9.3+4
   flutter_secure_storage: ^9.2.2
+  encrypt: ^5.0.3
   staggered_grid_view_flutter: ^0.0.4
   dart_jsonwebtoken: ^2.8.2
   flutter_dotenv: ^5.1.0


### PR DESCRIPTION
Ticket: https://github.com/EnsembleUI/ensemble/issues/1984
docs: https://github.com/EnsembleUI/ensemble_docs/pull/82
Schema: https://github.com/EnsembleUI/ensemble-web-studio/pull/1639

When we were using `ensemble.storage.variable`, it was storing user information in plain text in the device, which is not ideal way to do it as it may caontain sensitive information.

So we can use `keyChain` & `keyStore` for secure storage, for which we already have action `saveKeyChain` to store the values, it can be used in the YAML and JS, both ways.

But we didn't had any way to read those values back, so i introduced a new action `readKeyChain`. It is only available in YAML, as this calls a async function whose return type is Future and we use callbacks to handle the result. Our JS is sync and we cannot use async/await in JS. 
```yaml
readKeyChain:
  key: adminPassword
  onComplete:
    invokeAPI:
      name: apiName
      inputs:
        adminPass: ${event.data.value} # it would be the value of the above key.
```

But for JS compatibility, i added 2 new actions `SetSecureStorage ` and `GetSecureStorage `. It encrypts the text using the technique `AES (Advanced Encryption Standard) in CBC mode` which gets the encryptionKey form the secrets. Wot it does is
- its gets the Plain text from action, encrypt it and store it in base64 in device storage.
- When we need it, it decrypt the encrypted_text and then pass it back to the UI to show the plain text.

Usage in Yaml
- With simple string as value
```yaml
setSecureStorage:
  key: adminPassword
  value: 'simpleString'     // stored as something asldakljd790asd9#asd@==
```
- with object as value
```yaml
setSecureStorage:
  key: adminPassword
  value:
     userName: 'username123'
     password: 'password123'
```
- Getting value back
```yaml
getSecureStorage:
  key: adminPassword
  onComplete:
    invokeAPI:
      name: apiName
      inputs:
        adminPass: ${event.data.value} # it would be the value of the above key.
```

Usage in JS:
```JS
// To save the value
ensemble.setSecureStorage({
  'key': 'name',
  'value': 'EnsembleUI'
});

// To get the value
ensemble.getSecureStorage({'key': 'name'});
// can also get value as
ensemble.getSecureStorage('name');
```
