### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+Ensemble is a Flutter/Dart monorepo (managed by Melos) that provides a runtime for building native apps from declarative YAML definitions. The starter app (`/starter`) is the primary runnable application.
+
+### Prerequisites
+- **Flutter SDK 3.38.7** must be installed at `/opt/flutter` with `/opt/flutter/bin` on `PATH`.
+- **Melos** must be globally activated (`dart pub global activate melos`).
+- `PATH` must include both `/opt/flutter/bin` and `$HOME/.pub-cache/bin`.
+
+### Key commands
+
+| Task | Command | Working directory |
+|------|---------|-------------------|
+| Bootstrap monorepo | `melos bootstrap` | `/workspace` |
+| Lint (core module) | `flutter analyze` | `/workspace/modules/ensemble` |
+| Lint (starter) | `flutter analyze` | `/workspace/starter` |
+| Unit tests (core) | `flutter test` | `/workspace/modules/ensemble` |
+| Unit tests (auth) | `flutter test` | `/workspace/modules/auth` |
+| Build web | `flutter build web --no-tree-shake-icons` | `/workspace/starter` |
+| Run web dev server | `flutter run -d web-server --web-port=8080 --web-hostname=0.0.0.0` | `/workspace/starter` |
+
+### Non-obvious gotchas
+- The starter's `pubspec.yaml` points the `ensemble` dependency to a git URL, but `melos bootstrap` overrides this with a local path reference. Always run `melos bootstrap` from the repo root before building.
+- The default `ensemble-config.yaml` uses `from: ensemble` which fetches app definitions from Ensemble's cloud (Firestore). This works without any local Firebase setup since it reads from a public Kitchen Sink demo app (`appId: e24402cb-75e2-404c-866c-29e6c3dd7992`).
+- To use local YAML definitions instead, change `from: ensemble` to `from: local` in `starter/ensemble/ensemble-config.yaml`.
+- `flutter analyze` will report ~520 pre-existing warnings in `modules/ensemble` (mostly unused imports and `must_be_immutable`). These are not regressions.
+- Web builds produce Wasm compatibility warnings for packages using `dart:html` — these are informational and do not block the JS build.
+- The Chrome device (`-d chrome`) opens a browser window; use `-d web-server` for headless/CI environments.
+- After changing dependencies in any module's `pubspec.yaml`, re-run `melos bootstrap` from the repo root.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for setting up and working with the development environment.

## Changes

- Created `AGENTS.md` at repo root with:
  - Project overview (Flutter/Dart monorepo managed by Melos)
  - Prerequisites (Flutter SDK, Melos, PATH setup)
  - Key commands table (bootstrap, lint, test, build, run)
  - Non-obvious gotchas discovered during environment setup

## Development Environment Verification

The following were verified during setup:

| Check | Status |
|-------|--------|
| `melos bootstrap` (46 packages) | Pass |
| `flutter analyze` (starter) | Pass (4 pre-existing warnings) |
| `flutter analyze` (core module) | Pass (520 pre-existing warnings) |
| `flutter test` (core module - 63 tests) | Pass |
| `flutter test` (auth module - 6 tests) | Pass |
| `flutter build web` (starter) | Pass |
| `flutter run -d web-server` (starter) | Pass |

### Demo

[ensemble_kitchen_sink_demo.mp4](https://cursor.com/agents/bc-30a0e5ca-dde8-44cd-aa25-5fba02d4913d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fensemble_kitchen_sink_demo.mp4)
[Kitchen Sink home screen](https://cursor.com/agents/bc-30a0e5ca-dde8-44cd-aa25-5fba02d4913d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_home_screen.webp)
[Interactive button demo](https://cursor.com/agents/bc-30a0e5ca-dde8-44cd-aa25-5fba02d4913d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_interactive_button.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30a0e5ca-dde8-44cd-aa25-5fba02d4913d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30a0e5ca-dde8-44cd-aa25-5fba02d4913d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

