### PR TITLE
fix: refine route change subscription logic in PageGroupState

### DIFF
--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -142,13 +142,15 @@ class PageGroupState extends State<PageGroup>
   }
   @override
   void didChangeDependencies() {
-    super.didChangeDependencies();
+    if (widget.menu is BottomNavBarMenu) {
+      super.didChangeDependencies();
 
-    // Subscribe to route changes to detect when we return to this ViewGroup
-    var route = ModalRoute.of(context);
-    if (route is PageRoute) {
-      Ensemble().routeObserver.unsubscribe(this);
-      Ensemble().routeObserver.subscribe(this, route);
+      // Subscribe to route changes to detect when we return to this ViewGroup
+      var route = ModalRoute.of(context);
+      if (route is PageRoute) {
+        Ensemble().routeObserver.unsubscribe(this);
+        Ensemble().routeObserver.subscribe(this, route);
+      }
     }
   }
 


### PR DESCRIPTION
- Updated the didChangeDependencies method to only call super and subscribe to route changes when the menu is of type BottomNavBarMenu, improving the component's behavior and performance.