### PR TITLE
feat(stripe): add Stripe payment integration module

### DIFF
--- a/modules/ensemble/lib/action/stripe_actions.dart
+++ b/modules/ensemble/lib/action/stripe_actions.dart
@@ -15,13 +15,13 @@ class ShowPaymentSheetAction extends EnsembleAction {
     super.initiator,
     required this.clientSecret,
     this.configuration,
-    this.onComplete,
+    this.onSuccess,
     this.onError,
   });
 
   final String clientSecret;
   final Map<String, dynamic>? configuration;
-  final EnsembleAction? onComplete;
+  final EnsembleAction? onSuccess;
   final EnsembleAction? onError;
 
   factory ShowPaymentSheetAction.fromYaml(
@@ -35,7 +35,7 @@ class ShowPaymentSheetAction extends EnsembleAction {
       initiator: initiator,
       clientSecret: Utils.getString(payload['clientSecret'], fallback: ''),
       configuration: Utils.getMap(payload['configuration']),
-      onComplete: EnsembleAction.from(payload['onComplete']),
+      onSuccess: EnsembleAction.from(payload['onComplete']),
       onError: EnsembleAction.from(payload['onError']),
     );
   }
@@ -49,8 +49,8 @@ class ShowPaymentSheetAction extends EnsembleAction {
         configuration: scopeManager.dataContext.eval(configuration),
       );
 
