### PR TITLE
chore: update Gradle and plugin versions

### DIFF
--- a/starter/android/app/build.gradle
+++ b/starter/android/app/build.gradle
@@ -61,6 +61,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     buildFeatures {
@@ -131,4 +132,5 @@ dependencies {
             prefer '$work_version'
         }
     }
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }

--- a/starter/android/build.gradle
+++ b/starter/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/starter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/starter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/starter/android/settings.gradle
+++ b/starter/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "2.1.10" apply false
 }
 


### PR DESCRIPTION
- Upgraded Android Gradle plugin from 8.1.0 to 8.6.0 in build.gradle and settings.gradle for improved features and performance.
- Enabled core library desugaring in app build.gradle to support newer Java language features.
- Updated Gradle wrapper to version 8.7 in gradle-wrapper.properties for better compatibility and enhancements.