### PR TITLE
feat(lottie): add .lottie file ext support

### DIFF
--- a/modules/ensemble/lib/widget/lottie/native/lottiestate.dart
+++ b/modules/ensemble/lib/widget/lottie/native/lottiestate.dart
@@ -7,10 +7,22 @@ import 'package:ensemble/widget/helpers/box_wrapper.dart';
 import 'package:ensemble/widget/lottie/lottie.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lottie/lottie.dart';
+import 'package:collection/collection.dart';
 
 class LottieState extends EWidgetState<EnsembleLottie>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
+
+  Future<LottieComposition?> _lottieDecoder(List<int> bytes) {
+    return LottieComposition.decodeZip(
+      bytes,
+      filePicker: (files) {
+        return files.firstWhereOrNull(
+          (f) => f.name.startsWith('animations/') && f.name.endsWith('.json'),
+        );
+      },
+    );
+  }
 
   @override
   void initState() {
@@ -78,6 +90,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
             onLoaded: (composition) {
               widget.controller.initializeLottieController(composition);
             },
+            decoder: widget.controller.source.endsWith('.lottie')
+                ? _lottieDecoder
+                : null,
             width: widget.controller.width?.toDouble(),
             height: widget.controller.height?.toDouble(),
             repeat: widget.controller.repeat,
@@ -87,6 +102,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
         }
         return Lottie.network(widget.controller.source,
             controller: widget.controller.lottieController,
+            decoder: widget.controller.source.endsWith('.lottie')
+                ? _lottieDecoder
+                : null,
             onLoaded: (composition) {
               widget.controller.initializeLottieController(composition);
             },
@@ -101,6 +119,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
         return Lottie.asset(
           Utils.getLocalAssetFullPath(widget.controller.source),
           controller: widget.controller.lottieController,
+          decoder: widget.controller.source.endsWith('.lottie')
+              ? _lottieDecoder
+              : null,
           onLoaded: (composition) {
             widget.controller.initializeLottieController(composition);
           },

--- a/modules/ensemble/lib/widget/lottie/web/lottiestate.dart
+++ b/modules/ensemble/lib/widget/lottie/web/lottiestate.dart
@@ -18,6 +18,7 @@ import 'package:js_widget/js_widget.dart';
 import 'dart:js' as js;
 import 'dart:html' as html;
 import 'package:lottie/lottie.dart';
+import 'package:collection/collection.dart';
 
 class LottieState extends EWidgetState<EnsembleLottie>
     with SingleTickerProviderStateMixin, LottieAction {
@@ -84,6 +85,17 @@ class LottieState extends EWidgetState<EnsembleLottie>
       rtn = Padding(padding: widget.controller.margin!, child: rtn);
     }
     return rtn;
+  }
+
+  Future<LottieComposition?> _lottieDecoder(List<int> bytes) {
+    return LottieComposition.decodeZip(
+      bytes,
+      filePicker: (files) {
+        return files.firstWhereOrNull(
+          (f) => f.name.startsWith('animations/') && f.name.endsWith('.json'),
+        );
+      },
+    );
   }
 
   // Render this when the runtime is flutter web with html renderer
@@ -251,6 +263,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
         if (Utils.isAssetAvailableLocally(assetName)) {
           return Lottie.asset(Utils.getLocalAssetFullPath(assetName),
               controller: widget.controller.lottieController,
+              decoder: widget.controller.source.endsWith('.lottie')
+                  ? _lottieDecoder
+                  : null,
               onLoaded: (LottieComposition composition) {
                 widget.controller.initializeLottieController(composition);
               },
@@ -266,6 +281,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
         return Lottie.network(
           widget.controller.source,
           controller: widget.controller.lottieController,
+          decoder: widget.controller.source.endsWith('.lottie')
+              ? _lottieDecoder
+              : null,
           onLoaded: (composition) {
             widget.controller.initializeLottieController(composition);
           },
@@ -280,6 +298,9 @@ class LottieState extends EWidgetState<EnsembleLottie>
 
       return Lottie.asset(Utils.getLocalAssetFullPath(widget.controller.source),
           controller: widget.controller.lottieController,
+          decoder: widget.controller.source.endsWith('.lottie')
+              ? _lottieDecoder
+              : null,
           onLoaded: (LottieComposition composition) {
             widget.controller.initializeLottieController(composition);
           },


### PR DESCRIPTION
## Summary

- Add support for `.lottie` file extension in the Lottie widget
- Introduce custom decoder to handle `.lottie` (zip-based) format
- Maintain backward compatibility with existing `.json` animations

## Key Changes

### Lottie Support
- Detect `.lottie` file extension in Lottie widget
- Decode and extract animation data from `.lottie` files
- Reuse existing rendering pipeline for playback

### Compatibility
- Ensure `.json` animations continue to work without changes
- Handle invalid or unsupported `.lottie` files gracefully

## Usage Example

```yaml
- Lottie:
    testId: animation
    source: Router.lottie
    styles:
      width: 200
      height: 200