-      if (onComplete != null) {
-        await ScreenController().executeAction(context, onComplete!);
+      if (onSuccess != null) {
+        await ScreenController().executeAction(context, onSuccess!);
       }
     } catch (e) {
       if (onError != null) {

--- a/modules/ensemble/lib/action/stripe_actions.dart
+++ b/modules/ensemble/lib/action/stripe_actions.dart
@@ -1,0 +1,65 @@
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/stub/stripe_manager.dart';
+import 'package:get_it/get_it.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter/material.dart';
+
+/// Show Stripe payment sheet
+class ShowPaymentSheetAction extends EnsembleAction {
+  ShowPaymentSheetAction({
+    super.initiator,
+    required this.clientSecret,
+    this.configuration,
+    this.onComplete,
+    this.onError,
+  });
+
+  final String clientSecret;
+  final Map<String, dynamic>? configuration;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory ShowPaymentSheetAction.fromYaml(
+      {Invokable? initiator, Map? payload}) {
+    if (payload == null || payload['clientSecret'] == null) {
+      throw LanguageError(
+          "showPaymentSheet requires a 'clientSecret' parameter.");
+    }
+
+    return ShowPaymentSheetAction(
+      initiator: initiator,
+      clientSecret: Utils.getString(payload['clientSecret'], fallback: ''),
+      configuration: Utils.getMap(payload['configuration']),
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future<void> execute(BuildContext context, ScopeManager scopeManager) async {
+    try {
+      final stripeManager = GetIt.I<StripeManager>();
+      await stripeManager.showPaymentSheet(
+        clientSecret: scopeManager.dataContext.eval(clientSecret),
+        configuration: scopeManager.dataContext.eval(configuration),
+      );
+
+      if (onComplete != null) {
+        await ScreenController().executeAction(context, onComplete!);
+      }
+    } catch (e) {
+      if (onError != null) {
+        await ScreenController().executeAction(
+          context,
+          onError!,
+          event: EnsembleEvent(initiator, error: e.toString()),
+        );
+      }
+    }
+  }
+}

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -26,6 +26,7 @@ import 'package:ensemble/action/phone_contact_action.dart';
 import 'package:ensemble/action/secure_storage.dart';
 import 'package:ensemble/action/sign_in_out_action.dart';
 import 'package:ensemble/action/sign_in_with_verification_code_actions.dart';
+import 'package:ensemble/action/stripe_actions.dart';
 import 'package:ensemble/action/toast_actions.dart';
 import 'package:ensemble/action/take_screenshot.dart';
 import 'package:ensemble/action/disable_hardware_navigation.dart';
@@ -992,6 +993,8 @@ enum ActionType {
   sendVerificationCode,
   validateVerificationCode,
   resendVerificationCode,
+  // Stripe actions
+  showPaymentSheet,
 }
 
 /// payload representing an Action to do (navigateToScreen, InvokeAPI, ..)
@@ -1231,6 +1234,9 @@ abstract class EnsembleAction {
           initiator: initiator, payload: payload);
     } else if (actionType == ActionType.resendVerificationCode) {
       return ResendVerificationCodeAction.fromYaml(
+          initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.showPaymentSheet) {
+      return ShowPaymentSheetAction.fromYaml(
           initiator: initiator, payload: payload);
     } else {
       throw LanguageError("Invalid action.",

--- a/modules/ensemble/lib/framework/stub/stripe_manager.dart
+++ b/modules/ensemble/lib/framework/stub/stripe_manager.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import 'package:ensemble/framework/error_handling.dart';
+
+/// Abstract interface for Stripe operations
+abstract class StripeManager {
+  /// Show the Stripe payment sheet
+  Future<void> showPaymentSheet({
+    required String clientSecret,
+    Map<String, dynamic>? configuration,
+  });
+}
+
+/// Stub implementation of StripeManager
+class StripeManagerStub implements StripeManager {
+  @override
+  Future<void> showPaymentSheet({
+    required String clientSecret,
+    Map<String, dynamic>? configuration,
+    BuildContext? context,
+  }) async {
+    throw ConfigError('Stripe module is not enabled');
+  }
+}

--- a/modules/ensemble/lib/module/stripe_module.dart
+++ b/modules/ensemble/lib/module/stripe_module.dart
@@ -1,0 +1,10 @@
+import 'package:ensemble/framework/stub/stripe_manager.dart';
+import 'package:get_it/get_it.dart';
+
+abstract class StripeModule {}
+
+class StripeModuleStub implements StripeModule {
+  StripeModuleStub() {
+    GetIt.I.registerSingleton<StripeManager>(StripeManagerStub());
+  }
+}

--- a/modules/ensemble_stripe/README.md
+++ b/modules/ensemble_stripe/README.md
@@ -57,7 +57,7 @@ showPaymentSheet:
         state: "NY"
         postalCode: "10001"
         country: "US"
-  onComplete:
+  onSuccess:
     showToast:
       message: "Payment completed successfully"
   onError:
@@ -89,26 +89,18 @@ View:
               padding: 15
               borderRadius: 8
             onTap:
-              executeActionGroup:
-                actions:
-                  - initializeStripe:
-                      publishableKey: "pk_test_your_key"
-                      onComplete:
-                        showPaymentSheet:
-                          clientSecret: "pi_test_client_secret_here"
-                          configuration:
-                            merchantDisplayName: "Your Company"
-                            primaryButtonLabel: "Pay Now"
-                            style: "system"
-                          onComplete:
-                            showToast:
-                              message: "Payment successful!"
-                          onError:
-                            showToast:
-                              message: "Payment failed: {{event.error}}"
-                      onError:
-                        showToast:
-                          message: "Failed to initialize Stripe"
+              showPaymentSheet:
+                clientSecret: "pi_test_client_secret_here"
+                configuration:
+                  merchantDisplayName: "Your Company"
+                  primaryButtonLabel: "Pay Now"
+                  style: "system"
+                onSuccess:
+                  showToast:
+                    message: "Payment successful!"
+                onError:
+                  showToast:
+                    message: ${event.error}
 ```
 
 ## Configuration

--- a/modules/ensemble_stripe/README.md
+++ b/modules/ensemble_stripe/README.md
@@ -1,0 +1,151 @@
+# Ensemble Stripe Module
+
+A Stripe payment integration module for the Ensemble framework, providing easy-to-use actions for handling payments with Stripe's Payment Sheet.
+
+## Features
+
+- **Payment Processing**: Initialize Stripe and show payment sheets
+- **Payment Sheet**: Display the native Stripe payment sheet for secure payments
+- **Error Handling**: Comprehensive error handling with onError callbacks
+- **Modular Design**: Easy to extend with new payment features
+
+## Installation
+
+The Stripe actions are now part of the Ensemble runtime and are available by default. To use the Stripe module implementation, add it to your Ensemble project:
+
+```yaml
+dependencies:
+  ensemble_stripe:
+    path: modules/ensemble_stripe
+```
+
+## Configuration
+
+Stripe is automatically initialized when the module is enabled. Add your Stripe configuration to `ensemble-config.yaml`:
+
+```yaml
+# Stripe payment configuration
+stripe:
+  enabled: true
+  publishableKey: "pk_test_your_publishable_key_here"
+  stripeAccountId: "acct_optional_account_id"  # Optional
+  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay
+```
+
+The configuration is automatically read from `ensemble-config.yaml` when the first payment sheet is shown.
+
+## Actions
+
+### showPaymentSheet
+
+Display the native Stripe payment sheet.
+
+```yaml
+showPaymentSheet:
+  clientSecret: "pi_client_secret_here"
+  configuration:
+    merchantDisplayName: "Your Company"
+    primaryButtonLabel: "Pay Now"
+    style: "system"  # "light", "dark", or "system"
+    billingDetails:
+      name: "John Doe"
+      email: "john@example.com"
+      phone: "+1234567890"
+      address:
+        line1: "123 Main St"
+        city: "New York"
+        state: "NY"
+        postalCode: "10001"
+        country: "US"
+  onComplete:
+    showToast:
+      message: "Payment completed successfully"
+  onError:
+    showToast:
+      message: "Payment failed"
+```
+
+## Complete Example
+
+Here's a complete example of a payment flow:
+
+```yaml
+View:
+  body:
+    Column:
+      children:
+        - Text:
+            text: "Complete Payment"
+            styles:
+              fontSize: 24
+              fontWeight: bold
+              marginBottom: 20
+        
+        - Button:
+            text: "Pay $20.00"
+            styles:
+              backgroundColor: "#007AFF"
+              color: white
+              padding: 15
+              borderRadius: 8
+            onTap:
+              executeActionGroup:
+                actions:
+                  - initializeStripe:
+                      publishableKey: "pk_test_your_key"
+                      onComplete:
+                        showPaymentSheet:
+                          clientSecret: "pi_test_client_secret_here"
+                          configuration:
+                            merchantDisplayName: "Your Company"
+                            primaryButtonLabel: "Pay Now"
+                            style: "system"
+                          onComplete:
+                            showToast:
+                              message: "Payment successful!"
+                          onError:
+                            showToast:
+                              message: "Payment failed: {{event.error}}"
+                      onError:
+                        showToast:
+                          message: "Failed to initialize Stripe"
+```
+
+## Configuration
+
+### iOS Configuration
+
+Add the following to your `ios/Runner/Info.plist`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Scan your card to add it automatically</string>
+```
+
+### Android Configuration
+
+Ensure your Android app uses:
+- Android 5.0 (API level 21) and above
+- Kotlin version 1.8.0 and above
+- Android Gradle plugin 8 and higher
+- `FlutterFragmentActivity` instead of `FlutterActivity`
+
+## Error Handling
+
+All actions support error handling through the `onError` callback. The error information is available in the event data:
+
+```yaml
+onError:
+  showToast:
+    message: "Error: {{event.error}}"
+```
+
+## Dependencies
+
+- `flutter_stripe: ^11.5.0`
+- `ensemble: path: ../ensemble`
+- `get_it: ^8.0.3`
+
+## License
+
+This module follows the same license as the Ensemble framework. 

--- a/modules/ensemble_stripe/README.md
+++ b/modules/ensemble_stripe/README.md
@@ -11,12 +11,31 @@ A Stripe payment integration module for the Ensemble framework, providing easy-t
 
 ## Installation
 
+### Option 1: Using the Starter Script (Recommended)
+
+Run the enable script from your starter project:
+
+```bash
+npm run hasStripe
+```
+
+This will automatically:
+- Add the dependency to `pubspec.yaml`
+- Update `ensemble_modules.dart`
+- Add iOS camera permissions
+- Enable Stripe in `ensemble-config.yaml`
+
+### Option 2: Manual Installation
+
 The Stripe actions are now part of the Ensemble runtime and are available by default. To use the Stripe module implementation, add it to your Ensemble project:
 
 ```yaml
 dependencies:
   ensemble_stripe:
-    path: modules/ensemble_stripe
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: main
+      path: modules/ensemble_stripe
 ```
 
 ## Configuration

--- a/modules/ensemble_stripe/README.md
+++ b/modules/ensemble_stripe/README.md
@@ -107,7 +107,16 @@ View:
 
 ### iOS Configuration
 
-Add the following to your `ios/Runner/Info.plist`:
+Compatible with apps targeting iOS 13 or above.
+To upgrade your iOS deployment target to 13.0, you can either do so in Xcode under your Build Settings, or by modifying IPHONEOS_DEPLOYMENT_TARGET in your project.pbxproj directly.
+
+You will also need to update in your Podfile:
+
+```podfile
+platform :ios, '13.0'
+```
+
+For card scanning add the following to your `ios/Runner/Info.plist`:
 
 ```xml
 <key>NSCameraUsageDescription</key>
@@ -117,6 +126,7 @@ Add the following to your `ios/Runner/Info.plist`:
 ### Android Configuration
 
 Ensure your Android app uses:
+
 - Android 5.0 (API level 21) and above
 - Kotlin version 1.8.0 and above
 - Android Gradle plugin 8 and higher

--- a/modules/ensemble_stripe/lib/ensemble_stripe.dart
+++ b/modules/ensemble_stripe/lib/ensemble_stripe.dart
@@ -1,0 +1,10 @@
+import 'package:ensemble/framework/stub/stripe_manager.dart';
+import 'package:ensemble/module/stripe_module.dart';
+import 'package:get_it/get_it.dart';
+import 'stripe_manager.dart';
+
+class StripeModuleImpl implements StripeModule {
+  StripeModuleImpl() {
+    GetIt.I.registerSingleton<StripeManager>(StripeManagerImpl());
+  }
+}

--- a/modules/ensemble_stripe/lib/stripe_manager.dart
+++ b/modules/ensemble_stripe/lib/stripe_manager.dart
@@ -38,8 +38,6 @@ class StripeManagerImpl implements StripeManager {
       }
 
       _isInitialized = true;
-      print(
-          'Stripe initialized successfully with key: ${publishableKey.substring(0, 10)}...');
     } catch (e) {
       throw Exception('Failed to initialize Stripe: $e');
     }

--- a/modules/ensemble_stripe/lib/stripe_manager.dart
+++ b/modules/ensemble_stripe/lib/stripe_manager.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+import 'package:ensemble/framework/stub/stripe_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_stripe/flutter_stripe.dart';
+import 'package:yaml/yaml.dart';
+
+/// Real implementation of StripeManager for the ensemble_stripe module
+class StripeManagerImpl implements StripeManager {
+  bool _isInitialized = false;
+
+  /// Auto-initialize Stripe from ensemble configuration
+  Future<void> _ensureInitialized() async {
+    if (_isInitialized) return;
+
+    try {
+      // Get configuration from ensemble
+      final config = await _getStripeConfig();
+      if (config == null || !config['enabled']) {
+        throw Exception('Stripe is not enabled in configuration');
+      }
+
+      final publishableKey = config['publishableKey'] as String?;
+      if (publishableKey == null || publishableKey.isEmpty) {
+        throw Exception('Stripe publishableKey is required in configuration');
+      }
+
+      Stripe.publishableKey = publishableKey;
+
+      final stripeAccountId = config['stripeAccountId'] as String?;
+      if (stripeAccountId != null && stripeAccountId.isNotEmpty) {
+        Stripe.stripeAccountId = stripeAccountId;
+      }
+
+      final merchantIdentifier = config['merchantIdentifier'] as String?;
+      if (merchantIdentifier != null && merchantIdentifier.isNotEmpty) {
+        Stripe.merchantIdentifier = merchantIdentifier;
+      }
+
+      _isInitialized = true;
+      print(
+          'Stripe initialized successfully with key: ${publishableKey.substring(0, 10)}...');
+    } catch (e) {
+      throw Exception('Failed to initialize Stripe: $e');
+    }
+  }
+
+  /// Get Stripe configuration from ensemble config
+  Future<Map<String, dynamic>?> _getStripeConfig() async {
+    try {
+      // Load the ensemble configuration file
+      final yamlString =
+          await rootBundle.loadString('ensemble/ensemble-config.yaml');
+      final YamlMap yamlMap = loadYaml(yamlString);
+
+      // Extract Stripe configuration
+      final stripeConfig = yamlMap['stripe'] as YamlMap?;
+      if (stripeConfig == null) {
+        print('Stripe configuration not found in ensemble-config.yaml');
+        return null;
+      }
+
+      return {
+        'enabled': stripeConfig['enabled'] as bool? ?? false,
+        'publishableKey': stripeConfig['publishableKey'] as String?,
+        'stripeAccountId': stripeConfig['stripeAccountId'] as String?,
+        'merchantIdentifier': stripeConfig['merchantIdentifier'] as String?,
+      };
+    } catch (e) {
+      print('Error reading Stripe configuration: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<void> showPaymentSheet({
+    required String clientSecret,
+    Map<String, dynamic>? configuration,
+  }) async {
+    // Auto-initialize if not already initialized
+    await _ensureInitialized();
+
+    try {
+      // Parse theme mode from configuration
+      ThemeMode themeMode = ThemeMode.system;
+      if (configuration?['style'] != null) {
+        final style = configuration!['style'].toString().toLowerCase();
+        switch (style) {
+          case 'light':
+            themeMode = ThemeMode.light;
+            break;
+          case 'dark':
+            themeMode = ThemeMode.dark;
+            break;
+          default:
+            themeMode = ThemeMode.system;
+        }
+      }
+
+      // Parse billing details safely
+      BillingDetails? billingDetails;
+      if (configuration?['billingDetails'] != null) {
+        try {
+          billingDetails = BillingDetails.fromJson(
+            Map<String, dynamic>.from(configuration!['billingDetails']),
+          );
+        } catch (e) {
+          print('Stripe: Failed to parse billing details: $e');
+          // Continue without billing details
+        }
+      }
+
+      await Stripe.instance.initPaymentSheet(
+        paymentSheetParameters: SetupPaymentSheetParameters(
+          // Main params
+          paymentIntentClientSecret: clientSecret,
+          merchantDisplayName: configuration?['merchantDisplayName'],
+          preferredNetworks: configuration?['preferredNetworks'] != null
+              ? (configuration?['preferredNetworks'] as List<dynamic>)
+                  .map((network) =>
+                      CardBrand.values.firstWhere((e) => e.name == network))
+                  .toList()
+              : null,
+          // Customer params
+          customerId: configuration?['customerId'],
+          customerEphemeralKeySecret:
+              configuration?['customerEphemeralKeySecret'],
+          returnURL: configuration?['returnURL'],
+          // Extra params
+          primaryButtonLabel: configuration?['primaryButtonLabel'],
+          applePay: configuration?['applePay'] != null
+              ? PaymentSheetApplePay(
+                  merchantCountryCode: configuration?['applePay']
+                      ['merchantCountryCode'] as String,
+                )
+              : null,
+          googlePay: configuration?['googlePay'] != null
+              ? PaymentSheetGooglePay(
+                  merchantCountryCode: configuration?['googlePay']
+                      ['merchantCountryCode'] as String,
+                  testEnv: configuration?['googlePay']?['testEnv'] ?? false,
+                )
+              : null,
+          style: themeMode,
+          billingDetails: billingDetails,
+        ),
+      );
+      await Stripe.instance.presentPaymentSheet();
+    } catch (e) {
+      print('Stripe: Error showing payment sheet: $e');
+      throw Exception('Failed to show payment sheet: $e');
+    }
+  }
+}

--- a/modules/ensemble_stripe/melos_ensemble_stripe.iml
+++ b/modules/ensemble_stripe/melos_ensemble_stripe.iml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/android/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/example/android/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/Flutter" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/Pods" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks" />
+      <excludeFolder url="file://$MODULE_DIR$/example/macos/Flutter" />
+      <excludeFolder url="file://$MODULE_DIR$/example/macos/Pods" />
+      <excludeFolder url="file://$MODULE_DIR$/example/macos/.symlinks" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/modules/ensemble_stripe/pubspec.yaml
+++ b/modules/ensemble_stripe/pubspec.yaml
@@ -1,0 +1,28 @@
+name: ensemble_stripe
+description: Stripe payment integration for Ensemble framework
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: ">=3.10.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  ensemble:
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: ensemble-v1.1.75
+      path: modules/ensemble
+
+  flutter_stripe: ^11.5.0
+  get_it: ^8.0.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  # No assets needed for this module 

--- a/starter/android/app/build.gradle
+++ b/starter/android/app/build.gradle
@@ -133,4 +133,7 @@ dependencies {
         }
     }
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+    
+    // Material Design support
+    implementation 'com.google.android.material:material:1.9.0'
 }

--- a/starter/android/app/src/main/res/values-night/styles.xml
+++ b/starter/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/starter/android/app/src/main/res/values/styles.xml
+++ b/starter/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/starter/ensemble/ensemble-config.yaml
+++ b/starter/ensemble/ensemble-config.yaml
@@ -117,3 +117,11 @@ environmentVariables:
 #      messagingSenderId: "nnnnnn"
 #      appId: "n:xxxxxxx"
 #      measurementId: "G-xxxxx"
+
+# Stripe payment configuration
+# Uncomment and configure when using Stripe payments
+#stripe:
+#  enabled: true
+#  publishableKey: "pk_test_your_publishable_key_here"
+#  stripeAccountId: "acct_optional_account_id"  # Optional
+#  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay

--- a/starter/ios/Runner/AppDelegate.swift
+++ b/starter/ios/Runner/AppDelegate.swift
@@ -3,7 +3,7 @@ import Flutter
 // import GoogleMaps
 import flutter_local_notifications
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   static let methodChannelName: String = "com.ensembleui.host.platform"
   var methodChannel: FlutterMethodChannel?

--- a/starter/lib/generated/ensemble_modules.dart
+++ b/starter/lib/generated/ensemble_modules.dart
@@ -15,6 +15,8 @@ import 'package:ensemble/framework/stub/plaid_link_manager.dart';
 import 'package:ensemble/module/auth_module.dart';
 import 'package:ensemble/module/location_module.dart';
 import 'package:ensemble/framework/stub/moengage_manager.dart';
+import 'package:ensemble/module/stripe_module.dart';
+// import 'package:ensemble_stripe/ensemble_stripe.dart';
 //import 'package:ensemble_bluetooth/ensemble_bluetooth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -84,6 +86,8 @@ class EnsembleModules {
   static const useBracket = false;
   static const useNetworkInfo = false;
   static const useBluetooth = false;
+
+  static const useStripe = false;
 
   // widgets
   static const enableChat = false;
@@ -213,6 +217,13 @@ class EnsembleModules {
       //GetIt.I.registerSingleton<BluetoothManager>(BluetoothManagerImpl());
     } else {
       GetIt.I.registerSingleton<BluetoothManager>(BluetoothManagerStub());
+    }
+
+    if (useStripe) {
+      // Initialize the real Stripe module implementation
+      // GetIt.I.registerSingleton<StripeModule>(StripeModuleImpl());
+    } else {
+      GetIt.I.registerSingleton<StripeModule>(StripeModuleStub());
     }
   }
 }

--- a/starter/package.json
+++ b/starter/package.json
@@ -28,7 +28,8 @@
     "qrCodeEnabled": "ts-node src/dart_runner.ts qr_code",
     "hasGoogleMaps": "ts-node src/dart_runner.ts google_maps",
     "generate_keystore": "ts-node src/dart_runner.ts generateKeystore",
-    "hasAdobeAnalytics": "ts-node src/dart_runner.ts adobe_analytics"
+    "hasAdobeAnalytics": "ts-node src/dart_runner.ts adobe_analytics",
+    "hasStripe": "ts-node src/dart_runner.ts stripe"
   },
   "keywords": [],
   "author": "",

--- a/starter/pubspec.yaml
+++ b/starter/pubspec.yaml
@@ -136,6 +136,12 @@ dependencies:
   #     ref: main
   #     path: modules/adobe_analytics
 
+  ensemble_stripe:
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: main
+      path: modules/ensemble_stripe
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2

--- a/starter/pubspec.yaml
+++ b/starter/pubspec.yaml
@@ -136,11 +136,11 @@ dependencies:
   #     ref: main
   #     path: modules/adobe_analytics
 
-  ensemble_stripe:
-    git:
-      url: https://github.com/EnsembleUI/ensemble.git
-      ref: main
-      path: modules/ensemble_stripe
+  # ensemble_stripe:
+  #   git:
+  #     url: https://github.com/EnsembleUI/ensemble.git
+  #     ref: main
+  #     path: modules/ensemble_stripe
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/starter/scripts/modules/enable_stripe.dart
+++ b/starter/scripts/modules/enable_stripe.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import '../utils.dart';
+import '../utils/proguard_utils.dart';
 
 Future<void> main(List<String> arguments) async {
   List<String> platforms = getPlatforms(arguments);
@@ -36,6 +37,15 @@ ensemble_stripe:
     },
   ];
 
+  const proguardRules = '''
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivity\$g
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter\$Args
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter\$Error
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningActivityStarter
+-dontwarn com.stripe.android.pushProvisioning.PushProvisioningEphemeralKeyProvider
+-keep class com.stripe.** { *; }
+''';
+
   try {
     // Update the ensemble_modules.dart file
     updateEnsembleModules(
@@ -49,6 +59,10 @@ ensemble_stripe:
     // Update iOS configuration for Stripe
     if (platforms.contains('ios')) {
       updateIOSPermissions(iOSPermissions, arguments);
+    }
+
+    if (platforms.contains('android')) {
+      createProguardRules(proguardRules);
     }
 
     // Update ensemble-config.yaml to enable Stripe

--- a/starter/scripts/modules/enable_stripe.dart
+++ b/starter/scripts/modules/enable_stripe.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import '../utils.dart';
+
+Future<void> main(List<String> arguments) async {
+  List<String> platforms = getPlatforms(arguments);
+  String? ensembleVersion = getArgumentValue(arguments, 'ensemble_version');
+
+  final stripeStatements = {
+    'moduleStatements': [
+      "import 'package:ensemble_stripe/ensemble_stripe.dart';",
+      "GetIt.I.registerSingleton<StripeModule>(StripeModuleImpl());",
+    ],
+    'useStatements': [
+      'static const useStripe = true;',
+    ],
+  };
+
+  final pubspecDependencies = [
+    {
+      'statement': '''
+ensemble_stripe:
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: ${await packageVersion(version: ensembleVersion)}
+      path: modules/ensemble_stripe''',
+      'regex':
+          r'#\s*ensemble_stripe:\s*\n\s*#\s*git:\s*\n\s*#\s*url:\s*https:\/\/github\.com\/EnsembleUI\/ensemble\.git\s*\n\s*#\s*ref:\s*main\s*\n\s*#\s*path:\s*modules\/ensemble_stripe',
+    }
+  ];
+
+  final iOSPermissions = [
+    {
+      'key': 'cameraDescription',
+      'value': 'NSCameraUsageDescription',
+    },
+  ];
+
+  try {
+    // Update the ensemble_modules.dart file
+    updateEnsembleModules(
+      stripeStatements['moduleStatements'],
+      stripeStatements['useStatements'],
+    );
+
+    // Update the pubspec.yaml file
+    updatePubspec(pubspecDependencies);
+
+    // Update iOS configuration for Stripe
+    if (platforms.contains('ios')) {
+      updateIOSPermissions(iOSPermissions, arguments);
+    }
+
+    // Update ensemble-config.yaml to enable Stripe
+    updateStripeConfig(arguments);
+
+    print('Stripe module enabled successfully for ${platforms.join(', ')}! 🎉');
+    exit(0);
+  } catch (e) {
+    print('Starter Error: $e');
+    exit(1);
+  }
+}
+
+void updateStripeConfig(List<String> arguments) {
+  final publishableKey = getArgumentValue(arguments, 'publishableKey');
+  final stripeAccountId = getArgumentValue(arguments, 'stripeAccountId');
+  final merchantIdentifier = getArgumentValue(arguments, 'merchantIdentifier');
+
+  if (publishableKey == null) {
+    throw Exception('Missing required parameter: publishableKey');
+  }
+
+  try {
+    final file = File(ensembleConfigFilePath);
+    if (!file.existsSync()) {
+      throw Exception('Config file not found.');
+    }
+
+    String content = file.readAsStringSync();
+
+    // Simple approach: replace each commented line individually
+    // This is more reliable than complex regex patterns
+    content = content.replaceAll('#stripe:', 'stripe:');
+    content = content.replaceAll('#  enabled: true', '  enabled: true');
+    content = content.replaceAll(
+        '#  publishableKey: "pk_test_your_publishable_key_here"',
+        '  publishableKey: "$publishableKey"');
+    if (stripeAccountId != null) {
+      content = content.replaceAll(
+          '#  stripeAccountId: "acct_optional_account_id"  # Optional',
+          '  stripeAccountId: "$stripeAccountId"  # Optional');
+    }
+    if (merchantIdentifier != null) {
+      content = content.replaceAll(
+          '#  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay',
+          '  merchantIdentifier: "$merchantIdentifier"   # Optional, for Apple Pay');
+    }
+
+    file.writeAsStringSync(content);
+  } catch (e) {
+    throw Exception(
+        'Failed to update Stripe configuration in ensemble-config.yaml: $e');
+  }
+}

--- a/starter/src/modules_scripts.ts
+++ b/starter/src/modules_scripts.ts
@@ -328,4 +328,34 @@ export const modules: Script[] = [
       },
     ],
   },
+  {
+    name: 'stripe',
+    path: 'scripts/modules/enable_stripe.dart',
+    parameters: [
+      {
+        key: 'publishableKey',
+        question: 'Please provide your Stripe publishable key: ',
+        platform: ['android', 'ios'],
+        type: 'text',
+      },
+      {
+        key: 'stripeAccountId',
+        question: 'Please provide your Stripe account ID: ',
+        platform: [],
+        type: 'text',
+      },
+      {
+        key: 'merchantIdentifier',
+        question: 'Please provide your merchant identifier: ',
+        platform: [],
+        type: 'text',
+      },
+      {
+        key: 'cameraDescription',
+        question: 'Please provide a camera usage description: ',
+        platform: ['ios'],
+        type: 'text',
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
- Introduced ShowPaymentSheetAction for displaying Stripe payment sheets.
- Implemented StripeManager interface with a stub and a real implementation.
- Added configuration support for Stripe in ensemble-config.yaml.
- Updated README with usage instructions and examples for Stripe integration.
- Registered Stripe module in the Ensemble framework.

# Configuration

Stripe is automatically initialized when the module is enabled. Add your Stripe configuration to `ensemble-config.yaml`:

```yaml
# Stripe payment configuration
stripe:
  enabled: true
  publishableKey: "pk_test_your_publishable_key_here"
  stripeAccountId: "acct_optional_account_id"  # Optional
  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay
```

## Actions

### showPaymentSheet

Display the native Stripe payment sheet.

```yaml
showPaymentSheet:
  clientSecret: "pi_client_secret_here"
  configuration:
    merchantDisplayName: "Your Company"
    primaryButtonLabel: "Pay Now"
    style: "system"  # "light", "dark", or "system"
    billingDetails:
      name: "John Doe"
      email: "john@example.com"
      phone: "+1234567890"
      address:
        line1: "123 Main St"
        city: "New York"
        state: "NY"
        postalCode: "10001"
        country: "US"
  onSuccess:
    showToast:
      message: "Payment completed successfully"
  onError:
    showToast:
      message: "Payment failed"
```
