### PR TITLE
feat: add spans support to Text widget for inline rich text and widget embedding

### DIFF
--- a/modules/ensemble/lib/widget/text/span_definition.dart
+++ b/modules/ensemble/lib/widget/text/span_definition.dart
@@ -1,0 +1,59 @@
+import 'package:ensemble/util/utils.dart';
+
+/// Represents a single span entry from the YAML spans list.
+/// Each span is either a text span or a widget span, never both.
+class SpanDefinition {
+  /// For text spans
+  final String? text;
+  final Map<String, dynamic>? textStyle;
+  final dynamic onTap;
+
+  /// For widget spans
+  final dynamic widgetDefinition;
+
+  SpanDefinition._({
+    this.text,
+    this.textStyle,
+    this.onTap,
+    this.widgetDefinition,
+  });
+
+  bool get isTextSpan => text != null;
+  bool get isWidgetSpan => widgetDefinition != null;
+
+  /// Parse a single span entry from the YAML list.
+  /// Expected formats:
+  ///   - { text: "Hello", textStyle: {...}, onTap: {...} }
+  ///   - { widget: { Icon: { name: info, ... } } }
+  static SpanDefinition? from(dynamic entry) {
+    if (entry is! Map) return null;
+
+    if (entry.containsKey('text')) {
+      return SpanDefinition._(
+        text: Utils.optionalString(entry['text']),
+        textStyle: entry['textStyle'] is Map
+            ? Map<String, dynamic>.from(entry['textStyle'])
+            : null,
+        onTap: entry['onTap'],
+      );
+    } else if (entry.containsKey('widget')) {
+      return SpanDefinition._(
+        widgetDefinition: entry['widget'],
+      );
+    }
+    return null;
+  }
+
+  /// Parse the entire spans list from raw YAML value
+  static List<SpanDefinition> parseAll(dynamic rawSpans) {
+    if (rawSpans is! List) return [];
+    final List<SpanDefinition> result = [];
+    for (final entry in rawSpans) {
+      final span = SpanDefinition.from(entry);
+      if (span != null) {
+        result.add(span);
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- Extends the existing `Text` widget with a new `spans` property that enables rich text rendering with mixed styling and inline widgets (e.g., Icons, Images) within a single text flow
- When `spans` is provided, the widget internally uses `Text.rich()` with `TextSpan` and `WidgetSpan` children; existing `text:` usage remains fully unchanged
- Adds `span_definition.dart` as a lightweight data class for parsing span entries from raw YAML

## YAML Syntax

```yaml
Text:
  spans:
    - text: "Read our "
    - text: "Terms of Service"
      textStyle:
        color: 0xff4b93e7
        decoration: underline
      onTap:
        navigateScreen:
          name: HelpScreen
    - widget:
        Icon:
          name: info
          size: 18
  styles:
    textStyle:
      fontSize: 16
```

## Span Types
- **Text spans** — `text`, optional `textStyle` override, optional `onTap` action
- **Widget spans** — any Ensemble widget (Icon, Image, etc.) rendered inline via `WidgetSpan`