### PR TITLE
fix(phone_contact): replace RuntimeError with debugPrint for missing contact photo

### DIFF
--- a/modules/ensemble/lib/action/phone_contact_action.dart
+++ b/modules/ensemble/lib/action/phone_contact_action.dart
@@ -10,6 +10,7 @@ import 'package:ensemble/framework/stub/contacts_manager.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:get_it/get_it.dart';
 
@@ -124,7 +125,9 @@ class GetPhoneContactPhotoAction extends EnsembleAction {
             id!, PhoneContactPhotoResponse(image: Uint8List.fromList([])));
         updateContactData(scopeManager, context, id!);
       }
-      throw RuntimeError('Contact Photo Error: $error');
+      if (kDebugMode) {
+        debugPrint('Contact photo missing $error');
+      }
     });
 
     return Future.value(null);


### PR DESCRIPTION
## Summary

* Replace thrown `RuntimeError` with `debugPrint` when contact photo is missing
* Treat missing contact images as a normal, non-fatal scenario

## Key Changes

### Error Handling

* Replace:

    * `throw RuntimeError('Contact Photo Error: $error');`
* With:

    * `debugPrint('Contact photo missing $error');`
* Ensure the app logs the issue in debug mode instead of interrupting execution


### Expected Behavior

* Missing contact photos no longer cause runtime failures
* Application continues to function normally
* Developers retain visibility via debug logs during development
