### PR TITLE
chore(release): update ensemble_otp to version 1.0.2

### DIFF
--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   flutter_layout_grid: ^2.0.3
   email_validator: ^2.0.1
   mask_text_input_formatter: ^2.5.0
-  ensemble_otp: ^1.0.1
+  ensemble_otp: ^1.0.2
   form_validator: ^2.1.1
   flutter_svg: ^2.2.0
   flutter_svg_provider: ^1.0.7

--- a/packages/ensemble_otp/CHANGELOG.md
+++ b/packages/ensemble_otp/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.2] - iOS Build Fixes
+
+* Fixed iOS build errors related to Swift header imports
+* Corrected podspec configuration for proper Swift module generation
+* Updated method channel naming for consistency
+* Resolved podspec name mismatch issues
+* Added proper Swift header configuration in podspec
+
 ## [1.0.1]
 
 * fixed podspec file for iOS

--- a/packages/ensemble_otp/README.md
+++ b/packages/ensemble_otp/README.md
@@ -26,7 +26,7 @@ Add this to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  ensemble_otp: ^1.0.1
+  ensemble_otp: ^1.0.2
 ```
 
 Then run:

--- a/packages/ensemble_otp/ios/Classes/OtpPinFieldPlugin.m
+++ b/packages/ensemble_otp/ios/Classes/OtpPinFieldPlugin.m
@@ -1,11 +1,11 @@
 #import "OtpPinFieldPlugin.h"
-#if __has_include(<otp_pin_field/otp_pin_field-Swift.h>)
-#import <otp_pin_field/otp_pin_field-Swift.h>
+#if __has_include(<ensemble_otp/ensemble_otp-Swift.h>)
+#import <ensemble_otp/ensemble_otp-Swift.h>
 #else
 // Support project import fallback if the generated compatibility header
 // is not copied when this plugin is created as a library.
 // https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816
-#import "otp_pin_field-Swift.h"
+#import "ensemble_otp-Swift.h"
 #endif
 
 @implementation OtpPinFieldPlugin

--- a/packages/ensemble_otp/ios/Classes/OtpPinFieldPlugin.swift
+++ b/packages/ensemble_otp/ios/Classes/OtpPinFieldPlugin.swift
@@ -1,9 +1,9 @@
 import Flutter
 import UIKit
 
-public class SwiftOtpPinFieldPlugin: NSObject, FlutterPlugin {
+@objc public class SwiftOtpPinFieldPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "otp_pin_field", binaryMessenger: registrar.messenger())
+    let channel = FlutterMethodChannel(name: "ensemble_otp", binaryMessenger: registrar.messenger())
     let instance = SwiftOtpPinFieldPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }

--- a/packages/ensemble_otp/ios/ensemble_otp.podspec
+++ b/packages/ensemble_otp/ios/ensemble_otp.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ensemble_otp'
-  s.version          = '1.0.0'
+  s.version          = '1.0.2'
   s.summary          = 'A beautiful and highly customizable Flutter widget for OTP and PIN code input fields.'
   s.description      = <<-DESC
 A beautiful and highly customizable Flutter widget for OTP and PIN code input fields. Features include beautiful animations, custom styling, SMS autofill, custom keyboards, and extensive customization options. Perfect for authentication flows, verification screens, and any application requiring secure PIN or OTP input.
@@ -19,6 +19,10 @@ A beautiful and highly customizable Flutter widget for OTP and PIN code input fi
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.pod_target_xcconfig = { 
+    'DEFINES_MODULE' => 'YES', 
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'ensemble_otp-Swift.h'
+  }
   s.swift_version = '5.0'
 end

--- a/packages/ensemble_otp/pubspec.yaml
+++ b/packages/ensemble_otp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ensemble_otp
 description: A beautiful and highly customizable Flutter widget for OTP and PIN code input fields. Features include beautiful animations, custom styling, SMS autofill, custom keyboards, and extensive customization options. Perfect for authentication flows, verification screens, and any application requiring secure PIN or OTP input.
-version: 1.0.1
+version: 1.0.2
 
 homepage: https://ensembleui.com
 repository: https://github.com/EnsembleUI/ensemble/tree/main/packages/ensemble_otp


### PR DESCRIPTION
- Fixed iOS build errors related to Swift header imports.
- Corrected podspec configuration for proper Swift module generation.
- Updated method channel naming for consistency.
- Resolved podspec name mismatch issues.
- Added proper Swift header configuration in podspec.