### PR TITLE
feat(device): streamline MediaQuery capability and add device metric notifications

### DIFF
--- a/modules/ensemble/lib/framework/device.dart
+++ b/modules/ensemble/lib/framework/device.dart
@@ -100,7 +100,7 @@ mixin MediaQueryCapability {
 
   int get screenWidth => _getData().size.width.toInt();
   int get screenHeight => _getData().size.height.toInt();
-  String get screenOrientation => _getData().orientation.toString();
+  String get screenOrientation => _getData().orientation.name;
   int get safeAreaTop => _getData().padding.top.toInt();
   int get safeAreaBottom => _getData().padding.bottom.toInt();
 }

--- a/modules/ensemble/lib/framework/device.dart
+++ b/modules/ensemble/lib/framework/device.dart
@@ -94,13 +94,8 @@ class Device
 }
 
 mixin MediaQueryCapability {
-  static MediaQueryData? data;
-
   MediaQueryData _getData() {
-    if (StorageManager().isPreview() == true) {
-      return MediaQuery.of(Utils.globalAppKey.currentContext!);
-    }
-    return data ??= MediaQuery.of(Utils.globalAppKey.currentContext!);
+    return MediaQuery.of(Utils.globalAppKey.currentContext!);
   }
 
   int get screenWidth => _getData().size.width.toInt();

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -5,6 +5,7 @@ import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/data_context.dart';
+import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/devmode.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/extensions.dart';
@@ -281,6 +282,36 @@ class PageState extends State<Page>
       }
       // reset inactive time
       appLastPaused = null;
+    }
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _notifyDeviceMetricBindings();
+    });
+  }
+
+  /// Re-evaluate ${device.width} / orientation after rotation.
+  void _notifyDeviceMetricBindings() {
+    final d = Device();
+    void fire(ScopeManager sm) {
+      for (final e in <(String, Object)>[
+        ('width', d.screenWidth),
+        ('height', d.screenHeight),
+        ('orientation', d.screenOrientation),
+      ]) {
+        sm.dispatch(ModelChangeEvent(DeviceBindingSource(e.$1), e.$2));
+      }
+    }
+
+    fire(_scopeManager);
+    final pageGroupScope = PageGroupWidget.getScope(context);
+    if (pageGroupScope != null && pageGroupScope != _scopeManager) {
+      fire(pageGroupScope);
     }
   }
 


### PR DESCRIPTION
- Removed static MediaQueryData from MediaQueryCapability mixin.
- Simplified _getData() method to always return current MediaQuery data.
- Implemented didChangeMetrics() in PageState to notify device metrics on orientation changes.
- Added _notifyDeviceMetricBindings() to dispatch updated device dimensions and orientation.