### PR TITLE
added support for hiding header onListViewScroll

### DIFF
--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -38,6 +38,8 @@ const String backgroundBluetoothSubscribeTask = 'backgroundBluetoothSubscribeTas
 const String ensembleMethodChannelName = 'com.ensembleui.host.platform';
 GlobalKey<NavigatorState>? externalAppNavigateKey;
 ScrollController? externalScrollController;
+Map<String, ScrollController> persistentControllers = {};
+String? currentPageKey;
 
 @pragma('vm:entry-point')
 void callbackDispatcher() {

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -646,6 +646,8 @@ body: FooterLayout(
     );
   }
 Widget buildScrollablePageContentWithCollapsableHeader(bool hasDrawer) {
+    externalScrollController = ScrollController();
+
     return NestedScrollView(
       controller: externalScrollController,
       physics: ClampingScrollPhysics(),

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -215,6 +215,9 @@ class PageState extends State<Page>
 
   @override
   void initState() {
+      currentPageKey = widget._pageModel.hashCode.toString();
+      externalScrollController = ScrollController();
+      persistentControllers[currentPageKey!] = externalScrollController!;
     WidgetsBinding.instance.addObserver(this);
     _scopeManager = ScopeManager(
         widget._initialDataContext
@@ -647,10 +650,6 @@ body: FooterLayout(
     );
   }
 Widget buildScrollablePageContentWithCollapsableHeader(bool hasDrawer) {
-
-    externalScrollController = ScrollController();
-    persistentControllers[currentPageKey!] = externalScrollController!;
-
     return NestedScrollView(
       controller: externalScrollController,
       physics: ClampingScrollPhysics(),

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -197,6 +197,8 @@ class PageState extends State<Page>
   void didPopNext() {
     super.didPopNext();
       currentPageKey = widget._pageModel.hashCode.toString();
+      externalScrollController = ScrollController();
+      persistentControllers[currentPageKey!] = externalScrollController!;
     if (widget._pageModel.viewBehavior.onResume != null) {
       ScreenController().executeActionWithScope(
           context, _scopeManager, widget._pageModel.viewBehavior.onResume!,
@@ -645,35 +647,27 @@ body: FooterLayout(
     );
   }
 Widget buildScrollablePageContentWithCollapsableHeader(bool hasDrawer) {
-        bool isScrollableView = widget._pageModel.runtimeStyles?['scrollableView'] == true;
-if (isScrollableView) {
-  currentPageKey = widget._pageModel.hashCode.toString();
-  if (persistentControllers.containsKey(currentPageKey!)) {
+
     externalScrollController = ScrollController();
     persistentControllers[currentPageKey!] = externalScrollController!;
-  } else {
-    externalScrollController = ScrollController();
-    persistentControllers[currentPageKey!] = externalScrollController!;
-  }
-}
-  return NestedScrollView(
-    controller: externalScrollController,
-    physics: ClampingScrollPhysics(),
-    headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-      List<Widget> slivers = [];
-      // Build the AppBar using your existing method
-      Widget? appBar = buildSliverAppBar(widget._pageModel, hasDrawer);
 
-      // Add AppBar to slivers if it exists and is not manually hidden
-      if (appBar != null) {
-        slivers.add(appBar);
-      }
-      
-      return slivers;
-    },
-    body: getBody(true), // Pass true since we have a header structure
-  );
+    return NestedScrollView(
+      controller: externalScrollController,
+      physics: ClampingScrollPhysics(),
+      headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+        List<Widget> slivers = [];
+        // Build the AppBar using your existing method
+        Widget? appBar = buildSliverAppBar(widget._pageModel, hasDrawer);
 
+        // Add AppBar to slivers if it exists and is not manually hidden
+        if (appBar != null) {
+          slivers.add(appBar);
+        }
+
+        return slivers;
+      },
+      body: getBody(true), // Pass true since we have a header structure
+    );
   }
 
   Widget getBody(bool hasAppBar) {

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -196,9 +196,7 @@ class PageState extends State<Page>
   @override
   void didPopNext() {
     super.didPopNext();
-      currentPageKey = widget._pageModel.hashCode.toString();
       externalScrollController = ScrollController();
-      persistentControllers[currentPageKey!] = externalScrollController!;
     if (widget._pageModel.viewBehavior.onResume != null) {
       ScreenController().executeActionWithScope(
           context, _scopeManager, widget._pageModel.viewBehavior.onResume!,
@@ -215,9 +213,7 @@ class PageState extends State<Page>
 
   @override
   void initState() {
-      currentPageKey = widget._pageModel.hashCode.toString();
       externalScrollController = ScrollController();
-      persistentControllers[currentPageKey!] = externalScrollController!;
     WidgetsBinding.instance.addObserver(this);
     _scopeManager = ScopeManager(
         widget._initialDataContext

--- a/modules/ensemble/lib/layout/helpers/list_view_core.dart
+++ b/modules/ensemble/lib/layout/helpers/list_view_core.dart
@@ -103,6 +103,7 @@ class _ListViewCoreState extends State<ListViewCore> {
   late final Debouncer debounce;
   late final Debouncer _scrollDebouce;
   late final ScrollController _scrollController;
+  double _previousOffset = 0.0;
 
   int? _lastFetchedIndex;
 
@@ -161,16 +162,24 @@ class _ListViewCoreState extends State<ListViewCore> {
     // given the nestedScroll property is set to true and View is Scrollable
     // Note that we are not using jumpTo to avoid jerky movement of external
     // Scroll instead we are using animateTo which is smoother than jumpTo
+    ScrollController? currentExternalScrollController = persistentControllers[currentPageKey];
     if (externalScrollController != null &&
         widget.nestedScroll &&
         widget.shrinkWrap) {
-      final currentOffset = _scrollController.position.pixels;
+      _scrollController.addListener(() {
+        
+      final currentOffset = _scrollController.offset;
+      final scrollingUp = currentOffset > _previousOffset;
+      final scrollingDown = currentOffset < _previousOffset;
 
-      externalScrollController!.animateTo(
-        currentOffset,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
+      if (scrollingUp) {
+        currentExternalScrollController!.animateTo(100, duration: const Duration(milliseconds: 16), curve: Curves.linear);
+      } else if (scrollingDown && currentOffset > 0) {
+        currentExternalScrollController!.jumpTo(0);
+      }
+
+      _previousOffset = currentOffset;
+    });
     }
   }
 

--- a/modules/ensemble/lib/layout/helpers/list_view_core.dart
+++ b/modules/ensemble/lib/layout/helpers/list_view_core.dart
@@ -162,7 +162,7 @@ class _ListViewCoreState extends State<ListViewCore> {
     // given the nestedScroll property is set to true and View is Scrollable
     // Note that we are not using jumpTo to avoid jerky movement of external
     // Scroll instead we are using animateTo which is smoother than jumpTo
-    ScrollController? currentExternalScrollController = persistentControllers[currentPageKey];
+    ScrollController? currentExternalScrollController = externalScrollController;
     if (externalScrollController != null &&
         widget.nestedScroll &&
         widget.shrinkWrap) {


### PR DESCRIPTION
Added support for hiding header when a user scrolls in listview. 

- added a new function buildScrollablePageContentWithCollapsableHeader that will be invoked only if we have set collapsableHeader property true in header styles

- when header collaps, body exceeds the defined SafeArea, to prevent this, I've added safe area for this scenario as well. we will need to set collapseSafeArea to true in header styles
- also added floating property to AnimationHeader
