### PR TITLE
Enhance action styling and payload handling in ShowBottomSheetAction and ShowToastAction

### DIFF
--- a/modules/ensemble/lib/action/bottom_sheet_actions.dart
+++ b/modules/ensemble/lib/action/bottom_sheet_actions.dart
@@ -1,13 +1,11 @@
-import 'package:collection/collection.dart';
-import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/apiproviders/api_provider.dart';
-import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/model.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
+import 'package:ensemble/page_model.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/ensemble_utils.dart';
 import 'package:ensemble/util/utils.dart';
@@ -15,7 +13,7 @@ import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/material.dart';
 
 /// open a Modal Bottom Sheet
-class ShowBottomSheetAction extends EnsembleAction {
+class ShowBottomSheetAction extends EnsembleAction with HasStyles, Invokable {
   ShowBottomSheetAction({
     super.initiator,
     super.inputs,
@@ -28,6 +26,21 @@ class ShowBottomSheetAction extends EnsembleAction {
   static const dragHandleHeight = 3.0;
   static const dragHandleVerticalMargin = 10.0;
 
+  @override
+  Map<String, Function> getters() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> methods() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> setters() {
+    return {};
+  }
+
   final Map payload;
   final dynamic body;
   final EnsembleAction? onDismiss;
@@ -38,12 +51,14 @@ class ShowBottomSheetAction extends EnsembleAction {
       throw LanguageError(
           "${ActionType.showBottomSheet.name} requires a body widget.");
     }
+    // Create a mutable copy of payload so we can update styles after resolution
+    final mutablePayload = Map<String, dynamic>.from(payload);
     return ShowBottomSheetAction(
         initiator: initiator,
         inputs: Utils.getMap(payload['inputs']),
         body: body,
         onDismiss: EnsembleAction.from(payload['onDismiss']),
-        payload: payload);
+        payload: mutablePayload);
   }
 
   EdgeInsets? margin(scopeManager) =>

--- a/modules/ensemble/lib/action/toast_actions.dart
+++ b/modules/ensemble/lib/action/toast_actions.dart
@@ -3,12 +3,14 @@ import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/widget/toast.dart';
+import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/cupertino.dart';
 
 enum ToastType { success, error, warning, info }
 
-class ShowToastAction extends EnsembleAction {
+class ShowToastAction extends EnsembleAction with HasStyles, Invokable {
   ShowToastAction(
       {super.initiator,
       this.type,
@@ -18,6 +20,7 @@ class ShowToastAction extends EnsembleAction {
       this.dismissible,
       this.alignment,
       this.duration,
+      this.payload,
       this.styles});
 
   ToastType? type;
@@ -31,7 +34,24 @@ class ShowToastAction extends EnsembleAction {
 
   final Alignment? alignment;
   final int? duration; // the during in seconds before toast is dismissed
-  final Map<String, dynamic>? styles;
+  Map<String, dynamic>? styles;
+
+  final Map? payload;
+
+  @override
+  Map<String, Function> getters() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> methods() {
+    return {};
+  }
+
+  @override
+  Map<String, Function> setters() {
+    return {};
+  }
 
   factory ShowToastAction.fromYaml({Map? payload}) {
     if (payload == null ||
@@ -41,6 +61,8 @@ class ShowToastAction extends EnsembleAction {
       throw LanguageError(
           "${ActionType.showToast.name} requires either a message or a body widget.");
     }
+    // Create a mutable copy of payload so we can update styles after resolution
+    final mutablePayload = Map<String, dynamic>.from(payload);
     return ShowToastAction(
         type: ToastType.values.from(payload['options']?['type']),
         title: Utils.optionalString(payload['title']),
@@ -49,7 +71,8 @@ class ShowToastAction extends EnsembleAction {
         dismissible: Utils.optionalBool(payload['options']?['dismissible']),
         alignment: Utils.getAlignment(payload['options']?['alignment']),
         duration: Utils.optionalInt(payload['options']?['duration'], min: 1),
-        styles: Utils.getMap(payload['styles']));
+        styles: Utils.getMap(payload['styles']),
+        payload: mutablePayload);
   }
 
   factory ShowToastAction.fromMap(dynamic inputs) =>

--- a/modules/ensemble/lib/screen_controller.dart
+++ b/modules/ensemble/lib/screen_controller.dart
@@ -16,6 +16,7 @@ import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/stub/camera_manager.dart';
 import 'package:ensemble/framework/theme/theme_loader.dart';
+import 'package:ensemble/framework/theme_manager.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/view/page.dart' as ensemble;
 import 'package:ensemble/framework/view/page_group.dart';
@@ -187,6 +188,9 @@ class ScreenController {
     if (!context.mounted) {
       context = scopeManager.dataContext.buildContext;
     }
+
+    // Automatically configure and resolve styles for actions that use HasStyles
+    EnsembleThemeManager().applyActionStyles(context, scopeManager, action);
 
     /// TODO: The below Actions should be move to their execute() functions
     if (action is NavigateExternalScreen) {


### PR DESCRIPTION
Fixes: https://github.com/EnsembleUI/ensemble/issues/2140

- Integrated HasStyles and Invokable mixins into ShowBottomSheetAction and ShowToastAction for improved styling capabilities.
- Updated ShowBottomSheetAction and ShowToastAction to create mutable copies of payload for style updates.
- Added applyActionStyles method in EnsembleThemeManager to automatically configure styles for actions using HasStyles.
- Introduced utility methods in EnsembleThemeManager for deriving widget types and extracting payloads from actions.