### PR TITLE
feat(ensemble): enhance reusable Actions handling

### DIFF
--- a/modules/ensemble/README.md
+++ b/modules/ensemble/README.md
@@ -75,6 +75,7 @@ This package has a substantial `test/` directory. Run package tests with `melos 
 
 ## Additional technical documentation
 
+- [Reusable Actions](docs/reusable-actions.md) — app-level and page-level Actions, `executeAction`, scoped `Import`/`Global`/`API`, and events.
 - [Layout widgets (tabs, ListView scroll)](docs/layout-widgets.md) — EDL layout behavior in `lib/layout`.
 - [Runtime security and data bindings](docs/runtime-security-and-data-bindings.md) — screen id validation for definition providers, `saveFile` naming, multipart upload path checks, `ensemble.storage.clear()` behavior and binding refresh, WebView TLS/reputation settings, global script handler payloads, and device metric bindings after rotation.
 

--- a/modules/ensemble/docs/reusable-actions.md
+++ b/modules/ensemble/docs/reusable-actions.md
@@ -1,0 +1,392 @@
+# Reusable Actions
+
+This document describes **reusable Actions** in Ensemble: named, parameterized
+workflows you can call from any screen with `executeAction`. Implementation
+lives in `lib/action/execute_action.dart`, `lib/action/action_scope_util.dart`,
+and `lib/page_model.dart`.
+
+Reusable Actions are similar to custom widgets: they support scoped
+`Import`, `Global`, and `API` blocks, plus **events** for communicating
+results back to the caller.
+
+## Overview
+
+| Concept | Description |
+| --- | --- |
+| **App-level Action** | YAML file under `actions/` in a local app, or an entry in the Studio `resources` artifact `Actions` map |
+| **Page-level Action** | `Action:` block defined inline on a screen YAML |
+| **Invocation** | `executeAction` with a `name`, optional `inputs`, and optional `events` |
+| **Scope** | Each run creates a child scope with its own inputs, imports, APIs, and global code |
+
+Page-level Actions override app-level Actions when both share the same name.
+
+## Minimal example
+
+**`actions/showMessage.yaml`**
+
+```yaml
+Action:
+  inputs:
+    - message
+  body:
+    showToast:
+      message: ${message}
+```
+
+**Screen**
+
+```yaml
+Button:
+  label: Greet
+  onTap:
+    executeAction:
+      name: showMessage
+      inputs:
+        message: Hello ${ensemble.storage.helloApp.name.first}
+```
+
+## Action definition structure
+
+A reusable Action requires a `body` — a single Ensemble action (or action
+group). Optional fields:
+
+| Field | Description |
+| --- | --- |
+| `inputs` | List of parameter names passed in at call time |
+| `events` | Declares events the action can dispatch (documentation + Studio hints) |
+| `body` | The action tree to execute (required) |
+
+### App-level file layout
+
+For local apps, each Action is a separate file. The file can use a top-level
+`Action:` wrapper with sibling resource blocks:
+
+```yaml
+Import:
+  - common
+
+Global: |-
+  function formatUserName(user) {
+    return user.firstName + ' ' + user.lastName;
+  }
+
+API:
+  getUser:
+    url: ${env.apiURL}/users/${userId}
+    method: GET
+
+Action:
+  inputs:
+    - userId
+  events:
+    onSuccess:
+      data:
+        user: object
+  body:
+    invokeAPI:
+      name: getUser
+```
+
+`Import`, `Global`, and `API` at the file root are merged into the Action
+definition at load time (same pattern as custom widgets).
+
+### Page-level layout
+
+Define Actions directly on a screen:
+
+```yaml
+View:
+  body:
+    Button:
+      label: Fetch
+      onTap:
+        executeAction:
+          name: callAPI
+          inputs:
+            call: true
+
+Action:
+  callAPI:
+    inputs:
+      - call
+    body:
+      executeConditionalAction:
+        conditions:
+          - if: ${call == true}
+            action:
+              invokeAPI:
+                name: mockAPI
+
+API:
+  mockAPI:
+    url: ${env.apiURL}/users/1
+    method: GET
+```
+
+## Calling a reusable Action
+
+Use the `executeAction` action:
+
+```yaml
+executeAction:
+  name: fetchUser          # required — action name
+  inputs:                  # optional — maps to declared input parameters
+    userId: 1
+  events:                  # optional — handlers for events dispatched by the action
+    onSuccess:
+      showToast:
+        message: Loaded ${event.data.user.firstName}
+    onError:
+      showToast:
+        message: ${event.data.message}
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Name of the reusable Action |
+| `inputs` | No | Key/value map of input parameters |
+| `events` | No | Event handlers (see below) |
+
+Input values support data bindings (`${...}`) and are evaluated in the
+caller's scope before being passed into the action.
+
+## Events
+
+Events let a reusable Action communicate results to its caller without
+writing to `ensemble.storage`. The pattern matches custom widget events.
+
+### 1. Declare events on the Action
+
+```yaml
+Action:
+  events:
+    onSuccess:
+      data:
+        user: object
+    onError:
+      data:
+        message: string
+```
+
+Event declarations describe the payload shape. They are optional but
+recommended for documentation and tooling.
+
+### 2. Dispatch events from the action body
+
+Use `dispatchEvent` inside the action `body`:
+
+```yaml
+body:
+  invokeAPI:
+    name: getUser
+    onResponse:
+      dispatchEvent:
+        onSuccess:
+          data:
+            user: ${getUser.body}
+    onError:
+      dispatchEvent:
+        onError:
+          data:
+            message: Failed to fetch user
+```
+
+### 3. Handle events at the call site
+
+Wire handlers in `executeAction`:
+
+```yaml
+executeAction:
+  name: fetchUser
+  inputs:
+    userId: 1
+  events:
+    onSuccess:
+      navigateScreen:
+        name: Profile
+    onError:
+      showToast:
+        message: ${event.data.message}
+```
+
+Event handlers run in the **caller's scope**. The dispatched payload is
+available as `event.data` (and `event.error` when applicable).
+
+### Multiple steps in the body
+
+When the body needs more than one action (for example, run code then call an
+API), use `executeActionGroup`:
+
+```yaml
+body:
+  executeActionGroup:
+    executeInOrder: true
+    actions:
+      - executeCode:
+          body: |-
+            console.log('starting fetch');
+      - invokeAPI:
+          name: getUser
+          onResponse:
+            dispatchEvent:
+              onSuccess:
+                data:
+                  user: ${getUser.body}
+```
+
+## Scoped resources
+
+### Import
+
+Pull in app scripts from the `scripts/` directory (local) or the `Scripts`
+resources map (Ensemble/CDN):
+
+```yaml
+Import:
+  - common
+  - utils
+```
+
+Imported functions are available inside the action scope for `Global` code and
+API `onResponse` blocks.
+
+### Global
+
+JavaScript functions and variables scoped to the action run:
+
+```yaml
+Global: |-
+  function formatUserName(user) {
+    return user.firstName + ' ' + user.lastName;
+  }
+```
+
+Global code runs after inputs are set and before the `body` executes.
+
+### API
+
+APIs defined on a reusable Action are scoped to the action's child scope.
+Use `invokeAPI` by name inside the `body`:
+
+```yaml
+API:
+  getUser:
+    url: https://api.example.com/users/${userId}
+    method: GET
+
+Action:
+  inputs:
+    - userId
+  body:
+    invokeAPI:
+      name: getUser
+```
+
+Action-scoped APIs are merged into the page `apiMap` while the action runs,
+so bindings like `${getUser.body}` work inside the action. Prefer
+`dispatchEvent` to pass API results to the caller rather than relying on
+screen-level bindings.
+
+## Local app setup
+
+### Directory structure
+
+```
+ensemble/apps/yourAppName/
+├── actions/
+│   ├── showMessage.yaml
+│   └── fetchUser.yaml
+├── .manifest.json
+├── screens/
+├── widgets/
+└── scripts/
+```
+
+### Manifest
+
+Register each action in `.manifest.json`:
+
+```json
+{
+  "actions": [
+    { "name": "showMessage" },
+    { "name": "fetchUser" }
+  ]
+}
+```
+
+### pubspec assets
+
+Include the actions directory in `pubspec.yaml`:
+
+```yaml
+flutter:
+  assets:
+    - ensemble/apps/yourAppName/actions/
+```
+
+The starter app's `helloApp` includes working examples:
+`actions/showMessage.yaml`, `actions/fetchUser.yaml`, and usage on
+`screens/Hello Home.yaml`.
+
+## Ensemble and CDN providers
+
+For Studio / Firestore apps, Actions are stored in the `resources` artifact
+under the `Actions` key (see `ResourceArtifactEntry.Actions` in
+`lib/framework/definition_providers/provider.dart`).
+
+Each entry is a map of action name to YAML content. The same file-level layout
+applies:
+
+```yaml
+Import:
+  - apiUtils
+API:
+  myApi:
+    url: https://example.com/data
+    method: GET
+Action:
+  inputs: []
+  body:
+    invokeAPI:
+      name: myApi
+```
+
+For CDN-hosted apps, actions are parsed from the manifest `actions` array with
+`name` and `content` fields. File-level `Import`, `Global`, and `API` blocks
+are merged automatically.
+
+Remote definitions (`resources.ensemble`) use the same `Actions` map structure.
+
+## Scope and isolation
+
+| Data | Visibility |
+| --- | --- |
+| `inputs` | Action scope only; set per call |
+| `Import` / `Global` | Action scope only |
+| `API` bindings | Available inside the action while it runs |
+| `dispatchEvent` payload | Passed explicitly to caller via `event.data` |
+| `ensemble.storage` | App-global; only used if the action explicitly writes to it |
+
+Keep side effects explicit: use **events** for outputs, **inputs** for
+parameters, and avoid `ensemble.storage` unless the data should be shared
+across the whole app.
+
+## When to use reusable Actions
+
+| Use reusable Actions when… | Use inline actions when… |
+| --- | --- |
+| The same workflow appears on multiple screens | The logic is used once on a single screen |
+| You want a named, testable unit (login, checkout, fetch profile) | The action is a simple one-liner (`navigateScreen`, `showToast`) |
+| The workflow needs its own APIs, scripts, or global helpers | No extra scope or resources are needed |
+
+## Implementation references
+
+| File | Role |
+| --- | --- |
+| `lib/action/execute_action.dart` | Parses and runs `executeAction` |
+| `lib/action/action_scope_util.dart` | Merges resources, prepares child scope, registers event handlers |
+| `lib/page_model.dart` | Merges global and page-level `Action:` blocks into `actionsMap` |
+| `lib/framework/definition_providers/local_provider.dart` | Loads `actions/*.yaml` for local apps |
+| `lib/framework/definition_providers/cdn_provider.dart` | Parses CDN manifest actions |
+| `lib/framework/definition_providers/ensemble_provider.dart` | Loads `Actions` from Firestore resources |

