### PR TITLE
Add mergeOptions support for Firestore set operation

### DIFF
--- a/modules/ensemble/lib/framework/apiproviders/firestore/firestore_api_provider.dart
+++ b/modules/ensemble/lib/framework/apiproviders/firestore/firestore_api_provider.dart
@@ -274,7 +274,6 @@ class FirestoreAPIProvider extends APIProvider with LiveAPIProvider {
       'message': 'Subscribed to API',
       'documents': []
     };
-    ;
     return FirestoreResponse(
       apiState: APIState.success,
       body: body,

--- a/modules/ensemble/lib/framework/apiproviders/firestore/firestore_app.dart
+++ b/modules/ensemble/lib/framework/apiproviders/firestore/firestore_app.dart
@@ -149,9 +149,27 @@ class FirestoreApp {
 
   Future<void> performSetOperation(Map evaluatedApi) async {
     String path = evaluatedApi['path'];
-    Map<String, dynamic> data = EnsembleFieldValue.prepareToSendToFirestore(evaluatedApi['data']);
+    Map<String, dynamic> data =
+        EnsembleFieldValue.prepareToSendToFirestore(evaluatedApi['data']);
     DocumentReference docRef = firestore.doc(path);
-    return await docRef.set(data);
+
+    SetOptions? setOptions;
+    Map? mergeOptions = evaluatedApi['mergeOptions'];
+
+    if (mergeOptions != null) {
+      bool hasMerge = mergeOptions['merge'] == true;
+      bool hasMergeFields = mergeOptions['mergeFields'] is List;
+
+      // mergeFields takes priority over merge if both are provided
+      if (hasMergeFields) {
+        List<String> fields = List<String>.from(mergeOptions['mergeFields']);
+        setOptions = SetOptions(mergeFields: fields);
+      } else if (hasMerge) {
+        setOptions = SetOptions(merge: true);
+      }
+    }
+
+    return await docRef.set(data, setOptions);
   }
 
   Future<void> performUpdateOperation(Map evaluatedApi) async {


### PR DESCRIPTION
## Summary
- Adds `mergeOptions` property to Firestore `set` operation
- Supports `merge: true` and `mergeFields: [...]` options
- `mergeFields` takes priority if both are provided
- By default merge is false, when `mergeOptions` isn't defined for backward compatibility

The benefit of using merge is that if the document doesn't exist, it creates the new document with the given fields, but if the document already exists, it just updates the given field, while the rest remain the same.

## Example Usage

```yaml
# merge: true - merges all passed fields, preserves existing
myAPI:
  type: firestore
  path: users/user123
  operation: set
  mergeOptions:
    merge: true
  data:
    name: "John"
    email: "john@example.com"

# mergeFields - only writes specified fields useful with form fields data or api response.
myAPI:
  type: firestore
  path: users/user123
  operation: set
  mergeOptions:
    mergeFields:
      - name
      - updatedAt
  data:
    name: "John"
    email: "ignored"
    updatedAt: ${FieldValue.serverTimestamp()}
 ```
 
 Once approved, then before merging i will add the docs, schema, and Kitchen Sink Example.
 
 Schema PR: https://github.com/EnsembleUI/ensemble-web-studio/pull/1725
 Docs: https://github.com/EnsembleUI/ensemble_docs/pull/98#event-22963623585
 Also updated Kitchen Sink Example
 