### PR TITLE
feat(image): add support for custom HTTP headers in image requests

### DIFF
--- a/modules/ensemble/lib/widget/image.dart
+++ b/modules/ensemble/lib/widget/image.dart
@@ -1,8 +1,9 @@
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:ensemble/action/haptic_action.dart';
 import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/widget/colored_box_placeholder.dart';
 import 'package:ensemble/framework/widget/widget.dart';
@@ -74,10 +75,8 @@ class EnsembleImage extends StatefulWidget
       'pinchToZoom': (value) =>
           _controller.pinchToZoom = Utils.optionalBool(value),
       'colorFilter': (value) => _controller.colorFilter = ColorFilterComposite.from(value),
-      'headers': (value) =>
-          _controller.headers = Utils.getMap(value)
+      'headers': (value) => _controller.headers = Utils.getMap(value)
           ?.map((key, value) => MapEntry(key.toString(), value.toString())),
-
     };
   }
 }
@@ -170,12 +169,30 @@ class ImageState extends EWidgetState<EnsembleImage> {
     return rtn;
   }
 
+  /// Evaluate headers using DataContext
+  Map<String, String>? _evaluateHeaders() {
+    if (widget._controller.headers == null) {
+      return null;
+    }
+
+    DataContext? dataContext = scopeManager?.dataContext;
+    if (dataContext == null) {
+      return widget._controller.headers;
+    }
+
+    Map<String, String> evaluatedHeaders = {};
+    widget._controller.headers!.forEach((key, value) {
+      evaluatedHeaders[key] = dataContext.eval(value).toString();
+    });
+    return evaluatedHeaders;
+  }
+
   Future<String> fetch(String url) async {
     String str = (widget.controller.source.contains("?")) ? "&" : "?";
     final http.Response response = await http
         .get(
         Uri.parse("$url${str}timeStamp=${DateTime.now().toString()}"),
-        headers: widget._controller.headers);
+        headers: _evaluateHeaders());
     DateTime lastModifiedDateTime =
         parseHttpDate("${response.headers['last-modified']}");
     if (widget._controller.lastModifiedCache == null ||
@@ -243,7 +260,7 @@ class ImageState extends EWidgetState<EnsembleImage> {
             width: widget._controller.width?.toDouble(),
             height: widget._controller.height?.toDouble(),
           ),
-          httpHeaders: widget._controller.headers,
+          httpHeaders: _evaluateHeaders(),
         );
       }
 
@@ -274,7 +291,7 @@ class ImageState extends EWidgetState<EnsembleImage> {
               height: widget._controller.height?.toDouble(),
               fit: fit,
               errorBuilder: (context, error, stacktrace) => errorFallback())
-          : Image.file(File(widget._controller.source),
+          : Image.file(io.File(widget._controller.source),
               width: widget._controller.width?.toDouble(),
               height: widget._controller.height?.toDouble(),
               fit: fit,
@@ -322,7 +339,7 @@ class ImageState extends EWidgetState<EnsembleImage> {
           width: widget._controller.width?.toDouble(),
           height: widget._controller.height?.toDouble(),
         ),
-        headers: widget._controller.headers,
+        headers: _evaluateHeaders(),
       );
     }
     // attempt local assets

--- a/modules/ensemble/lib/widget/image.dart
+++ b/modules/ensemble/lib/widget/image.dart
@@ -11,7 +11,6 @@ import 'package:ensemble/util/utils.dart';
 import 'package:ensemble/widget/helpers/ColorFilter_Composite.dart';
 import 'package:ensemble/widget/helpers/box_wrapper.dart';
 import 'package:ensemble/widget/helpers/controllers.dart';
-import 'package:ensemble/widget/helpers/widgets.dart';
 import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -45,6 +44,7 @@ class EnsembleImage extends StatefulWidget
       'placeholderColor': () => _controller.placeholderColor,
       'colorFilter': () =>
           _controller.colorFilter?.toString() ?? 'null',
+      'headers': () => _controller.headers,
     };
   }
 
@@ -74,6 +74,8 @@ class EnsembleImage extends StatefulWidget
       'pinchToZoom': (value) =>
           _controller.pinchToZoom = Utils.optionalBool(value),
       'colorFilter': (value) => _controller.colorFilter = ColorFilterComposite.from(value),
+      'headers': (value) =>
+          _controller.headers = Utils.getMap(value)?.cast<String, String>(),
 
     };
   }
@@ -101,6 +103,7 @@ class ImageController extends BoxController {
   dynamic fallback;
   bool cache = true;
   bool? pinchToZoom;
+  Map<String, String>? headers;
 }
 
 class ImageState extends EWidgetState<EnsembleImage> {
@@ -169,7 +172,9 @@ class ImageState extends EWidgetState<EnsembleImage> {
   Future<String> fetch(String url) async {
     String str = (widget.controller.source.contains("?")) ? "&" : "?";
     final http.Response response = await http
-        .get(Uri.parse("$url${str}timeStamp=${DateTime.now().toString()}"));
+        .get(
+        Uri.parse("$url${str}timeStamp=${DateTime.now().toString()}"),
+        headers: widget._controller.headers);
     DateTime lastModifiedDateTime =
         parseHttpDate("${response.headers['last-modified']}");
     if (widget._controller.lastModifiedCache == null ||
@@ -237,6 +242,7 @@ class ImageState extends EWidgetState<EnsembleImage> {
             width: widget._controller.width?.toDouble(),
             height: widget._controller.height?.toDouble(),
           ),
+          httpHeaders: widget._controller.headers,
         );
       }
 
@@ -315,6 +321,7 @@ class ImageState extends EWidgetState<EnsembleImage> {
           width: widget._controller.width?.toDouble(),
           height: widget._controller.height?.toDouble(),
         ),
+        headers: widget._controller.headers,
       );
     }
     // attempt local assets

--- a/modules/ensemble/lib/widget/image.dart
+++ b/modules/ensemble/lib/widget/image.dart
@@ -75,7 +75,8 @@ class EnsembleImage extends StatefulWidget
           _controller.pinchToZoom = Utils.optionalBool(value),
       'colorFilter': (value) => _controller.colorFilter = ColorFilterComposite.from(value),
       'headers': (value) =>
-          _controller.headers = Utils.getMap(value)?.cast<String, String>(),
+          _controller.headers = Utils.getMap(value)
+          ?.map((key, value) => MapEntry(key.toString(), value.toString())),
 
     };
   }


### PR DESCRIPTION
### Summary
Add support for custom HTTP headers in network images.

### Key Changes

**Image Request Handling**  
- Enable passing custom HTTP headers (e.g., `Authorization`) with network image requests.  
- Extend existing image loading logic to include header configuration.  
- Ensure headers are correctly attached to all outgoing image fetch requests.  

**API Consistency**  
- Align network image behavior with standard HTTP request patterns.  
- Avoid ad-hoc workarounds for authenticated or protected image resources.  

**Code Improvements**  
- Refactor request pipeline to support header injection cleanly.  
- Maintain backward compatibility for existing image usage.  

**Video Demonstration**  
[Watch video](https://github.com/user-attachments/assets/efc8e950-866f-4000-b4e5-a6a2f4643871)

### Usage Example

```yaml
- Image:
    source: https://example.com/image.png
    headers:
      Authorization: "Bearer ${token}"
      X-Custom-Header: "my-custom-value"