--- a/modules/ensemble/lib/action/action_scope_util.dart
+++ b/modules/ensemble/lib/action/action_scope_util.dart
@@ -1,0 +1,204 @@
+import 'package:ensemble/ensemble.dart';
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/data_context.dart';
+import 'package:ensemble/framework/definition_providers/provider.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/widget/view_util.dart';
+import 'package:ensemble/page_model.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:source_span/source_span.dart';
+import 'package:yaml/yaml.dart';
+
+/// Utilities for reusable Action definitions that support scoped
+/// [Import], [Global], and [API] blocks (similar to custom widgets).
+class ActionScopeUtil {
+  static const List<String> _fileLevelKeys = [
+    PageModel.importToken,
+    'Global',
+    'API',
+  ];
+
+  /// Merge file-level [Import], [Global], and [API] into the Action definition.
+  static YamlMap? mergeActionFileContent(Map actionContent) {
+    final dynamic actionRoot = actionContent['Action'];
+    if (actionRoot is! Map) {
+      return null;
+    }
+
+    final Map<dynamic, dynamic> merged = Map.from(actionRoot);
+    for (final key in _fileLevelKeys) {
+      if (actionContent[key] != null) {
+        merged[key] = actionContent[key];
+      }
+    }
+    return YamlMap.wrap(merged);
+  }
+
+  /// Normalize a single action definition from any provider format.
+  /// Handles file-level [Action] wrappers with sibling [Import]/[Global]/[API]
+  /// blocks, as well as already-flattened definitions.
+  static YamlMap? normalizeActionDefinition(dynamic definition) {
+    YamlMap? yaml;
+    if (definition is YamlMap) {
+      yaml = definition;
+    } else if (definition is Map) {
+      yaml = YamlMap.wrap(definition);
+    } else if (definition is String && definition.isNotEmpty) {
+      final parsed = loadYaml(definition);
+      if (parsed is YamlMap) {
+        yaml = parsed;
+      }
+    }
+    if (yaml == null) {
+      return null;
+    }
+
+    if (yaml['Action'] is Map) {
+      return mergeActionFileContent(yaml) ?? yaml;
+    }
+    return yaml;
+  }
+
+  /// Normalize all entries in an [Actions] resources map.
+  static Map<String, YamlMap> normalizeActionsMap(Map actionsRaw) {
+    final Map<String, YamlMap> normalized = {};
+    actionsRaw.forEach((key, value) {
+      final YamlMap? action = normalizeActionDefinition(value);
+      if (action != null) {
+        normalized[key.toString()] = action;
+      }
+    });
+    return normalized;
+  }
+
+  /// Normalize the [Actions] entry inside a resources map, if present.
+  static Map? normalizeResources(Map? resources) {
+    if (resources == null) {
+      return null;
+    }
+    final dynamic actions = resources[ResourceArtifactEntry.Actions.name];
+    if (actions is! Map || actions.isEmpty) {
+      return resources;
+    }
+    final Map normalized = Map.from(resources);
+    normalized[ResourceArtifactEntry.Actions.name] =
+        normalizeActionsMap(actions);
+    return normalized;
+  }
+
+  /// Merge file-level keys when an [Action] wrapper is present in CDN content.
+  static YamlMap mergeCdnActionContent(YamlMap yaml, dynamic actionRoot) {
+    return normalizeActionDefinition(yaml) ?? YamlMap();
+  }
+
+  static Map<String, YamlMap>? parseApiMap(YamlMap definition) {
+    final dynamic apiNode = definition['API'];
+    if (apiNode is! YamlMap) {
+      return null;
+    }
+    final Map<String, YamlMap> apiMap = {};
+    apiNode.forEach((key, value) {
+      if (value is YamlMap) {
+        apiMap[key.toString()] = value;
+      }
+    });
+    return apiMap.isEmpty ? null : apiMap;
+  }
+
+  static Map<String, EnsembleEvent> parseEventParams(YamlMap definition) {
+    final Map<String, EnsembleEvent> eventParams = {};
+    final dynamic eventsNode = definition['events'];
+    if (eventsNode is Map) {
+      eventsNode.forEach((key, value) {
+        eventParams[key.toString()] = EnsembleEvent.fromYaml(
+            key.toString(), value is YamlMap ? value : null);
+      });
+    }
+    return eventParams;
+  }
+
+  static Map<String, EnsembleAction?> parseEventHandlers(Map? eventsPayload) {
+    final Map<String, EnsembleAction?> eventHandlers = {};
+    if (eventsPayload is Map) {
+      eventsPayload.forEach((key, value) {
+        eventHandlers[key.toString()] = EnsembleAction.from(value);
+      });
+    }
+    return eventHandlers;
+  }
+
+  /// Register caller-provided event handlers on the action scope.
+  /// Handlers execute in the parent (caller) scope, matching custom widget behavior.
+  static void registerEventHandlers({
+    required ScopeManager parentScope,
+    required ScopeManager actionScope,
+    required Map<String, EnsembleAction?> eventHandlers,
+  }) {
+    eventHandlers.forEach((eventName, action) {
+      if (action == null) {
+        return;
+      }
+      final handler = EnsembleEventHandler(parentScope, action);
+      actionScope.dataContext.addDataContextById(eventName, handler);
+    });
+  }
+
+  static ({String? code, SourceSpan? span}) parseGlobalCode(YamlMap definition) {
+    final YamlNode? globalCodeNode = definition.nodes['Global'];
+    if (globalCodeNode == null) {
+      return (code: null, span: null);
+    }
+    return (
+      code: Utils.optionalString(globalCodeNode.value),
+      span: ViewUtil.getDefinition(globalCodeNode),
+    );
+  }
+
+  /// Prepare a child scope with imports, APIs, global code, and input parameters.
+  static ScopeManager prepareScope({
+    required ScopeManager parentScope,
+    required YamlMap definition,
+    required List<String> parameters,
+    Map<String, dynamic> callInputs = const {},
+    Map<String, EnsembleAction?> eventHandlers = const {},
+  }) {
+    final importedCode = definition[PageModel.importToken] != null
+        ? Ensemble().getConfig()?.processImports(definition[PageModel.importToken])
+        : null;
+    final apiMap = parseApiMap(definition);
+
+    final ScopeManager childScope = parentScope.createChildScope(
+      childImportedCode: importedCode,
+      mergedApiMap: apiMap,
+    );
+
+    apiMap?.forEach((key, value) {
+      if (!childScope.dataContext.hasContext(key)) {
+        childScope.dataContext.addInvokableContext(key, APIResponse());
+      }
+    });
+
+    for (final String param in parameters) {
+      if (callInputs.containsKey(param)) {
+        final dynamic evaluated = childScope.dataContext.eval(callInputs[param]);
+        childScope.dataContext.addDataContextById(param, evaluated);
+      }
+    }
+
+    final global = parseGlobalCode(definition);
+    if (global.code != null && global.span != null) {
+      childScope.dataContext.evalCode(global.code!, global.span!);
+    }
+
+    if (eventHandlers.isNotEmpty) {
+      registerEventHandlers(
+        parentScope: parentScope,
+        actionScope: childScope,
+        eventHandlers: eventHandlers,
+      );
+    }
+
+    return childScope;
+  }
+}

