### PR TITLE
added always on display action and uprgraded gradle version

### DIFF
--- a/modules/ensemble/lib/action/wakelock_action.dart
+++ b/modules/ensemble/lib/action/wakelock_action.dart
@@ -1,0 +1,87 @@
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/device.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+/// Action to control device screen wakelock
+/// Prevents the screen from turning off automatically when enabled
+class WakelockAction extends EnsembleAction {
+  WakelockAction({
+    super.initiator,
+    required this.enable,
+    this.onComplete,
+    this.onError,
+  });
+
+  final dynamic enable;
+  final EnsembleAction? onComplete;
+  final EnsembleAction? onError;
+
+  factory WakelockAction.from({Invokable? initiator, Map? payload}) {
+    if (payload == null || payload['enable'] == null) {
+      throw LanguageError(
+          "${ActionType.wakelock.name} requires the 'enable' property (true/false).");
+    }
+
+    return WakelockAction(
+      initiator: initiator,
+      enable: payload['enable'],
+      onComplete: EnsembleAction.from(payload['onComplete']),
+      onError: EnsembleAction.from(payload['onError']),
+    );
+  }
+
+  @override
+  Future<void> execute(BuildContext context, ScopeManager scopeManager) async {
+    try {
+      print("WakelockAction: Setting wakelock to $enable");
+      // Evaluate the enable property
+      final shouldEnable = Utils.getBool(
+        scopeManager.dataContext.eval(enable),
+        fallback: false,
+      );
+
+      // Toggle wakelock based on the enable value
+      if (shouldEnable) {
+        print("WakelockAction: Enabling wakelock");
+        await WakelockPlus.enable();
+      } else {
+        print("WakelockAction: Disabling wakelock");
+        await WakelockPlus.disable();
+      }
+
+      // Verify and update the cached status from actual platform state
+      await Device().refreshWakelockStatus();
+      print("WakelockAction: Actual wakelock status is now: ${await WakelockPlus.enabled}");
+
+      // Execute onComplete callback if provided
+      if (onComplete != null) {
+        ScreenController().executeActionWithScope(
+          context,
+          scopeManager,
+          onComplete!,
+          event: EnsembleEvent(initiator),
+        );
+      }
+    } catch (e) {
+      // Execute onError callback if provided
+      print("WakelockAction: Error toggling wakelock: $e");
+      if (onError != null) {
+        ScreenController().executeActionWithScope(
+          context,
+          scopeManager,
+          onError!,
+          event: EnsembleEvent(initiator, error: e.toString()),
+        );
+      } else {
+        throw LanguageError("Error toggling wakelock: $e");
+      }
+    }
+  }
+}

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -32,6 +32,7 @@ import 'package:ensemble/action/take_screenshot.dart';
 import 'package:ensemble/action/disable_hardware_navigation.dart';
 import 'package:ensemble/action/close_app.dart';
 import 'package:ensemble/action/getLocation.dart';
+import 'package:ensemble/action/wakelock_action.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
@@ -990,6 +991,7 @@ enum ActionType {
   bluetoothStartScan,
   bluetoothStopScan,
   bluetoothConnect,
+  wakelock,
   bluetoothDisconnect,
   bluetoothSubscribeCharacteristic,
   bluetoothUnsubscribeCharacteristic,
@@ -1225,6 +1227,8 @@ abstract class EnsembleAction {
       return StartScanBluetoothAction.from(payload: payload);
     } else if (actionType == ActionType.bluetoothConnect) {
       return ConnectBluetoothAction.from(payload: payload);
+    } else if (actionType == ActionType.wakelock) {
+      return WakelockAction.from(initiator: initiator, payload: payload);
     } else if (actionType == ActionType.bluetoothDisconnect) {
       return DisconnectBluetoothAction.from(payload: payload);
     } else if (actionType == ActionType.bluetoothSubscribeCharacteristic) {

--- a/modules/ensemble/pubspec.yaml
+++ b/modules/ensemble/pubspec.yaml
@@ -107,7 +107,7 @@ dependencies:
   crypto: ^3.0.3 
   ensemble_dropdown: ^0.1.0
   collection: ^1.17.1
-  package_info_plus: ^8.0.0
+  package_info_plus: ^9.0.0
   audioplayers: ^5.2.1
   logger: ^2.2.0
   visibility_detector: ^0.4.0+2
@@ -122,6 +122,7 @@ dependencies:
   safe_device: ^1.2.1
   firebase_app_check: ^0.3.2+6
   cloud_functions: ^5.5.1
+  wakelock_plus: ^1.4.0
 
 dev_dependencies:
   flutter_test:

--- a/starter/android/build.gradle
+++ b/starter/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '2.1.10'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/starter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/starter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip


### PR DESCRIPTION
Ticket: https://pub.dev/packages/wakelock_plus

Example EDL of action:
```yaml
wakelock:
  enable: true # could be true and false
  onComplete: |
    console.log('Wakelock enabled - screen will stay awake');
  onError: |
    console.log('Failed to enable wakelock');
```
And we can get the current status from using `ensemble.device.wakelockEnabled`

Its latest version required `package_info_plus ` to be upgraded, and `package_info_plus ` required the latest Kotlin and gradle version.