### PR TITLE
fix(page-group): notify selected page on ViewGroup resume

### DIFF
--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -1,6 +1,3 @@
-import 'dart:developer';
-
-import 'package:ensemble/action/drawer_actions.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/device.dart';
@@ -172,6 +169,14 @@ class PageGroupState extends State<PageGroup>
           context,
           _scopeManager,
           widget.model.onViewGroupResume!,
+      );
+      // After resuming the ViewGroup, notify the currently selected page so that
+      // it can refresh and execute onViewGroupUpdate (if defined).
+      // Also pass along the current ViewGroup scope data as payload so the child
+      // page can merge and update its DataContext accordingly.
+      viewGroupNotifier.updatePage(
+        viewGroupNotifier.viewIndex,
+        payload: _scopeManager.dataContext.getContextMap(),
       );
     }
   }


### PR DESCRIPTION
- Fixed functionality to notify the currently selected page to refresh and execute onViewGroupUpdate after resuming the ViewGroup.
- Passed current ViewGroup scope data as payload for child page DataContext updates.