--- a/modules/ensemble/lib/action/execute_action.dart
+++ b/modules/ensemble/lib/action/execute_action.dart
@@ -1,3 +1,4 @@
+import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/scope.dart';
@@ -9,10 +10,16 @@ import 'package:yaml/yaml.dart';
 
 /// Execute a named reusable Action defined under the page-level `Actions:` block and in the app's `actions` directory.
 class ExecuteActionAction extends EnsembleAction {
-  ExecuteActionAction({super.initiator, required this.name, this.rawInputs});
+  ExecuteActionAction({
+    super.initiator,
+    required this.name,
+    this.rawInputs,
+    this.eventHandlers = const {},
+  });
 
   final String name;
   final Map<String, dynamic>? rawInputs;
+  final Map<String, EnsembleAction?> eventHandlers;
 
   factory ExecuteActionAction.fromYaml({Invokable? initiator, Map? payload}) {
     if (payload == null) {
@@ -33,6 +40,8 @@ class ExecuteActionAction extends EnsembleAction {
       initiator: initiator,
       name: name,
       rawInputs: inputs,
+      eventHandlers: ActionScopeUtil.parseEventHandlers(
+          Utils.getMap(payload['events'])),
     );
   }
 
@@ -62,17 +71,14 @@ class ExecuteActionAction extends EnsembleAction {
       }
     }
 
-    // Build a child scope so parameter values are available as variables
-    final ScopeManager childScope = scopeManager.createChildScope();
-
-    final Map<String, dynamic> callInputs = rawInputs ?? const {};
-    for (final String param in parameters) {
-      if (callInputs.containsKey(param)) {
-        final dynamic evaluated =
-            childScope.dataContext.eval(callInputs[param]);
-        childScope.dataContext.addDataContextById(param, evaluated);
-      }
-    }
+    // Build a child scope with optional Import, API, Global, and input parameters
+    final ScopeManager childScope = ActionScopeUtil.prepareScope(
+      parentScope: scopeManager,
+      definition: definition,
+      parameters: parameters,
+      callInputs: rawInputs ?? const {},
+      eventHandlers: eventHandlers,
+    );
 
     // Now resolve and execute the inner Action tree.
     final dynamic bodyNode = definition['body'];

--- a/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/bindings.dart';
 import 'package:ensemble/framework/definition_providers/provider.dart';
@@ -804,13 +805,10 @@ class CdnDefinitionProvider extends DefinitionProvider {
         final YamlMap? yaml = _yamlFromUnknown(content);
         if (yaml == null) continue;
 
-        // Flatten optional top-level "Action" wrapper
+        // Flatten optional top-level "Action" wrapper and merge file-level
+        // Import, Global, and API blocks into the action definition.
         final dynamic root = yaml['Action'] ?? yaml;
-        if (root is YamlMap) {
-          actions[name] = root;
-        } else if (root is Map) {
-          actions[name] = YamlMap.wrap(root);
-        }
+        actions[name] = ActionScopeUtil.mergeCdnActionContent(yaml, root);
       }
     }
 
