### PR TITLE
feat(widget): enhance semantics label retrieval logic

### DIFF
--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -250,7 +250,87 @@ abstract class WidgetController extends Controller with HasStyles {
     if (label != null && label!.isNotEmpty) {
       return label;
     }
-    return null;
+
+    // Try to find a label by looking up the current value in the items
+    try {
+      // First, try to get the current value
+      dynamic currentValue;
+
+      // Try to access value property directly
+      try {
+        currentValue = (this as dynamic).maybeValue;
+      } catch (e) {
+        // Try getValue method
+        try {
+          currentValue = (this as dynamic).getValue();
+        } catch (e) {
+          // No value property found
+          return null;
+        }
+      }
+
+      if (currentValue == null) return null;
+
+      // Now try to find the items and look up the label
+      try {
+        final items = (this as dynamic).items;
+        if (items != null && items is List) {
+          for (final item in items) {
+            if (item is Map) {
+              // Handle item as Map with value/label structure
+              final itemValue = item['value'];
+              final itemLabel = item['label'];
+
+              // Compare values more robustly
+              if (itemValue != null &&
+                  (itemValue.toString() == currentValue.toString() ||
+                      itemValue == currentValue)) {
+                // Found matching item, return its label
+                if (itemLabel != null && itemLabel.toString().isNotEmpty) {
+                  return itemLabel.toString();
+                }
+                // If no label, use the value itself
+                return currentValue.toString();
+              }
+            } else {
+              // Handle custom objects
+              try {
+                // Try to access properties dynamically
+                final itemValue = (item as dynamic).value;
+                final itemLabel = (item as dynamic).label;
+
+                // Compare values more robustly
+                if (itemValue != null &&
+                    (itemValue.toString() == currentValue.toString() ||
+                        itemValue == currentValue)) {
+                  // Found matching item, return its label
+                  if (itemLabel != null && itemLabel.toString().isNotEmpty) {
+                    // Check if the label is a translation key and translate it
+                    final translatedLabel =
+                        Utils.translate(itemLabel.toString(), null);
+                    return translatedLabel;
+                  }
+                  // If no label, use the value itself
+                  return currentValue.toString();
+                }
+              } catch (e) {
+                // Try to access as simple value
+                if (item != null &&
+                    (item.toString() == currentValue.toString() ||
+                        item == currentValue)) {
+                  // Item is a simple value that matches, use it directly
+                  return currentValue.toString();
+                }
+              }
+            }
+          }
+        }
+      } catch (e) {}
+
+      return currentValue.toString();
+    } catch (e) {
+      return null;
+    }
   }
 
   @override


### PR DESCRIPTION
### Issue
Dropdown is not showing `aria-label` if there is no semantics label, and no label of dropdown

### Fix
If there is no semantics label, and no label, then use the label of the value

e.g
this dropdown, does not have the label, or the semantics label, in this case, its value is en, and label for this value is `r@kpn.languages.english` => English
So the `aria-label` in this case should be English
```yaml
Dropdown:
  items:
    - { label: "r@kpn.languages.english", "value": "en" }
    - { label: "r@kpn.languages.dutch", "value": "nl" }
  value: ${app.locale.languageCode}
  onChange: |
    ensemble.setLocale({ "languageCode": event.data.value });
    ensemble.storage.userSelectedLanguage = event.data.value;
```

### Implementation
- Improved the method for retrieving labels based on current values by adding robust checks for both direct property access and dynamic object handling.
- Implemented a fallback mechanism to return the current value if no label is found, ensuring better handling of various item structures.