### PR TITLE
fix: semantics handling for aria-label

### DIFF
--- a/modules/ensemble/lib/framework/widget/widget.dart
+++ b/modules/ensemble/lib/framework/widget/widget.dart
@@ -177,18 +177,24 @@ abstract class EWidgetState<W extends HasController>
           child: rtn,
         );
       }
-      if(widgetController.semantics != null){
+
+      // If semantics is provided, use it. Otherwise, if label exists on the controller, use it as label for aria-label.
+      final String? semanticsLabel = widgetController.getSemanticsLabel();
+      if (widgetController.semantics != null) {
+        final semantics = widgetController.semantics;
         rtn = Semantics(
-          label: widgetController.semantics!.label,
-          hint: widgetController.semantics!.hint,
-          focusable: widgetController.semantics!.focusable,
-          child: FocusTraversalGroup(
-            policy: ReadingOrderTraversalPolicy(),
-            child: FocusableActionDetector(
-              enabled: widgetController.semantics!.focusable,
-              child: rtn,
-            ),
-          ),
+          label: semanticsLabel!,
+          hint: semantics?.hint,
+          focusable: semantics?.focusable,
+          child: semantics?.focusable == true
+              ? FocusTraversalGroup(
+                  policy: ReadingOrderTraversalPolicy(),
+                  child: FocusableActionDetector(
+                    enabled: true,
+                    child: rtn,
+                  ),
+                )
+              : rtn,
         );
       }
     }

--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -241,6 +241,18 @@ abstract class WidgetController extends Controller with HasStyles {
 
   set testId(value) => _testId = value;
 
+  /// Returns the best available label for semantics/aria-label accessibility.
+  /// Widgets should set [label] if they want to participate in accessibility fallback.
+  String? getSemanticsLabel() {
+    if (semantics?.label != null && semantics!.label!.isNotEmpty) {
+      return semantics!.label;
+    }
+    if (label != null && label!.isNotEmpty) {
+      return label;
+    }
+    return null;
+  }
+
   @override
   Map<String, Function> getBaseGetters() {
     return {


### PR DESCRIPTION
- Introduced a new method `getSemanticsLabel` in `WidgetController` to provide a fallback for accessibility labels.
- Updated `EWidgetState` to utilize the new semantics label method, improving accessibility support by conditionally using the controller's semantics or label.
- Refactored semantics handling to streamline the focusable widget logic.