### PR TITLE
feat(stripe): add initializeStripe action

### DIFF
--- a/modules/ensemble/lib/action/action_invokable.dart
+++ b/modules/ensemble/lib/action/action_invokable.dart
@@ -61,6 +61,8 @@ abstract class ActionInvokable with Invokable {
       ActionType.bluetoothUnsubscribeCharacteristic,
       ActionType.setSecureStorage,
       ActionType.clearSecureStorage,
+      ActionType.initializeStripe,
+      ActionType.showPaymentSheet,
     ]);
   }
 

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -994,6 +994,7 @@ enum ActionType {
   validateVerificationCode,
   resendVerificationCode,
   // Stripe actions
+  initializeStripe,
   showPaymentSheet,
 }
 
@@ -1234,6 +1235,9 @@ abstract class EnsembleAction {
           initiator: initiator, payload: payload);
     } else if (actionType == ActionType.resendVerificationCode) {
       return ResendVerificationCodeAction.fromYaml(
+          initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.initializeStripe) {
+      return InitializeStripeAction.fromYaml(
           initiator: initiator, payload: payload);
     } else if (actionType == ActionType.showPaymentSheet) {
       return ShowPaymentSheetAction.fromYaml(

--- a/modules/ensemble/lib/framework/stub/stripe_manager.dart
+++ b/modules/ensemble/lib/framework/stub/stripe_manager.dart
@@ -5,6 +5,13 @@ import 'package:ensemble/framework/error_handling.dart';
 
 /// Abstract interface for Stripe operations
 abstract class StripeManager {
+  /// Initialize Stripe with the given configuration
+  Future<void> initializeStripe({
+    String? publishableKey,
+    String? stripeAccountId,
+    String? merchantIdentifier,
+  });
+
   /// Show the Stripe payment sheet
   Future<void> showPaymentSheet({
     required String clientSecret,
@@ -14,6 +21,15 @@ abstract class StripeManager {
 
 /// Stub implementation of StripeManager
 class StripeManagerStub implements StripeManager {
+  @override
+  Future<void> initializeStripe({
+    String? publishableKey,
+    String? stripeAccountId,
+    String? merchantIdentifier,
+  }) async {
+    throw ConfigError('Stripe module is not enabled');
+  }
+
   @override
   Future<void> showPaymentSheet({
     required String clientSecret,

--- a/modules/ensemble_stripe/README.md
+++ b/modules/ensemble_stripe/README.md
@@ -40,20 +40,46 @@ dependencies:
 
 ## Configuration
 
-Stripe is automatically initialized when the module is enabled. Add your Stripe configuration to `ensemble-config.yaml`:
+Stripe should be initialized using the `initializeStripe` action. This allows you to:
+
+- Initialize Stripe with different keys for different environments
+- Initialize Stripe conditionally based on user preferences
+- Initialize Stripe with dynamic configuration from your backend
 
 ```yaml
-# Stripe payment configuration
-stripe:
-  enabled: true
-  publishableKey: "pk_test_your_publishable_key_here"
-  stripeAccountId: "acct_optional_account_id"  # Optional
-  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay
+# Example: Initialize Stripe with dynamic configuration
+initializeStripe:
+  publishableKey: ${apiResponse.stripeKey}
+  onSuccess:
+    showToast:
+      message: "Stripe ready for payments"
 ```
 
-The configuration is automatically read from `ensemble-config.yaml` when the first payment sheet is shown.
-
 ## Actions
+
+### initializeStripe
+
+Initialize Stripe with custom configuration. This is the primary way to initialize Stripe in your application.
+
+```yaml
+initializeStripe:
+  publishableKey: "pk_test_your_publishable_key_here"  # Required
+  stripeAccountId: "acct_optional_account_id"  # Optional
+  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay
+  onSuccess:
+    showToast:
+      message: "Stripe initialized successfully"
+  onError:
+    showToast:
+      message: "Failed to initialize Stripe"
+```
+
+**Parameters:**
+- `publishableKey` (required): Your Stripe publishable key
+- `stripeAccountId` (optional): Your Stripe account ID for Connect applications
+- `merchantIdentifier` (optional): Your merchant identifier for Apple Pay
+- `onSuccess` (optional): Action to execute when initialization succeeds
+- `onError` (optional): Action to execute when initialization fails
 
 ### showPaymentSheet
 
@@ -99,6 +125,24 @@ View:
               fontSize: 24
               fontWeight: bold
               marginBottom: 20
+        
+        - Button:
+            text: "Initialize Stripe"
+            styles:
+              backgroundColor: "#28a745"
+              color: white
+              padding: 15
+              borderRadius: 8
+              marginBottom: 10
+            onTap:
+              initializeStripe:
+                publishableKey: "pk_test_your_publishable_key_here"
+                onSuccess:
+                  showToast:
+                    message: "Stripe initialized successfully"
+                onError:
+                  showToast:
+                    message: "Failed to initialize Stripe"
         
         - Button:
             text: "Pay $20.00"

--- a/starter/scripts/modules/enable_stripe.dart
+++ b/starter/scripts/modules/enable_stripe.dart
@@ -65,55 +65,10 @@ ensemble_stripe:
       createProguardRules(proguardRules);
     }
 
-    // Update ensemble-config.yaml to enable Stripe
-    updateStripeConfig(arguments);
-
     print('Stripe module enabled successfully for ${platforms.join(', ')}! 🎉');
     exit(0);
   } catch (e) {
     print('Starter Error: $e');
     exit(1);
-  }
-}
-
-void updateStripeConfig(List<String> arguments) {
-  final publishableKey = getArgumentValue(arguments, 'publishableKey');
-  final stripeAccountId = getArgumentValue(arguments, 'stripeAccountId');
-  final merchantIdentifier = getArgumentValue(arguments, 'merchantIdentifier');
-
-  if (publishableKey == null) {
-    throw Exception('Missing required parameter: publishableKey');
-  }
-
-  try {
-    final file = File(ensembleConfigFilePath);
-    if (!file.existsSync()) {
-      throw Exception('Config file not found.');
-    }
-
-    String content = file.readAsStringSync();
-
-    // Simple approach: replace each commented line individually
-    // This is more reliable than complex regex patterns
-    content = content.replaceAll('#stripe:', 'stripe:');
-    content = content.replaceAll('#  enabled: true', '  enabled: true');
-    content = content.replaceAll(
-        '#  publishableKey: "pk_test_your_publishable_key_here"',
-        '  publishableKey: "$publishableKey"');
-    if (stripeAccountId != null) {
-      content = content.replaceAll(
-          '#  stripeAccountId: "acct_optional_account_id"  # Optional',
-          '  stripeAccountId: "$stripeAccountId"  # Optional');
-    }
-    if (merchantIdentifier != null) {
-      content = content.replaceAll(
-          '#  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay',
-          '  merchantIdentifier: "$merchantIdentifier"   # Optional, for Apple Pay');
-    }
-
-    file.writeAsStringSync(content);
-  } catch (e) {
-    throw Exception(
-        'Failed to update Stripe configuration in ensemble-config.yaml: $e');
   }
 }


### PR DESCRIPTION
- Introduced the InitializeStripeAction class to allow dynamic initialization of Stripe with custom configurations.
- Updated ActionType enum to include initializeStripe and showPaymentSheet actions.
- Enhanced README documentation to provide examples for initializing Stripe and handling success/error actions.
- Modified StripeManager interface and implementation to support the new initialization method.
- Removed outdated configuration handling from the enable_stripe script.

### initializeStripe

Initialize Stripe with custom configuration. This is the primary way to initialize Stripe in your application.

```yaml
initializeStripe:
  publishableKey: "pk_test_your_publishable_key_here"  # Required
  stripeAccountId: "acct_optional_account_id"  # Optional
  merchantIdentifier: "merchant.com.yourapp"   # Optional, for Apple Pay
  onSuccess:
    showToast:
      message: "Stripe initialized successfully"
  onError:
    showToast:
      message: "Failed to initialize Stripe"
```

**Parameters:**
- `publishableKey` (required): Your Stripe publishable key
- `stripeAccountId` (optional): Your Stripe account ID for Connect applications
- `merchantIdentifier` (optional): Your merchant identifier for Apple Pay
- `onSuccess` (optional): Action to execute when initialization succeeds
- `onError` (optional): Action to execute when initialization fails