@@ -819,7 +817,7 @@ class CdnDefinitionProvider extends DefinitionProvider {
       ResourceArtifactEntry.Scripts.name: code,
     };
     if (actions.isNotEmpty) {
-      resources['Actions'] = actions;
+      resources[ResourceArtifactEntry.Actions.name] = actions;
     }
     if (resources.isNotEmpty) {
       // Store as plain Map (not YamlMap) to match Ensemble provider behavior

--- a/modules/ensemble/lib/framework/definition_providers/ensemble_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/ensemble_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
+import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/bindings.dart';
 import 'package:ensemble/framework/error_handling.dart';
@@ -659,6 +660,8 @@ class AppModel {
           //    }
           code.addAll(value.value);
         }
+      } else if (key == ResourceArtifactEntry.Actions.name && value is Map) {
+        output[key] = ActionScopeUtil.normalizeActionsMap(value);
       } else {
         // copy over non-Widgets
         output[key] = value;

--- a/modules/ensemble/lib/framework/definition_providers/local_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/local_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/definition_providers/provider.dart';
 import 'package:ensemble/framework/definition_providers/screen_selector_security.dart';
@@ -159,14 +160,14 @@ class LocalDefinitionProvider extends FileDefinitionProvider {
                 continue;
               }
 
-              final dynamic actionRoot = (actionContent)['Action'];
-              if (actionRoot is! Map) {
+              final YamlMap? actionDefinition =
+                  ActionScopeUtil.mergeActionFileContent(actionContent);
+              if (actionDefinition == null) {
                 debugPrint('Action root in $actionName is not a Map/YamlMap');
                 continue;
               }
 
-              final Map rootMap = actionRoot;
-              actions[actionName] = YamlMap.wrap(rootMap);
+              actions[actionName] = actionDefinition;
             } catch (e) {
               // ignore error loading individual action
             }
@@ -179,7 +180,7 @@ class LocalDefinitionProvider extends FileDefinitionProvider {
       output[ResourceArtifactEntry.Widgets.name] = widgets;
       output[ResourceArtifactEntry.Scripts.name] = code;
       if (actions.isNotEmpty) {
-        output['Actions'] = actions;
+        output[ResourceArtifactEntry.Actions.name] = actions;
       }
 
       return output;

--- a/modules/ensemble/lib/framework/definition_providers/provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/provider.dart
@@ -23,7 +23,7 @@ enum ArtifactType {
 }
 
 // the root entries of the Resource artifact
-enum ResourceArtifactEntry { Widgets, Scripts, API }
+enum ResourceArtifactEntry { Widgets, Scripts, Actions, API }
 
 enum _Provider { local, remote, ensemble, cdn }
 

--- a/modules/ensemble/lib/page_model.dart
+++ b/modules/ensemble/lib/page_model.dart
@@ -1,3 +1,4 @@
+import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/data_utils.dart';
 import 'package:ensemble/framework/error_handling.dart';
@@ -140,20 +141,20 @@ abstract class PageModel {
     // Start with global reusable Actions, if any (from app resources)
     Map<String, YamlMap>? merged = {};
     Map? globalResources = Ensemble().getConfig()?.getResources();
-    final dynamic globalActions = globalResources?['Actions'];
+    final dynamic globalActions =
+        globalResources?[ResourceArtifactEntry.Actions.name];
     if (globalActions is Map) {
-      globalActions.forEach((key, value) {
-        if (value is YamlMap) {
-          merged[key.toString()] = value;
-        }
+      ActionScopeUtil.normalizeActionsMap(globalActions).forEach((key, value) {
+        merged[key] = value;
       });
     }
 
     // Overlay page-level Actions from this document; page overrides global on name clash
     if (map != null) {
       map.forEach((key, value) {
-        if (value is YamlMap) {
-          merged[key] = value;
+        final YamlMap? action = ActionScopeUtil.normalizeActionDefinition(value);
+        if (action != null) {
+          merged[key.toString()] = action;
         }
       });
     }

--- a/starter/README.md
+++ b/starter/README.md
@@ -71,13 +71,14 @@ ensemble/apps/yourAppName/
 ├── fonts/
 ├── scripts/
 ├── widgets/
+├── actions/         # Reusable app-level Actions (see modules/ensemble/docs/reusable-actions.md)
 ├── screens/
 ├── translations/
 ├── config/
 │   ├── appConfig.json
 │   ├── secrets.json
 ├── theme.yaml
-├── .manifest.json   # Required for widgets and scripts to work correctly
+├── .manifest.json   # Required for widgets, scripts, and actions to work correctly
 ```
 #### 2. Update `ensemble-config.yaml`  
 - Open `ensemble/ensemble-config.yaml` and set `from: local` under `definitions`.  
@@ -95,6 +96,7 @@ flutter:
     - ensemble/apps/helloApp/
     - ensemble/apps/helloApp/screens/
     - ensemble/apps/helloApp/widgets/
+    - ensemble/apps/helloApp/actions/
     - ensemble/apps/helloApp/scripts/
     - ensemble/apps/helloApp/assets/
     - ensemble/apps/helloApp/translations/

--- a/starter/ensemble/apps/helloApp/.manifest.json
+++ b/starter/ensemble/apps/helloApp/.manifest.json
@@ -18,6 +18,9 @@
     "actions": [
         {
             "name": "showMessage"
+        },
+        {
+            "name": "fetchUser"
         }
     ]
 }

--- a/starter/ensemble/apps/helloApp/actions/fetchUser.yaml
+++ b/starter/ensemble/apps/helloApp/actions/fetchUser.yaml
@@ -1,0 +1,40 @@
+Import:
+  - common
+
+Action:
+  inputs:
+    - userId
+  events:
+    onSuccess:
+      data:
+        user: object
+    onError:
+      data:
+        message: string
+  body:
+    invokeAPI:
+      name: getUser
+      inputs:
+        userId: ${userId}
+      onResponse:
+        dispatchEvent:
+          onSuccess:
+            data:
+              user: ${getUser.body}
+      onError:
+        dispatchEvent:
+          onError:
+            data:
+              message: Failed to fetch user
+
+API:
+  getUser:
+    url: https://dummyjson.com/users/${userId}
+    method: GET
+    onResponse: |-
+      saveName(response.body.firstName, response.body.lastName);
+
+Global: |-
+  function formatUserName(user) {
+    return user.firstName + ' ' + user.lastName;
+  }

--- a/starter/ensemble/apps/helloApp/screens/Hello Home.yaml
+++ b/starter/ensemble/apps/helloApp/screens/Hello Home.yaml
@@ -56,6 +56,22 @@ View:
                   message: Hello ${ensemble.storage.helloApp.name.first}
 
         - Button:
+            testId: fetch_user_action_button
+            label: Fetch user (app Action with API)
+            onTap:
+              executeAction:
+                name: fetchUser
+                inputs:
+                  userId: ${Math.floor(Math.random() * 100)}
+                events:
+                  onSuccess:
+                    showToast:
+                      message: Loaded ${event.data.user.firstName} ${event.data.user.lastName}
+                  onError:
+                    showToast:
+                      message: ${event.data.message}
+
+        - Button:
             label: Call API (page reusable action)
             onTap:
               executeAction:


### PR DESCRIPTION
## Description

Enhances Ensemble reusable Actions so app-level and page-level actions can carry their own scoped resources (Import, Global, API) and communicate back to callers via events — matching the pattern already used by custom widgets.

Previously, global action files only loaded the inner Action: block; sibling API/Global/Import blocks were ignored, and callers had no way to react to action outcomes without side effects like ensemble.storage.

This PR adds ActionScopeUtil for scope preparation, wires event handlers through executeAction, updates all definition providers to normalize action definitions, and adds documentation plus a starter example (fetchUser).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added ActionScopeUtil to merge file-level Import, Global, and API into action definitions and prepare a child scope per executeAction run
- Extended ExecuteActionAction to accept events handlers on the call site and register them for dispatchEvent inside the action body
- Updated definition providers (local, cdn, ensemble) and page_model to normalize action definitions consistently
- Added Actions to the ResourceArtifactEntry enum and replaced hardcoded 'Actions' string keys
- Added modules/ensemble/docs/reusable-actions.md with full usage guide (scoped resources, events, local/Studio/CDN setup)
- Added starter example actions/fetchUser.yaml (scoped API + events) and wired it on Hello Home.yaml
- Updated modules/ensemble/README.md and starter/README.md with actions folder and doc links

## How to Test

1. From the repo root, run melos bootstrap, then cd starter && flutter run (or web-server) with from: local in ensemble-config.yaml
2. On Hello Home, tap "Show message via reusable Action" — confirm the toast still works (showMessage action)
3. Tap "Fetch user (app Action with API)" — confirm a success toast with the fetched user name, or an error toast on failure (fetchUser uses scoped API + onSuccess/onError events)
4. Run cd modules/ensemble && flutter analyze lib/action/ lib/page_model.dart lib/framework/definition_providers/ — confirm no new errors in changed files

## Screenshots / Videos

N/A

## Checklist

- [x] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [x] I have tested my changes on the relevant platform(s)
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors