### PR TITLE
[BUG] Disposed the progress extra timer when not in used.

### DIFF
--- a/modules/ensemble/lib/widget/progress_indicator.dart
+++ b/modules/ensemble/lib/widget/progress_indicator.dart
@@ -74,6 +74,7 @@ class ProgressController extends WidgetController {
 class ProgressState extends EWidgetState<EnsembleProgressIndicator> {
   static const interval = 100;
   Timer? countdownTimer;
+  Timer? mainTimer;
 
   bool hasCountdown() {
     return widget._controller.countdown != null &&
@@ -88,25 +89,31 @@ class ProgressState extends EWidgetState<EnsembleProgressIndicator> {
       // status timer that waits up every 500ms and update progress
       countdownTimer =
           Timer.periodic(const Duration(milliseconds: interval), (timer) {
-        setState(() {
-          widget._controller.value = min(1,
-              timer.tick * interval / (widget._controller.countdown! * 1000));
-        });
-        if (widget._controller.value == 1) {
+        if (mounted) {
+          setState(() {
+            widget._controller.value = min(1,
+                timer.tick * interval / (widget._controller.countdown! * 1000));
+          });
+          if (widget._controller.value == 1) {
+            timer.cancel();
+          }
+        } else {
           timer.cancel();
         }
       });
 
       // main timer that stops upon countdown
-      Timer(Duration(seconds: widget._controller.countdown!), () {
+      mainTimer = Timer(Duration(seconds: widget._controller.countdown!), () {
         countdownTimer?.cancel();
-        setState(() {
-          widget._controller.value = 1;
-        });
-        if (widget._controller.onCountdownComplete != null) {
-          ScreenController().executeAction(
-              context, widget._controller.onCountdownComplete!,
-              event: EnsembleEvent(widget));
+        if (mounted) {
+          setState(() {
+            widget._controller.value = 1;
+          });
+          if (widget._controller.onCountdownComplete != null) {
+            ScreenController().executeAction(
+                context, widget._controller.onCountdownComplete!,
+                event: EnsembleEvent(widget));
+          }
         }
       });
     }
@@ -114,8 +121,9 @@ class ProgressState extends EWidgetState<EnsembleProgressIndicator> {
 
   @override
   void dispose() {
-    super.dispose();
     countdownTimer?.cancel();
+    mainTimer?.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
When we have a timer set for each time of the causal tiles, it creates an extra timer which doesn't get disposed once it is used, so it generates the following error every time tiles changes.
```
I/flutter (19880): ----------------FIREBASE CRASHLYTICS----------------
I/flutter (19880): setState() called after dispose(): ProgressState#421dd(lifecycle state: defunct, not mounted)
I/flutter (19880): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
I/flutter (19880): The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
I/flutter (19880): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
I/flutter (19880): #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1163:9)
I/flutter (19880): #1      State.setState (package:flutter/src/widgets/framework.dart:1198:6)
I/flutter (19880): #2      ProgressState.initState.<anonymous closure> (package:ensemble/widget/progress_indicator.dart:103:9)
I/flutter (19880): #3      Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
I/flutter (19880): #4      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:423:19)
I/flutter (19880): #5      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:454:5)
I/flutter (19880): #6      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:12)
I/flutter (19880): ----------------------------------------------------
```

Fixed it.