### PR TITLE
Add `useIndexedTab` property for smooth tab switching with lazy-loaded indexed building

### DIFF
--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -66,8 +66,6 @@ class TabBarController extends BoxController {
     var setters = super.getBaseSetters();
     setters.addAll({
       'items': (values) => items = values,
-      'useIndexedTab': (value) =>
-      useIndexedTab = Utils.getBool(value, fallback: false),
     });
     return setters;
   }

--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -30,6 +30,7 @@ class TabBarController extends BoxController {
   TabBarAction? tabBarAction;
 
   int selectedIndex = 0;
+  bool useIndexedTab = false;
 
   List<TabItem> _originalItems = [];
   List<TabItem> _visibleItems = [];
@@ -65,6 +66,8 @@ class TabBarController extends BoxController {
     var setters = super.getBaseSetters();
     setters.addAll({
       'items': (values) => items = values,
+      'useIndexedTab': (value) =>
+      useIndexedTab = Utils.getBool(value, fallback: false),
     });
     return setters;
   }
@@ -80,10 +83,10 @@ class TabBarController extends BoxController {
 class TabItem {
   TabItem(
       {this.icon,
-      this.label,
-      this.tabWidget,
-      this.bodyWidget,
-      this.isVisible}) {
+        this.label,
+        this.tabWidget,
+        this.bodyWidget,
+        this.isVisible}) {
     if (icon == null && label == null && tabWidget == null) {
       throw LanguageError(
           "Each tab requires either an icon, a label, or a custom tabWidget");

--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -83,10 +83,10 @@ class TabBarController extends BoxController {
 class TabItem {
   TabItem(
       {this.icon,
-        this.label,
-        this.tabWidget,
-        this.bodyWidget,
-        this.isVisible}) {
+      this.label,
+      this.tabWidget,
+      this.bodyWidget,
+      this.isVisible}) {
     if (icon == null && label == null && tabWidget == null) {
       throw LanguageError(
           "Each tab requires either an icon, a label, or a custom tabWidget");

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -90,11 +90,16 @@ abstract class BaseTabBar extends StatefulWidget
           EnsembleAction.from(action, initiator: this),
       'onTabSelectionHaptic': (value) =>
           _controller.onTabSelectionHaptic = Utils.optionalString(value),
+      'useIndexedTab': (value) =>
+          _controller.useIndexedTab = Utils.getBool(value, fallback: false),
     };
   }
 }
 
 class TabBarState extends BaseTabBarState {
+  // Cache for indexed tab building mode
+  late List<Widget?> _cache;
+
   @override
   void initState() {
     super.initState();
@@ -102,8 +107,12 @@ class TabBarState extends BaseTabBarState {
   }
 
   void _initializeTabController() {
+    final safeIndex = _getValidInitialIndex();
+    if (widget.controller.useIndexedTab) {
+      _cache = List<Widget?>.filled(widget.controller.items.length, null);
+    }
     tabController = TabController(
-      initialIndex: _getValidInitialIndex(),
+      initialIndex: safeIndex,
       length: widget.controller.items.length,
       vsync: this,
     );
@@ -200,6 +209,12 @@ class TabBarState extends BaseTabBarState {
   void _reinitializeTabController() {
     tabController.removeListener(notifyListener);
     tabController.dispose();
+    // If a tab became hidden and the previously-selected index is now out of
+    // bounds, reset it before recreating the TabController and rebuilding,
+    // otherwise buildSelectedTab() will throw a RangeError.
+    if (widget._controller.selectedIndex >= widget._controller.items.length) {
+      widget._controller.selectedIndex = 0;
+    }
     _initializeTabController();
   }
 
@@ -216,6 +231,20 @@ class TabBarState extends BaseTabBarState {
     if (widget.controller.selectedIndex == index) {
       return;
     }
+
+    // If using indexed tab mode, build the tab on-demand before switching
+    if (widget.controller.useIndexedTab) {
+      final scopeManager = DataScopeWidget.getScope(context);
+      if (scopeManager != null &&
+          index < _cache.length &&
+          _cache[index] == null) {
+        final items = widget.controller.items;
+        if (index < items.length) {
+          _cache[index] = _buildTabAt(scopeManager, items[index]);
+        }
+      }
+    }
+
     setState(() {
       widget.controller.selectedIndex = index;
     });
@@ -264,13 +293,13 @@ class TabBarState extends BaseTabBarState {
     else {
       bool isExpanded = widget._controller.expanded;
 
-      // if Expanded is set, our content needs to stretch to the left-over height
-      // Note we make each Builder unique, as it tends to re-use
-      // the states (down the tree) from the previous Builder
-      // https://stackoverflow.com/questions/55425804/using-builder-instead-of-statelesswidget
-      Widget tabContent = Builder(
-          key: UniqueKey(),
-          builder: (BuildContext context) => buildSelectedTab());
+      // Use indexed tab building if enabled, otherwise use classic single-tab rendering
+      Widget tabContent = widget._controller.useIndexedTab
+          ? _buildTabBodies(context)
+          : Builder(
+              key: ValueKey(widget._controller.selectedIndex),
+              builder: (BuildContext context) => buildSelectedTab());
+
       if (isExpanded) {
         tabContent = Expanded(child: tabContent);
       }
@@ -279,16 +308,7 @@ class TabBarState extends BaseTabBarState {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           buildTabBar(),
-          // builder gives us dynamic height control vs TabBarView, but
-          // is sub-optimal since it recreates the tab content on each pass.
-          // This means onLoad API may be called multiple times in debug mode
-          tabContent
-
-          // This cause Expanded child to fail
-          // Padding(
-          //     padding: const EdgeInsets.only(left: 0),
-          //     child: Builder(builder: (BuildContext context) => buildSelectedTab())
-          // )
+          tabContent,
         ],
       );
       // if Expanded is set, stretch our column to left-over height
@@ -319,5 +339,55 @@ class TabBarState extends BaseTabBarState {
       return scopeManager.buildWidgetFromDefinition(selectedTab.bodyWidget);
     }
     return const Text("Unknown widget for this Tab");
+  }
+
+  /// Builds tabs on-demand with caching (used when useIndexedTab is true).
+  /// - Non-expanded: Column + Offstage for hidden tabs (zero-height)
+  /// - Expanded: IndexedStack (bounded height)
+  Widget _buildTabBodies(BuildContext context) {
+    final scopeManager = DataScopeWidget.getScope(context);
+    if (scopeManager == null) return const Text('Unknown widget for this Tab');
+
+    final items = widget._controller.items;
+    final selectedIndex = widget._controller.selectedIndex;
+
+    // Ensure cache size matches current item count
+    if (_cache.length != items.length) {
+      _cache = List<Widget?>.filled(items.length, null);
+    }
+
+    // Build the selected tab now if not already cached
+    _cache[selectedIndex] ??= _buildTabAt(scopeManager, items[selectedIndex]);
+
+    // Non-expanded: lives in unconstrained scroll context
+    // Use Column + Offstage to zero-out hidden tabs
+    if (!widget._controller.expanded) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: List.generate(items.length, (i) {
+          return Offstage(
+            offstage: i != selectedIndex,
+            child: _cache[i] ?? const SizedBox.shrink(),
+          );
+        }),
+      );
+    }
+
+    // Expanded: bounded height is provided by Expanded wrapper
+    // IndexedStack is safe here and stacks children in bounded space
+    return IndexedStack(
+      index: selectedIndex,
+      children: List.generate(
+        items.length,
+        (i) => _cache[i] ?? const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  /// Build a single tab at given index
+  Widget _buildTabAt(ScopeManager scopeManager, TabItem tab) {
+    if (tab.bodyWidget == null) return const SizedBox.shrink();
+    return scopeManager.buildWidgetFromDefinition(tab.bodyWidget);
   }
 }

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -363,6 +363,7 @@ class TabBarState extends BaseTabBarState {
   }
 
   /// Builds tabs on-demand with caching (used when useIndexedTab is true).
+  /// - Persistent tab bar: scroll only the selected tab body
   /// - Non-expanded: Column + Offstage for hidden tabs (zero-height)
   /// - Expanded: IndexedStack (bounded height)
   Widget _buildTabBodies(BuildContext context) {
@@ -380,28 +381,40 @@ class TabBarState extends BaseTabBarState {
     // Build the selected tab now if not already cached
     _cache[selectedIndex] ??= _buildTabAt(scopeManager, items[selectedIndex]);
 
+    Widget buildTabBody(int index) {
+      final tabBody = _cache[index] ?? const SizedBox.shrink();
+      if (!widget._controller.persistentTabBar) {
+        return tabBody;
+      }
+      return SingleChildScrollView(child: tabBody);
+    }
+
+    Widget buildOffstageTabs() {
+      return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: List.generate(items.length, (i) {
+            return Offstage(
+              offstage: i != selectedIndex,
+              child: buildTabBody(i),
+            );
+          }));
+    }
+
     // Non-expanded: lives in unconstrained scroll context
     // Use Column + Offstage to zero-out hidden tabs
     if (!widget._controller.expanded) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: List.generate(items.length, (i) {
-          return Offstage(
-            offstage: i != selectedIndex,
-            child: _cache[i] ?? const SizedBox.shrink(),
-          );
-        }),
-      );
+      return buildOffstageTabs();
     }
 
     // Expanded: bounded height is provided by Expanded wrapper
     // IndexedStack is safe here and stacks children in bounded space
     return IndexedStack(
       index: selectedIndex,
+      sizing: StackFit.expand,
       children: List.generate(
         items.length,
-        (i) => _cache[i] ?? const SizedBox.shrink(),
+        buildTabBody,
       ),
     );
   }

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -1,4 +1,3 @@
-
 import 'package:ensemble/action/haptic_action.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/bindings.dart';
@@ -59,42 +58,42 @@ abstract class BaseTabBar extends StatefulWidget
     return {
       'id': (value) => _controller.id = Utils.optionalString(value),
       'tabPosition': (position) =>
-      _controller.tabPosition = Utils.optionalString(position),
+          _controller.tabPosition = Utils.optionalString(position),
       'tabAlignment': (alignment) =>
-      _controller.tabAlignment = Utils.optionalString(alignment),
+          _controller.tabAlignment = Utils.optionalString(alignment),
       'indicatorSize': (type) =>
-      _controller.indicatorSize = Utils.optionalString(type),
+          _controller.indicatorSize = Utils.optionalString(type),
       'margin': (margin) => _controller.margin = Utils.optionalInsets(margin),
       'tabPadding': (padding) =>
-      _controller.tabPadding = Utils.optionalInsets(padding),
+          _controller.tabPadding = Utils.optionalInsets(padding),
       'tabFontSize': (fontSize) =>
-      _controller.tabFontSize = Utils.optionalInt(fontSize),
+          _controller.tabFontSize = Utils.optionalInt(fontSize),
       'tabFontWeight': (fontWeight) =>
-      _controller.tabFontWeight = Utils.getFontWeight(fontWeight),
+          _controller.tabFontWeight = Utils.getFontWeight(fontWeight),
       'tabBackgroundColor': (bgColor) =>
-      _controller.tabBackgroundColor = Utils.getColor(bgColor),
+          _controller.tabBackgroundColor = Utils.getColor(bgColor),
       'activeTabColor': (color) =>
-      _controller.activeTabColor = Utils.getColor(color),
+          _controller.activeTabColor = Utils.getColor(color),
       'inactiveTabColor': (color) =>
-      _controller.inactiveTabColor = Utils.getColor(color),
+          _controller.inactiveTabColor = Utils.getColor(color),
       'activeTabBackgroundColor': (color) =>
-      _controller.activeTabBackgroundColor = Utils.getColor(color),
+          _controller.activeTabBackgroundColor = Utils.getColor(color),
       'dividerColor': (color) =>
-      _controller.dividerColor = Utils.getColor(color),
+          _controller.dividerColor = Utils.getColor(color),
       'indicatorColor': (color) =>
-      _controller.indicatorColor = Utils.getColor(color),
+          _controller.indicatorColor = Utils.getColor(color),
       'indicatorThickness': (thickness) =>
-      _controller.indicatorThickness = Utils.optionalInt(thickness),
+          _controller.indicatorThickness = Utils.optionalInt(thickness),
       'selectedIndex': (index) =>
-      _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
+          _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
       'onTabSelection': (action) => _controller.onTabSelection =
           EnsembleAction.from(action, initiator: this),
       'onTabSelectionHaptic': (value) =>
-      _controller.onTabSelectionHaptic = Utils.optionalString(value),
+          _controller.onTabSelectionHaptic = Utils.optionalString(value),
       'persistentTabBar': (value) =>
-      _controller.persistentTabBar = Utils.getBool(value, fallback: false),
+          _controller.persistentTabBar = Utils.getBool(value, fallback: false),
       'useIndexedTab': (value) =>
-      _controller.useIndexedTab = Utils.getBool(value, fallback: false),
+          _controller.useIndexedTab = Utils.getBool(value, fallback: false),
     };
   }
 }
@@ -305,14 +304,14 @@ class TabBarState extends BaseTabBarState {
       Widget tabContent = widget._controller.useIndexedTab
           ? _buildTabBodies(context)
           : Builder(
-        key: UniqueKey(),
-        builder: (BuildContext context) {
-          if (widget._controller.persistentTabBar) {
-            return SingleChildScrollView(child: buildSelectedTab());
-          }
-          return buildSelectedTab();
-        },
-      );
+              key: UniqueKey(),
+              builder: (BuildContext context) {
+                if (widget._controller.persistentTabBar) {
+                  return SingleChildScrollView(child: buildSelectedTab());
+                }
+                return buildSelectedTab();
+              },
+            );
       if (isExpanded) {
         tabContent = Expanded(child: tabContent);
       }
@@ -357,7 +356,7 @@ class TabBarState extends BaseTabBarState {
     ScopeManager? scopeManager = DataScopeWidget.getScope(context);
     if (scopeManager != null) {
       TabItem selectedTab =
-      widget._controller.items[widget._controller.selectedIndex];
+          widget._controller.items[widget._controller.selectedIndex];
       return scopeManager.buildWidgetFromDefinition(selectedTab.bodyWidget);
     }
     return const Text("Unknown widget for this Tab");
@@ -402,7 +401,7 @@ class TabBarState extends BaseTabBarState {
       index: selectedIndex,
       children: List.generate(
         items.length,
-            (i) => _cache[i] ?? const SizedBox.shrink(),
+        (i) => _cache[i] ?? const SizedBox.shrink(),
       ),
     );
   }
@@ -413,4 +412,3 @@ class TabBarState extends BaseTabBarState {
     return scopeManager.buildWidgetFromDefinition(tab.bodyWidget);
   }
 }
-

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -293,11 +293,17 @@ class TabBarState extends BaseTabBarState {
     else {
       bool isExpanded = widget._controller.expanded;
 
+      // if Expanded is set, our content needs to stretch to the left-over height
+      // Note we make each Builder unique, as it tends to re-use
+      // the states (down the tree) from the previous Builder
+      // https://stackoverflow.com/questions/55425804/using-builder-instead-of-statelesswidget
+
       // Use indexed tab building if enabled, otherwise use classic single-tab rendering
       Widget tabContent = widget._controller.useIndexedTab
           ? _buildTabBodies(context)
           : Builder(
-              key: ValueKey(widget._controller.selectedIndex),
+              // Using ValueKey to rebuild only when selectedIndex changes
+              key: UniqueKey(),
               builder: (BuildContext context) => buildSelectedTab());
 
       if (isExpanded) {
@@ -308,7 +314,16 @@ class TabBarState extends BaseTabBarState {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           buildTabBar(),
-          tabContent,
+          // builder gives us dynamic height control vs TabBarView, but
+          // is sub-optimal since it recreates the tab content on each pass.
+          // This means onLoad API may be called multiple times in debug mode
+          tabContent
+
+          // This cause Expanded child to fail
+          // Padding(
+          //     padding: const EdgeInsets.only(left: 0),
+          //     child: Builder(builder: (BuildContext context) => buildSelectedTab())
+          // )
         ],
       );
       // if Expanded is set, stretch our column to left-over height


### PR DESCRIPTION
**Description:**  
Introduces `useIndexedTab`, a boolean property that enables IndexedStack-based tab building in TabBar widgets. 

**Problem it solves:**  
By default, when switching tabs, the previous tab's widget is removed from the widget tree. Switching back to that tab requires rebuilding it, which causes lag or freezing if the tab contains heavy data.

**Solution:**  
With `useIndexedTab: true`, tabs are built on-demand and cached. When you switch to a tab for the first time, it's built and cached. Tab switching becomes instant—no rebuild, no delay, no freeze. Unvisited tabs remain lazy and are not built until accessed.

**How it works:**  
- Tabs are built only when first accessed (lazy loading)
- Built tabs are cached and kept in the widget tree while the screen is active
- Uses `IndexedStack` (expanded) or `Column` with `Offstage` (non-expanded) to maintain widgets in tree
- Only the active tab is visible; others remain cached and ready

**Impact:**  
Eliminates freezed transitions when switching between tabs with heavy content.

https://github.com/user-attachments/assets/d20a713e-76bd-4498-b043-ebdbcbbe97db

