### PR TITLE
feat(tab): add persistentTabBar option for keep the tab pinned

### DIFF
--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -31,6 +31,8 @@ class TabBarController extends BoxController {
 
   int selectedIndex = 0;
 
+  bool persistentTabBar = false;
+
   List<TabItem> _originalItems = [];
   List<TabItem> _visibleItems = [];
 

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -90,6 +90,8 @@ abstract class BaseTabBar extends StatefulWidget
           EnsembleAction.from(action, initiator: this),
       'onTabSelectionHaptic': (value) =>
           _controller.onTabSelectionHaptic = Utils.optionalString(value),
+      'persistentTabBar': (value) =>
+          _controller.persistentTabBar = Utils.getBool(value, fallback: false),
     };
   }
 }
@@ -282,7 +284,12 @@ class TabBarState extends BaseTabBarState {
           // builder gives us dynamic height control vs TabBarView, but
           // is sub-optimal since it recreates the tab content on each pass.
           // This means onLoad API may be called multiple times in debug mode
-          tabContent
+
+          widget._controller.persistentTabBar
+              ? Expanded(
+                  child: SingleChildScrollView(
+                      child: tabContent))
+              : tabContent,
 
           // This cause Expanded child to fail
           // Padding(

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -286,9 +286,19 @@ class TabBarState extends BaseTabBarState {
           // This means onLoad API may be called multiple times in debug mode
 
           widget._controller.persistentTabBar
-              ? Expanded(
-                  child: SingleChildScrollView(
-                      child: tabContent))
+              ? (isExpanded
+                  ? Expanded(
+                      child: Builder(
+                        key: UniqueKey(),
+                        builder: (BuildContext context) =>
+                            SingleChildScrollView(child: buildSelectedTab()),
+                      ),
+                    )
+                  : Builder(
+                      key: UniqueKey(),
+                      builder: (BuildContext context) =>
+                          SingleChildScrollView(child: buildSelectedTab()),
+                    ))
               : tabContent,
 
           // This cause Expanded child to fail

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -272,7 +272,12 @@ class TabBarState extends BaseTabBarState {
       // https://stackoverflow.com/questions/55425804/using-builder-instead-of-statelesswidget
       Widget tabContent = Builder(
           key: UniqueKey(),
-          builder: (BuildContext context) => buildSelectedTab());
+          builder: (BuildContext context) {
+            if (widget._controller.persistentTabBar) {
+              return SingleChildScrollView(child: buildSelectedTab());
+            }
+            return buildSelectedTab();
+          });
       if (isExpanded) {
         tabContent = Expanded(child: tabContent);
       }
@@ -285,21 +290,7 @@ class TabBarState extends BaseTabBarState {
           // is sub-optimal since it recreates the tab content on each pass.
           // This means onLoad API may be called multiple times in debug mode
 
-          widget._controller.persistentTabBar
-              ? (isExpanded
-                  ? Expanded(
-                      child: Builder(
-                        key: UniqueKey(),
-                        builder: (BuildContext context) =>
-                            SingleChildScrollView(child: buildSelectedTab()),
-                      ),
-                    )
-                  : Builder(
-                      key: UniqueKey(),
-                      builder: (BuildContext context) =>
-                          SingleChildScrollView(child: buildSelectedTab()),
-                    ))
-              : tabContent,
+          tabContent,
 
           // This cause Expanded child to fail
           // Padding(


### PR DESCRIPTION
### Summary
Add `persistentTabBar` support so the tab bar stays pinned while only the tab content scrolls.

### Key Changes

**TabBar Behavior**  
- Add `persistentTabBar` parameter to `TabBar`.  
- Keep the tab bar fixed at the top.  
- Scroll only the selected tab content.

**Usage**  
```yaml
  body:
    TabBar:
      styles:
        persistentTabBar: true