### PR TITLE
fix: semantics handling for aria-label

### DIFF
--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -177,18 +177,23 @@ abstract class EWidgetState<W extends HasController>
           child: rtn,
         );
       }
-      if(widgetController.semantics != null){
+      // If semantics is provided, use it. Otherwise, if label exists on the controller, use it as semantics label.
+      final String? semanticsLabel = widgetController.getSemanticsLabel();
+      if (semanticsLabel != null || widgetController.semantics != null) {
+        final semantics = widgetController.semantics;
         rtn = Semantics(
-          label: widgetController.semantics!.label,
-          hint: widgetController.semantics!.hint,
-          focusable: widgetController.semantics!.focusable,
-          child: FocusTraversalGroup(
-            policy: ReadingOrderTraversalPolicy(),
-            child: FocusableActionDetector(
-              enabled: widgetController.semantics!.focusable,
-              child: rtn,
-            ),
-          ),
+          label: semanticsLabel,
+          hint: semantics?.hint,
+          focusable: semantics?.focusable,
+          child: semantics?.focusable == true
+              ? FocusTraversalGroup(
+                  policy: ReadingOrderTraversalPolicy(),
+                  child: FocusableActionDetector(
+                    enabled: true,
+                    child: rtn,
+                  ),
+                )
+              : rtn,
         );
       }
     }

--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -241,6 +241,18 @@ abstract class WidgetController extends Controller with HasStyles {
 
   set testId(value) => _testId = value;
 
+  /// Returns the best available label for semantics/aria-label accessibility.
+  /// Widgets should set [label] if they want to participate in accessibility fallback.
+  String? getSemanticsLabel() {
+    if (semantics?.label != null && semantics!.label!.isNotEmpty) {
+      return semantics!.label;
+    }
+    if (label != null && label!.isNotEmpty) {
+      return label;
+    }
+    return null;
+  }
+
   @override
   Map<String, Function> getBaseGetters() {
     return {
@@ -262,7 +274,8 @@ abstract class WidgetController extends Controller with HasStyles {
       'flex': (value) => flex = Utils.optionalInt(value, min: 1),
       'expanded': (value) => expanded = Utils.getBool(value, fallback: false),
       'visible': (value) => visible = Utils.getBool(value, fallback: true),
-      'opacity': (value) => opacity = Utils.optionalDouble(value, min: 0, max: 1),
+      'opacity': (value) =>
+          opacity = Utils.optionalDouble(value, min: 0, max: 1),
       'visibilityTransitionDuration': (value) =>
           visibilityTransitionDuration = Utils.getDuration(value),
       'elevation': (value) =>
@@ -287,7 +300,8 @@ abstract class WidgetController extends Controller with HasStyles {
       'classList': (value) => classList = value,
       'className': (value) => className = value,
       'tooltip': (value) => toolTip = Utils.getMap(value),
-      'semantics': (value) => semantics = EnsembleSemantics.fromYaml(Utils.getMap(value)),
+      'semantics': (value) =>
+          semantics = EnsembleSemantics.fromYaml(Utils.getMap(value)),
     };
   }
 
@@ -490,7 +504,8 @@ abstract class EnsembleWidgetController extends EnsembleController
       'flexMode': (value) => flexMode = FlexMode.values.from(value),
       'flex': (value) => flex = Utils.optionalInt(value, min: 1),
       'visible': (value) => visible = Utils.getBool(value, fallback: true),
-      'opacity': (value) => opacity = Utils.optionalDouble(value, min: 0, max: 1),
+      'opacity': (value) =>
+          opacity = Utils.optionalDouble(value, min: 0, max: 1),
       'visibilityTransitionDuration': (value) =>
           visibilityTransitionDuration = Utils.getDuration(value),
       'textDirection': (value) => textDirection = Utils.getTextDirection(value),
@@ -514,8 +529,9 @@ abstract class EnsembleWidgetController extends EnsembleController
       'classList': (value) => classList = value,
       'className': (value) => className = value,
       'tooltip': (value) => toolTip = Utils.getMap(value),
-      'semantics': (value) => semantics = EnsembleSemantics.fromYaml(Utils.getMap(value)),
-      };
+      'semantics': (value) =>
+          semantics = EnsembleSemantics.fromYaml(Utils.getMap(value)),
+    };
   }
 
   bool hasPositions() {
@@ -590,7 +606,7 @@ class EnsembleSemantics {
   String? label;
   String? hint;
 
-  EnsembleSemantics({this.label, this.hint,required this.focusable});
+  EnsembleSemantics({this.label, this.hint, required this.focusable});
 
   // Factory constructor to map from YAML
   factory EnsembleSemantics.fromYaml(Map<String, dynamic>? yamlMap) {


### PR DESCRIPTION
- Introduced a new method `getSemanticsLabel` in `WidgetController` to provide a fallback for accessibility labels.
- Updated `EWidgetState` to utilize the new semantics label method, improving accessibility support by conditionally using the controller's semantics or label.
- Refactored semantics handling to streamline the focusable widget logic.