### PR TITLE
Upgrade mobile_scanner to ^7.0.0 to restore arm64 iOS Simulator support

### DIFF
--- a/modules/qr_scanner/pubspec.yaml
+++ b/modules/qr_scanner/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
       path: modules/ensemble
 
   # QR/Barcode scanning
-  mobile_scanner: ^6.0.11
+  mobile_scanner: ^7.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Upgrade `mobile_scanner` to ^7.1.4 to restore arm64 iOS Simulator support

This PR upgrades the `mobile_scanner` dependency in the `qr_scanner` module from `^6.0.11` to `^7.1.4`.

The previous version relied on MLKit for iOS barcode/QR scanning, which does not support arm64 architecture on iOS Simulators (Apple Silicon Macs). This caused build and runtime failures when targeting arm64 simulators.

Starting with `mobile_scanner` v7.0.0, MLKit has been deprecated on iOS in favor of Apple’s native Vision API, which:
- Restores full support for arm64 iOS Simulators
- Aligns iOS with the existing macOS Vision implementation
- Lowers the minimum iOS deployment target back to Flutter’s default (12.0)
- Improves performance and reliability

### Changes
- Updated `modules/qr_scanner/pubspec.yaml`:
  ```yaml
  dependencies:
    mobile_scanner: ^7.1.4
    
### Impact
Fixes build failures on arm64 iOS Simulators (M1/M2/M3/M4 Macs)

Removes the need for Rosetta, physical devices, or architecture exclusions

Closes #2152
