### PR TITLE
feat(wifi): add optional ensemble_wifi module with connectToWifi action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ starter/package-lock.json
 starter/android/app/src/main/java/io/
 starter/ios/Runner/GeneratedPluginRegistrant.h
 starter/ios/Runner/GeneratedPluginRegistrant.m
+
+# remove molos .iml files
+**/melos_*.iml

--- a/modules/ensemble/lib/action/action_invokable.dart
+++ b/modules/ensemble/lib/action/action_invokable.dart
@@ -51,6 +51,7 @@ abstract class ActionInvokable with Invokable {
       ActionType.updateBadgeCount,
       ActionType.clearBadgeCount,
       ActionType.getNetworkInfo,
+      ActionType.connectToWifi,
       ActionType.checkPermission,
       ActionType.sendVerificationCode,
       ActionType.validateVerificationCode,

--- a/modules/ensemble/lib/action/wifi_action.dart
+++ b/modules/ensemble/lib/action/wifi_action.dart
@@ -1,0 +1,215 @@
+import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/scope.dart';
+import 'package:ensemble/framework/stub/wifi_manager.dart';
+import 'package:ensemble/screen_controller.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:ensemble_ts_interpreter/invokables/invokable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+
+enum WifiOperation { connect, disconnect, activate, deactivate }
+
+Future<dynamic> _handleWifiResult(
+  BuildContext context,
+  Invokable? initiator,
+  EnsembleAction? onSuccess,
+  EnsembleAction? onError,
+  bool? result,
+) {
+  if (result == true && onSuccess != null) {
+    return ScreenController().executeAction(context, onSuccess,
+        event: EnsembleEvent(initiator, data: {'connected': true}));
+  }
+  if (onError != null) {
+    final message = result == null
+        ? 'WiFi connection returned no result'
+        : 'WiFi connection was denied or could not be verified. '
+            'Check SSID/password, approve the system join prompt, and ensure '
+            'location permission is granted.';
+    return ScreenController().executeAction(context, onError,
+        event: EnsembleEvent(initiator,
+            error: message,
+            data: {'connected': result, 'status': 'error'}));
+  }
+  return Future.value(null);
+}
+
+Future<dynamic> _handleWifiError(
+  BuildContext context,
+  Invokable? initiator,
+  EnsembleAction? onError,
+  Object error,
+) {
+  if (onError != null) {
+    return ScreenController().executeAction(context, onError,
+        event: EnsembleEvent(initiator,
+            error: error.toString(), data: {'status': 'error'}));
+  }
+  return Future.value(null);
+}
+
+Future<dynamic> _handleWifiVoidResult(
+  BuildContext context,
+  Invokable? initiator,
+  EnsembleAction? onSuccess,
+) {
+  if (onSuccess != null) {
+    return ScreenController().executeAction(context, onSuccess,
+        event: EnsembleEvent(initiator, data: {'status': 'success'}));
+  }
+  return Future.value(null);
+}
+
+class ConnectToWifiAction extends EnsembleAction {
+  final WifiManager wifiManager = GetIt.I<WifiManager>();
+  final WifiOperation operation;
+  final String? ssid;
+  final String? ssidPrefix;
+  final String? password;
+  final bool isWep;
+  final bool isWpa3;
+  final bool saveNetwork;
+  final bool isHidden;
+  final EnsembleAction? onSuccess;
+  final EnsembleAction? onError;
+
+  ConnectToWifiAction({
+    super.initiator,
+    super.inputs,
+    required this.operation,
+    required this.ssid,
+    required this.ssidPrefix,
+    required this.password,
+    required this.isWep,
+    required this.isWpa3,
+    required this.saveNetwork,
+    required this.isHidden,
+    this.onSuccess,
+    this.onError,
+  });
+
+  factory ConnectToWifiAction.from({Invokable? initiator, dynamic payload}) =>
+      ConnectToWifiAction.fromYaml(
+          initiator: initiator, payload: Utils.getYamlMap(payload));
+
+  factory ConnectToWifiAction.fromYaml({Invokable? initiator, Map? payload}) {
+    final operationName =
+        Utils.optionalString(payload?['operation']) ?? 'connect';
+    final operation = WifiOperation.values.firstWhere(
+      (value) => value.name == operationName,
+      orElse: () => WifiOperation.connect,
+    );
+
+    return ConnectToWifiAction(
+      initiator: initiator,
+      inputs: Utils.getMap(payload?['inputs']),
+      operation: operation,
+      ssid: Utils.optionalString(payload?['ssid']),
+      ssidPrefix: Utils.optionalString(payload?['ssidPrefix']),
+      password: Utils.optionalString(payload?['password']),
+      isWep: Utils.getBool(payload?['isWep'], fallback: false),
+      isWpa3: Utils.getBool(payload?['isWpa3'], fallback: false),
+      saveNetwork: Utils.getBool(payload?['saveNetwork'], fallback: false),
+      isHidden: Utils.getBool(payload?['isHidden'], fallback: false),
+      onSuccess:
+          EnsembleAction.from(payload?['onSuccess'], initiator: initiator),
+      onError: EnsembleAction.from(payload?['onError'], initiator: initiator),
+    );
+  }
+
+  @override
+  Future<dynamic> execute(
+      BuildContext context, ScopeManager scopeManager) async {
+    if (kIsWeb) {
+      return _handleWifiError(context, initiator, onError,
+          'WiFi is not supported on the web');
+    }
+
+    try {
+      switch (operation) {
+        case WifiOperation.disconnect:
+          final result = await wifiManager.disconnect();
+          return _handleWifiResult(
+              context, initiator, onSuccess, onError, result);
+        case WifiOperation.activate:
+          await wifiManager.activateWifi();
+          return _handleWifiVoidResult(context, initiator, onSuccess);
+        case WifiOperation.deactivate:
+          await wifiManager.deactivateWifi();
+          return _handleWifiVoidResult(context, initiator, onSuccess);
+        case WifiOperation.connect:
+          return _connect(context, scopeManager);
+      }
+    } on PlatformException catch (e) {
+      final message = e.message?.isNotEmpty == true ? e.message! : e.code;
+      return _handleWifiError(
+        context,
+        initiator,
+        onError,
+        message,
+      );
+    } catch (e) {
+      final message = e is StateError ? e.message : e.toString();
+      return _handleWifiError(context, initiator, onError, message);
+    }
+  }
+
+  Future<dynamic> _connect(
+      BuildContext context, ScopeManager scopeManager) async {
+    final evaluatedSsid = ssid != null ? scopeManager.dataContext.eval(ssid) : null;
+    final evaluatedPrefix = ssidPrefix != null
+        ? scopeManager.dataContext.eval(ssidPrefix)
+        : null;
+    final evaluatedPassword =
+        password != null ? scopeManager.dataContext.eval(password) : null;
+
+    final hasPassword =
+        evaluatedPassword != null && evaluatedPassword.toString().isNotEmpty;
+    final hasSsid =
+        evaluatedSsid != null && evaluatedSsid.toString().isNotEmpty;
+    final hasPrefix =
+        evaluatedPrefix != null && evaluatedPrefix.toString().isNotEmpty;
+
+    if (!hasSsid && !hasPrefix) {
+      return _handleWifiError(context, initiator, onError,
+          'ssid or ssidPrefix is required for connect operation');
+    }
+
+    bool? result;
+    if (hasPrefix) {
+      if (hasPassword) {
+        result = await wifiManager.connectToSecureNetworkByPrefix(
+          evaluatedPrefix.toString(),
+          evaluatedPassword.toString(),
+          isWep: isWep,
+          isWpa3: isWpa3,
+          saveNetwork: saveNetwork,
+        );
+      } else {
+        result = await wifiManager.connectByPrefix(
+          evaluatedPrefix.toString(),
+          saveNetwork: saveNetwork,
+        );
+      }
+    } else if (hasPassword) {
+      result = await wifiManager.connectToSecureNetwork(
+        evaluatedSsid.toString(),
+        evaluatedPassword.toString(),
+        isWep: isWep,
+        isWpa3: isWpa3,
+        saveNetwork: saveNetwork,
+        isHidden: isHidden,
+      );
+    } else {
+      result = await wifiManager.connect(
+        evaluatedSsid.toString(),
+        saveNetwork: saveNetwork,
+      );
+    }
+
+    return _handleWifiResult(context, initiator, onSuccess, onError, result);
+  }
+}

--- a/modules/ensemble/lib/action/wifi_action.dart
+++ b/modules/ensemble/lib/action/wifi_action.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 
-enum WifiOperation { connect, disconnect, activate, deactivate }
+enum WifiOperation { connect, disconnect }
 
 Future<dynamic> _handleWifiResult(
   BuildContext context,
@@ -27,8 +27,8 @@ Future<dynamic> _handleWifiResult(
     final message = result == null
         ? 'WiFi connection returned no result'
         : 'WiFi connection was denied or could not be verified. '
-            'Check SSID/password, approve the system join prompt, and ensure '
-            'location permission is granted.';
+            'Check SSID/password, tap Connect on the system WiFi dialog (Android), '
+            'approve the system join prompt (iOS), and ensure location permission is granted.';
     return ScreenController().executeAction(context, onError,
         event: EnsembleEvent(initiator,
             error: message,
@@ -47,18 +47,6 @@ Future<dynamic> _handleWifiError(
     return ScreenController().executeAction(context, onError,
         event: EnsembleEvent(initiator,
             error: error.toString(), data: {'status': 'error'}));
-  }
-  return Future.value(null);
-}
-
-Future<dynamic> _handleWifiVoidResult(
-  BuildContext context,
-  Invokable? initiator,
-  EnsembleAction? onSuccess,
-) {
-  if (onSuccess != null) {
-    return ScreenController().executeAction(context, onSuccess,
-        event: EnsembleEvent(initiator, data: {'status': 'success'}));
   }
   return Future.value(null);
 }
@@ -134,12 +122,6 @@ class ConnectToWifiAction extends EnsembleAction {
           final result = await wifiManager.disconnect();
           return _handleWifiResult(
               context, initiator, onSuccess, onError, result);
-        case WifiOperation.activate:
-          await wifiManager.activateWifi();
-          return _handleWifiVoidResult(context, initiator, onSuccess);
-        case WifiOperation.deactivate:
-          await wifiManager.deactivateWifi();
-          return _handleWifiVoidResult(context, initiator, onSuccess);
         case WifiOperation.connect:
           return _connect(context, scopeManager);
       }

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -36,6 +36,7 @@ import 'package:ensemble/action/disable_hardware_navigation.dart';
 import 'package:ensemble/action/close_app.dart';
 import 'package:ensemble/action/getLocation.dart';
 import 'package:ensemble/action/wakelock_action.dart';
+import 'package:ensemble/action/wifi_action.dart';
 import 'package:ensemble/framework/apiproviders/api_provider.dart';
 import 'package:ensemble/framework/apiproviders/http_api_provider.dart';
 import 'package:ensemble/framework/apiproviders/sse_api_provider.dart';
@@ -1038,6 +1039,7 @@ enum ActionType {
   seekAudio,
   logEvent,
   getNetworkInfo,
+  connectToWifi,
   connectivityListener,
   deviceSecurity,
   bluetoothInit,
@@ -1280,6 +1282,8 @@ abstract class EnsembleAction {
       return ClearLocaleAction();
     } else if (actionType == ActionType.getNetworkInfo) {
       return GetNetworkInfoAction.from(initiator: initiator, payload: payload);
+    } else if (actionType == ActionType.connectToWifi) {
+      return ConnectToWifiAction.from(initiator: initiator, payload: payload);
     } else if (actionType == ActionType.connectivityListener) {
       return ConnectivityListenerAction.fromYaml(
           initiator: initiator, payload: payload);

--- a/modules/ensemble/lib/framework/stub/wifi_manager.dart
+++ b/modules/ensemble/lib/framework/stub/wifi_manager.dart
@@ -24,10 +24,6 @@ abstract class WifiManager {
   });
 
   Future<bool?> disconnect();
-
-  Future<void> activateWifi();
-
-  Future<void> deactivateWifi();
 }
 
 class WifiManagerStub implements WifiManager {
@@ -77,16 +73,6 @@ class WifiManagerStub implements WifiManager {
 
   @override
   Future<bool?> disconnect() {
-    _throwNotEnabled();
-  }
-
-  @override
-  Future<void> activateWifi() {
-    _throwNotEnabled();
-  }
-
-  @override
-  Future<void> deactivateWifi() {
     _throwNotEnabled();
   }
 }

--- a/modules/ensemble/lib/framework/stub/wifi_manager.dart
+++ b/modules/ensemble/lib/framework/stub/wifi_manager.dart
@@ -1,0 +1,92 @@
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:flutter/foundation.dart';
+
+abstract class WifiManager {
+  Future<bool?> connect(String ssid, {bool saveNetwork = false});
+
+  Future<bool?> connectByPrefix(String ssidPrefix, {bool saveNetwork = false});
+
+  Future<bool?> connectToSecureNetwork(
+    String ssid,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+    bool isHidden = false,
+  });
+
+  Future<bool?> connectToSecureNetworkByPrefix(
+    String ssidPrefix,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+  });
+
+  Future<bool?> disconnect();
+
+  Future<void> activateWifi();
+
+  Future<void> deactivateWifi();
+}
+
+class WifiManagerStub implements WifiManager {
+  WifiManagerStub();
+
+  Never _throwNotEnabled() {
+    if (kIsWeb) {
+      throw ConfigError(
+          "WiFi module is not supported on the web. Please review the Ensemble documentation.");
+    }
+    throw ConfigError(
+        "WiFi module is not enabled. Please review the Ensemble documentation.");
+  }
+
+  @override
+  Future<bool?> connect(String ssid, {bool saveNetwork = false}) {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<bool?> connectByPrefix(String ssidPrefix, {bool saveNetwork = false}) {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<bool?> connectToSecureNetwork(
+    String ssid,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+    bool isHidden = false,
+  }) {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<bool?> connectToSecureNetworkByPrefix(
+    String ssidPrefix,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+  }) {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<bool?> disconnect() {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<void> activateWifi() {
+    _throwNotEnabled();
+  }
+
+  @override
+  Future<void> deactivateWifi() {
+    _throwNotEnabled();
+  }
+}

--- a/modules/ensemble_wifi/README.md
+++ b/modules/ensemble_wifi/README.md
@@ -66,7 +66,7 @@ flowchart TB
 
 | Platform | Supported | Notes                                                                      |
 | -------- | --------- | -------------------------------------------------------------------------- |
-| Android  | Yes       | Android 10+ (API 29) recommended. Manifest + runtime location permission required. Legacy WiFi permissions included for API 28 and below. |
+| Android  | Yes       | Android 10+ (API 29) recommended. Requires `CHANGE_NETWORK_STATE` + runtime location permission. Legacy WiFi permissions for API 28 and below. |
 | iOS      | Yes       | iOS 11+. **Requires a physical device** — simulators cannot join WiFi.     |
 | Web      | No        | Action routes to `onError` with a web-not-supported message.               |
 
@@ -121,12 +121,14 @@ The enable script adds these manifest permissions:
 
 | Permission | Scope | Purpose |
 | ---------- | ----- | ------- |
-| `ACCESS_FINE_LOCATION` | All API levels | Required on Android 10+ (API 29+) for WiFi connect APIs |
+| `ACCESS_FINE_LOCATION` | All API levels | Runtime location grant for WiFi connect |
+| `CHANGE_NETWORK_STATE` | All API levels | Required for `ConnectivityManager.requestNetwork()` on Android 10+ |
 | `ACCESS_WIFI_STATE` | API 28 and below (`maxSdkVersion="28"`) | Read WiFi state on older Android |
-| `CHANGE_WIFI_STATE` | API 28 and below | Connect/disconnect on older Android |
-| `CHANGE_NETWORK_STATE` | API 28 and below | Network changes on older Android |
+| `CHANGE_WIFI_STATE` | API 28 and below | Legacy connect/disconnect on older Android |
 
-**Runtime:** `WifiManagerImpl` requests location permission via `Geolocator` before every connect attempt. Location services must also be enabled on the device.
+**Runtime:** `WifiManagerImpl` requests location permission via `Geolocator` before connect. Location services must also be enabled on the device.
+
+`CHANGE_NETWORK_STATE` is a normal (install-time) permission — no runtime prompt, but it **must** be in the manifest without `maxSdkVersion="28"` or Android 10+ throws `SecurityException` on connect.
 
 ```mermaid
 flowchart LR
@@ -134,10 +136,12 @@ flowchart LR
   Runtime["Geolocator<br/>(WifiManagerImpl)"]
   Connect["connectToWifi"]
 
+  Manifest -->|all API levels| NetChange["CHANGE_NETWORK_STATE"]
   Manifest -->|API 29+| LocPerm["ACCESS_FINE_LOCATION"]
-  Manifest -->|API 28−| Legacy["WiFi state + change permissions"]
+  Manifest -->|API 28−| Legacy["ACCESS/CHANGE_WIFI_STATE"]
   Connect --> Runtime
   Runtime -->|grant + services on| Connect
+  NetChange --> Connect
   LocPerm --> Connect
   Legacy --> Connect
 ```
@@ -159,8 +163,6 @@ One action handles all WiFi operations. Set `operation` to choose the mode (defa
 | ------------ | ------------------------------------------------ | ------------ |
 | `connect`    | Join a WiFi network (default)                    | Android, iOS |
 | `disconnect` | Disconnect from a network joined via this plugin | Android, iOS |
-| `activate`   | Turn WiFi radio on                               | Android only |
-| `deactivate` | Turn WiFi radio off                              | Android only |
 
 
 ### Connect routing
@@ -180,8 +182,6 @@ flowchart TD
 
   Start --> Op
   Op -->|disconnect| Disc["disconnect()"]
-  Op -->|activate| Act["activateWifi()"]
-  Op -->|deactivate| Deact["deactivateWifi()"]
   Op -->|connect / default| Prefix
 
   Prefix -->|yes| Pwd
@@ -247,7 +247,7 @@ sequenceDiagram
 
 | Parameter     | Required                                     | Default   | Description                                                   |
 | ------------- | -------------------------------------------- | --------- | ------------------------------------------------------------- |
-| `operation`   | No                                           | `connect` | `connect`, `disconnect`, `activate`, or `deactivate`          |
+| `operation`   | No                                           | `connect` | `connect` or `disconnect` |
 | `ssid`        | One of `ssid` or `ssidPrefix` (connect only) | —         | Exact network name                                            |
 | `ssidPrefix`  | One of `ssid` or `ssidPrefix` (connect only) | —         | Match nearest network by SSID prefix (common for IoT devices) |
 | `password`    | No                                           | —         | If set, uses secured connect                                  |
@@ -268,13 +268,6 @@ All string parameters support Ensemble expressions (e.g. `${devicePassword}`).
 ```yaml
 data:
   connected: true   # connect/disconnect returned true
-```
-
-**`onSuccess` (activate / deactivate)**
-
-```yaml
-data:
-  status: success
 ```
 
 **`onError`**
@@ -384,7 +377,8 @@ onTap:
 | Web not supported                                  | Expected — use Android or iOS device                                                                       |
 | iOS `hotspotError_8` / internal error on Simulator | Expected — test on a physical iPhone                                                                       |
 | Connect fails after location granted               | Wrong SSID/password, join prompt cancelled, or Hotspot Configuration not enabled in Apple Developer portal |
-| Prefix connect fails on older Android              | Re-run `enable_wifi.dart` to add legacy permissions, or confirm `minSdkVersion` targets API 29+             |
+| `MissingPluginException` for activate/deactivate   | Not supported — use `connect` / `disconnect` only (see Operations above)                                     |
+| `SecurityException`: `CHANGE_NETWORK_STATE` not granted | Remove `maxSdkVersion="28"` from `CHANGE_NETWORK_STATE` in manifest; rebuild and reinstall |
 
 
 ## Development

--- a/modules/ensemble_wifi/README.md
+++ b/modules/ensemble_wifi/README.md
@@ -66,7 +66,7 @@ flowchart TB
 
 | Platform | Supported | Notes                                                                      |
 | -------- | --------- | -------------------------------------------------------------------------- |
-| Android  | Yes       | Android 10+ (API 29) recommended. Requires location permission at runtime. |
+| Android  | Yes       | Android 10+ (API 29) recommended. Manifest + runtime location permission required. Legacy WiFi permissions included for API 28 and below. |
 | iOS      | Yes       | iOS 11+. **Requires a physical device** — simulators cannot join WiFi.     |
 | Web      | No        | Action routes to `onError` with a web-not-supported message.               |
 
@@ -89,7 +89,7 @@ The enable script:
 
 1. Uncomments the `ensemble_wifi` dependency in `starter/pubspec.yaml`
 2. Sets `useWifi = true` and registers `WifiManagerImpl` in `starter/lib/generated/ensemble_modules.dart`
-3. Adds Android `ACCESS_FINE_LOCATION` to `AndroidManifest.xml`
+3. Adds Android WiFi permissions to `AndroidManifest.xml` (see [Android permissions](#android-permissions))
 4. Adds `NSLocationWhenInUseUsageDescription` to `Info.plist`
 5. Adds WiFi entitlements to `Runner.entitlements` and links them in the Xcode project
 
@@ -115,12 +115,38 @@ flutter run
 3. **Apple Developer portal** — enable **Hotspot Configuration** and **Access WiFi Information** for your App ID. Entitlements are written to `Runner.entitlements`, but Apple must approve Hotspot Configuration for distribution.
 4. **System join prompt** — when iOS shows “Join Network”, tap **Join**. Cancelling returns a failed result.
 
+### Android permissions
+
+The enable script adds these manifest permissions:
+
+| Permission | Scope | Purpose |
+| ---------- | ----- | ------- |
+| `ACCESS_FINE_LOCATION` | All API levels | Required on Android 10+ (API 29+) for WiFi connect APIs |
+| `ACCESS_WIFI_STATE` | API 28 and below (`maxSdkVersion="28"`) | Read WiFi state on older Android |
+| `CHANGE_WIFI_STATE` | API 28 and below | Connect/disconnect on older Android |
+| `CHANGE_NETWORK_STATE` | API 28 and below | Network changes on older Android |
+
+**Runtime:** `WifiManagerImpl` requests location permission via `Geolocator` before every connect attempt. Location services must also be enabled on the device.
+
+```mermaid
+flowchart LR
+  Manifest["AndroidManifest.xml<br/>(enable script)"]
+  Runtime["Geolocator<br/>(WifiManagerImpl)"]
+  Connect["connectToWifi"]
+
+  Manifest -->|API 29+| LocPerm["ACCESS_FINE_LOCATION"]
+  Manifest -->|API 28−| Legacy["WiFi state + change permissions"]
+  Connect --> Runtime
+  Runtime -->|grant + services on| Connect
+  LocPerm --> Connect
+  Legacy --> Connect
+```
+
 ### Android setup checklist
 
-1. **Location permission** — grant when prompted (required on Android 10+ for WiFi connect APIs).
-2. **Location services** — must be enabled on the device.
-
-For Android 9 and below, `plugin_wifi_connect` may also require `ACCESS_WIFI_STATE`, `CHANGE_WIFI_STATE`, and `CHANGE_NETWORK_STATE` if you target older API levels.
+1. **Manifest permissions** — added automatically by `enable_wifi.dart` (see table above).
+2. **Location permission** — grant when prompted at runtime (required on Android 10+).
+3. **Location services** — must be enabled on the device.
 
 ## Ensemble action: `connectToWifi`
 
@@ -358,7 +384,7 @@ onTap:
 | Web not supported                                  | Expected — use Android or iOS device                                                                       |
 | iOS `hotspotError_8` / internal error on Simulator | Expected — test on a physical iPhone                                                                       |
 | Connect fails after location granted               | Wrong SSID/password, join prompt cancelled, or Hotspot Configuration not enabled in Apple Developer portal |
-| Prefix connect fails on older Android              | May need legacy WiFi permissions in `AndroidManifest.xml` (API 28 and below)                               |
+| Prefix connect fails on older Android              | Re-run `enable_wifi.dart` to add legacy permissions, or confirm `minSdkVersion` targets API 29+             |
 
 
 ## Development

--- a/modules/ensemble_wifi/README.md
+++ b/modules/ensemble_wifi/README.md
@@ -1,0 +1,380 @@
+# ensemble_wifi
+
+Ensemble module for programmatic WiFi connections on mobile devices. It wraps [`plugin_wifi_connect`](https://pub.dev/packages/plugin_wifi_connect) and exposes a single ensemble action, `connectToWifi`.
+
+Use this module when your app needs to join a WiFi network from code — for example IoT device setup where the device broadcasts a known SSID or SSID prefix.
+
+> **Not the same as `ensemble_network_info`** — that module *reads* WiFi metadata (SSID, IP, BSSID). This module *connects* to a network.
+
+## Overview
+
+```mermaid
+flowchart LR
+  subgraph app["Ensemble app"]
+    YAML["YAML / JS<br/>connectToWifi"]
+    Action["ConnectToWifiAction"]
+  end
+
+  subgraph core["ensemble (core)"]
+    GetIt["GetIt&lt;WifiManager&gt;"]
+    Stub["WifiManagerStub"]
+  end
+
+  subgraph module["ensemble_wifi"]
+    Impl["WifiManagerImpl"]
+  end
+
+  subgraph native["Native"]
+    Plugin["plugin_wifi_connect"]
+    OS["Android / iOS WiFi APIs"]
+  end
+
+  YAML --> Action
+  Action --> GetIt
+  GetIt -->|module enabled| Impl
+  GetIt -->|module disabled| Stub
+  Impl --> Plugin
+  Plugin --> OS
+  Stub -.->|throws config error| Action
+```
+
+When the module is disabled, the core runtime uses `WifiManagerStub`, which throws a configuration error if `connectToWifi` is invoked.
+
+### ensemble_wifi vs ensemble_network_info
+
+```mermaid
+flowchart TB
+  subgraph read["ensemble_network_info"]
+    R1["getNetworkInfo()"]
+    R2["Current SSID, IP, BSSID"]
+  end
+
+  subgraph connect["ensemble_wifi"]
+    C1["connectToWifi"]
+    C2["Join a network programmatically"]
+  end
+
+  Device["Device WiFi stack"]
+  R1 --> R2
+  R2 -.->|read only| Device
+  C1 --> C2
+  C2 -->|write / join| Device
+```
+
+## Platform support
+
+
+| Platform | Supported | Notes                                                                      |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| Android  | Yes       | Android 10+ (API 29) recommended. Requires location permission at runtime. |
+| iOS      | Yes       | iOS 11+. **Requires a physical device** — simulators cannot join WiFi.     |
+| Web      | No        | Action routes to `onError` with a web-not-supported message.               |
+
+
+## Enable the module
+
+From the `starter` directory:
+
+```bash
+dart scripts/modules/enable_wifi.dart --platforms=android,ios
+```
+
+Or via the Ensemble CLI:
+
+```bash
+enable wifi
+```
+
+The enable script:
+
+1. Uncomments the `ensemble_wifi` dependency in `starter/pubspec.yaml`
+2. Sets `useWifi = true` and registers `WifiManagerImpl` in `starter/lib/generated/ensemble_modules.dart`
+3. Adds Android `ACCESS_FINE_LOCATION` to `AndroidManifest.xml`
+4. Adds `NSLocationWhenInUseUsageDescription` to `Info.plist`
+5. Adds WiFi entitlements to `Runner.entitlements` and links them in the Xcode project
+
+Then from the repo root:
+
+```bash
+melos bootstrap
+```
+
+Rebuild the app (full rebuild after native changes):
+
+```bash
+cd starter
+flutter clean
+cd ios && pod install && cd ..
+flutter run
+```
+
+### iOS setup checklist
+
+1. **Physical device** — WiFi connect does not work on the iOS Simulator.
+2. **Location permission** — grant when prompted (`NSLocationWhenInUseUsageDescription`).
+3. **Apple Developer portal** — enable **Hotspot Configuration** and **Access WiFi Information** for your App ID. Entitlements are written to `Runner.entitlements`, but Apple must approve Hotspot Configuration for distribution.
+4. **System join prompt** — when iOS shows “Join Network”, tap **Join**. Cancelling returns a failed result.
+
+### Android setup checklist
+
+1. **Location permission** — grant when prompted (required on Android 10+ for WiFi connect APIs).
+2. **Location services** — must be enabled on the device.
+
+For Android 9 and below, `plugin_wifi_connect` may also require `ACCESS_WIFI_STATE`, `CHANGE_WIFI_STATE`, and `CHANGE_NETWORK_STATE` if you target older API levels.
+
+## Ensemble action: `connectToWifi`
+
+One action handles all WiFi operations. Set `operation` to choose the mode (default: `connect`).
+
+### Operations
+
+
+| Operation    | Description                                      | Platforms    |
+| ------------ | ------------------------------------------------ | ------------ |
+| `connect`    | Join a WiFi network (default)                    | Android, iOS |
+| `disconnect` | Disconnect from a network joined via this plugin | Android, iOS |
+| `activate`   | Turn WiFi radio on                               | Android only |
+| `deactivate` | Turn WiFi radio off                              | Android only |
+
+
+### Connect routing
+
+For `operation: connect` (or when `operation` is omitted), the action picks the underlying API based on the parameters you provide:
+
+```mermaid
+flowchart TD
+  Start(["operation: connect"])
+  Op{"operation?"}
+  Prefix{"ssidPrefix<br/>set?"}
+  Pwd{"password<br/>set?"}
+  SecPrefix["connectToSecureNetworkByPrefix"]
+  OpenPrefix["connectByPrefix"]
+  SecSsid["connectToSecureNetwork"]
+  OpenSsid["connect"]
+
+  Start --> Op
+  Op -->|disconnect| Disc["disconnect()"]
+  Op -->|activate| Act["activateWifi()"]
+  Op -->|deactivate| Deact["deactivateWifi()"]
+  Op -->|connect / default| Prefix
+
+  Prefix -->|yes| Pwd
+  Prefix -->|no| HasSsid{"ssid<br/>set?"}
+  Pwd -->|yes| SecPrefix
+  Pwd -->|no| OpenPrefix
+
+  HasSsid -->|yes| Pwd2{"password<br/>set?"}
+  HasSsid -->|no| Err["onError:<br/>ssid or ssidPrefix required"]
+  Pwd2 -->|yes| SecSsid
+  Pwd2 -->|no| OpenSsid
+```
+
+| Parameters provided       | Behavior                                           |
+| ------------------------- | -------------------------------------------------- |
+| `ssidPrefix` + `password` | Secured connect to nearest network matching prefix |
+| `ssidPrefix` only         | Open connect to nearest network matching prefix    |
+| `ssid` + `password`       | Secured connect to exact SSID                      |
+| `ssid` only               | Open connect to exact SSID                         |
+
+### Runtime flow (connect)
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Action as ConnectToWifiAction
+  participant Impl as WifiManagerImpl
+  participant Geo as Geolocator
+  participant Plugin as plugin_wifi_connect
+  participant OS as OS WiFi
+
+  User->>Action: connectToWifi (ssid, password, …)
+  Action->>Action: eval ssid / password expressions
+
+  alt Web platform
+    Action-->>User: onError (not supported)
+  else Mobile
+    Action->>Impl: connectToSecureNetwork(…)
+    Impl->>Geo: check / request location permission
+    alt Permission denied
+      Geo-->>Impl: denied
+      Impl-->>Action: StateError
+      Action-->>User: onError
+    else Permission granted
+      Geo-->>Impl: granted
+      Impl->>Plugin: connectToSecureNetwork(…)
+      Plugin->>OS: join network
+      OS-->>Plugin: result
+      Plugin-->>Impl: true / false / null
+      Impl-->>Action: result
+      alt result == true
+        Action-->>User: onSuccess (connected: true)
+      else result == false or null
+        Action-->>User: onError (denied or unverified)
+      end
+    end
+  end
+```
+
+
+### Parameters
+
+
+| Parameter     | Required                                     | Default   | Description                                                   |
+| ------------- | -------------------------------------------- | --------- | ------------------------------------------------------------- |
+| `operation`   | No                                           | `connect` | `connect`, `disconnect`, `activate`, or `deactivate`          |
+| `ssid`        | One of `ssid` or `ssidPrefix` (connect only) | —         | Exact network name                                            |
+| `ssidPrefix`  | One of `ssid` or `ssidPrefix` (connect only) | —         | Match nearest network by SSID prefix (common for IoT devices) |
+| `password`    | No                                           | —         | If set, uses secured connect                                  |
+| `saveNetwork` | No                                           | `false`   | Remember the network on the device after connecting           |
+| `isWep`       | No                                           | `false`   | WEP encryption (not supported on Android)                     |
+| `isWpa3`      | No                                           | `false`   | WPA3 network                                                  |
+| `isHidden`    | No                                           | `false`   | Hidden SSID (exact `ssid` connect only)                       |
+| `onSuccess`   | No                                           | —         | Action run when the operation succeeds                        |
+| `onError`     | No                                           | —         | Action run when the operation fails                           |
+
+
+All string parameters support Ensemble expressions (e.g. `${devicePassword}`).
+
+### Event data
+
+**`onSuccess` (connect / disconnect)**
+
+```yaml
+data:
+  connected: true   # connect/disconnect returned true
+```
+
+**`onSuccess` (activate / deactivate)**
+
+```yaml
+data:
+  status: success
+```
+
+**`onError`**
+
+```yaml
+error: "<message>"
+data:
+  status: error
+  connected: false   # or null, when connect verification failed
+```
+
+Use `${event.error}` and `${event.data.connected}` in nested actions (e.g. `showToast`).
+
+### JavaScript
+
+`connectToWifi` is exposed to page scripts via `ActionInvokable`:
+
+```javascript
+ensemble.connectToWifi({
+  ssid: 'MyNetwork',
+  password: myPassword,
+  onSuccess: { showToast: { message: 'Connected' } },
+  onError: { showToast: { message: event.error } }
+});
+```
+
+## Examples
+
+### Typical IoT provisioning flow
+
+```mermaid
+sequenceDiagram
+  participant App as Ensemble app
+  participant Phone as Phone WiFi
+  participant IoT as IoT device hotspot
+  participant Home as Home router
+
+  Note over App,Home: Phase 1 — join device hotspot
+  App->>Phone: connectToWifi (ssidPrefix: Device-)
+  Phone->>IoT: connect to Device-ABC123
+  IoT-->>App: device reachable on local network
+
+  Note over App,Home: Phase 2 — configure device, then rejoin home WiFi
+  App->>IoT: send home SSID + password
+  App->>Phone: connectToWifi (ssid: HomeNet, password, saveNetwork: true)
+  Phone->>Home: connect to home network
+```
+
+### Open network by SSID
+
+```yaml
+onTap:
+  connectToWifi:
+    ssid: MyIoT-Device
+    onSuccess:
+      showToast:
+        message: Connected
+    onError:
+      showToast:
+        message: ${event.error}
+```
+
+### Secured home network
+
+```yaml
+onTap:
+  connectToWifi:
+    ssid: KPN089C36
+    password: ${wifiPassword}
+    saveNetwork: true
+    onSuccess:
+      navigateScreen:
+        name: Home
+```
+
+### IoT device by SSID prefix
+
+Many IoT devices broadcast SSIDs like `DeviceName-ABC123`. Use a prefix match:
+
+```yaml
+onTap:
+  connectToWifi:
+    ssidPrefix: DeviceName-
+    password: ${devicePassword}
+    onSuccess:
+      showToast:
+        message: Connected to device
+```
+
+### Disconnect
+
+```yaml
+onTap:
+  connectToWifi:
+    operation: disconnect
+    onSuccess:
+      showToast:
+        message: Disconnected
+```
+
+## Troubleshooting
+
+
+| Symptom                                            | Likely cause                                                                                               |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Config error: module not enabled                   | Run `enable_wifi.dart` and `melos bootstrap`                                                               |
+| Web not supported                                  | Expected — use Android or iOS device                                                                       |
+| iOS `hotspotError_8` / internal error on Simulator | Expected — test on a physical iPhone                                                                       |
+| Connect fails after location granted               | Wrong SSID/password, join prompt cancelled, or Hotspot Configuration not enabled in Apple Developer portal |
+| Prefix connect fails on older Android              | May need legacy WiFi permissions in `AndroidManifest.xml` (API 28 and below)                               |
+
+
+## Development
+
+```bash
+melos bootstrap
+melos exec --scope="ensemble_wifi" -- flutter analyze
+```
+
+## Related
+
+
+| Package / module        | Purpose                                                        |
+| ----------------------- | -------------------------------------------------------------- |
+| `ensemble` (core)       | `ConnectToWifiAction`, `WifiManager` stub, action registration |
+| `ensemble_network_info` | Read current WiFi name, IP, BSSID (does not connect)           |
+| `plugin_wifi_connect`   | Native WiFi connect plugin                                     |
+
+

--- a/modules/ensemble_wifi/lib/ensemble_wifi.dart
+++ b/modules/ensemble_wifi/lib/ensemble_wifi.dart
@@ -1,0 +1,1 @@
+export 'wifi_manager_impl.dart';

--- a/modules/ensemble_wifi/lib/wifi_manager_impl.dart
+++ b/modules/ensemble_wifi/lib/wifi_manager_impl.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:ensemble/framework/stub/wifi_manager.dart';
+import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:plugin_wifi_connect/plugin_wifi_connect.dart';
+
+class WifiManagerImpl implements WifiManager {
+  Future<void> _ensureLocationPermission() async {
+    if (kIsWeb || (!Platform.isIOS && !Platform.isAndroid)) {
+      return;
+    }
+
+    if (!await Geolocator.isLocationServiceEnabled()) {
+      throw StateError(
+          'Location services are disabled. Enable location to connect to WiFi.');
+    }
+
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      throw StateError(
+          'Location permission is required to connect to WiFi on this device.');
+    }
+  }
+
+  Future<bool?> _connect(Future<bool?> Function() connect) async {
+    await _ensureLocationPermission();
+    return connect();
+  }
+
+  @override
+  Future<bool?> connect(String ssid, {bool saveNetwork = false}) {
+    return _connect(
+        () => PluginWifiConnect.connect(ssid, saveNetwork: saveNetwork));
+  }
+
+  @override
+  Future<bool?> connectByPrefix(String ssidPrefix, {bool saveNetwork = false}) {
+    return _connect(() => PluginWifiConnect.connectByPrefix(ssidPrefix,
+        saveNetwork: saveNetwork));
+  }
+
+  @override
+  Future<bool?> connectToSecureNetwork(
+    String ssid,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+    bool isHidden = false,
+  }) {
+    return _connect(() => PluginWifiConnect.connectToSecureNetwork(
+          ssid,
+          password,
+          isWep: isWep,
+          isWpa3: isWpa3,
+          saveNetwork: saveNetwork,
+          isHidden: isHidden,
+        ));
+  }
+
+  @override
+  Future<bool?> connectToSecureNetworkByPrefix(
+    String ssidPrefix,
+    String password, {
+    bool isWep = false,
+    bool isWpa3 = false,
+    bool saveNetwork = false,
+  }) {
+    return _connect(() => PluginWifiConnect.connectToSecureNetworkByPrefix(
+          ssidPrefix,
+          password,
+          isWep: isWep,
+          isWpa3: isWpa3,
+          saveNetwork: saveNetwork,
+        ));
+  }
+
+  @override
+  Future<bool?> disconnect() {
+    return PluginWifiConnect.disconnect();
+  }
+
+  @override
+  Future<void> activateWifi() {
+    return PluginWifiConnect.activateWifi();
+  }
+
+  @override
+  Future<void> deactivateWifi() {
+    return PluginWifiConnect.deactivateWifi();
+  }
+}

--- a/modules/ensemble_wifi/lib/wifi_manager_impl.dart
+++ b/modules/ensemble_wifi/lib/wifi_manager_impl.dart
@@ -85,14 +85,4 @@ class WifiManagerImpl implements WifiManager {
   Future<bool?> disconnect() {
     return PluginWifiConnect.disconnect();
   }
-
-  @override
-  Future<void> activateWifi() {
-    return PluginWifiConnect.activateWifi();
-  }
-
-  @override
-  Future<void> deactivateWifi() {
-    return PluginWifiConnect.deactivateWifi();
-  }
 }

--- a/modules/ensemble_wifi/pubspec.yaml
+++ b/modules/ensemble_wifi/pubspec.yaml
@@ -1,0 +1,25 @@
+name: ensemble_wifi
+description: Module that provides WiFi connection capabilities via plugin_wifi_connect.
+version: 0.0.1
+
+environment:
+  sdk: ">=3.5.0"
+  flutter: ">=3.24.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  ensemble:
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: ensemble-v1.2.44
+      path: modules/ensemble
+  plugin_wifi_connect: ^2.0.1
+  geolocator: ^9.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:

--- a/starter/lib/generated/ensemble_modules.dart
+++ b/starter/lib/generated/ensemble_modules.dart
@@ -8,6 +8,7 @@ import 'package:ensemble/framework/stub/face_camera_manager.dart';
 import 'package:ensemble/framework/stub/ensemble_bracket.dart';
 import 'package:ensemble/framework/stub/ensemble_chat.dart';
 import 'package:ensemble/framework/stub/network_info.dart';
+import 'package:ensemble/framework/stub/wifi_manager.dart';
 import 'package:ensemble/framework/stub/qr_code_scanner.dart';
 import 'package:ensemble/framework/stub/deferred_link_manager.dart';
 import 'package:ensemble/framework/stub/file_manager.dart';
@@ -75,6 +76,9 @@ import 'package:get_it/get_it.dart';
 // Uncomment to enable Firebase Remote Config (A/B testing, feature flags)
 // import 'package:ensemble_remote_config/remote_config.dart';
 
+// Uncomment to enable WiFi module
+// import 'package:ensemble_wifi/ensemble_wifi.dart';
+
 /// TODO: This class should be generated to enable selected Services
 class EnsembleModules {
   static final EnsembleModules _instance = EnsembleModules._internal();
@@ -98,6 +102,7 @@ class EnsembleModules {
 
   static const useBracket = false;
   static const useNetworkInfo = false;
+  static const useWifi = false;
   static const useBluetooth = false;
 
   static const useStripe = false;
@@ -236,6 +241,13 @@ class EnsembleModules {
       //GetIt.I.registerSingleton<NetworkInfoManager>(NetworkInfoImpl());
     } else {
       GetIt.I.registerSingleton<NetworkInfoManager>(NetworkInfoManagerStub());
+    }
+
+    if (useWifi) {
+      // Uncomment to enable WiFi module
+      // GetIt.I.registerSingleton<WifiManager>(WifiManagerImpl());
+    } else {
+      GetIt.I.registerSingleton<WifiManager>(WifiManagerStub());
     }
 
     if (useBluetooth) {

--- a/starter/pubspec.yaml
+++ b/starter/pubspec.yaml
@@ -52,6 +52,13 @@ dependencies:
   #     ref: main
   #     path: modules/ensemble_bluetooth
 
+  # Uncomment to enable WiFi module
+  # ensemble_wifi:
+  #   git:
+  #     url: https://github.com/EnsembleUI/ensemble.git
+  #     ref: main
+  #     path: modules/ensemble_wifi
+
   # Uncomment to enable camera module
   # ensemble_camera:
   #   git:

--- a/starter/scripts/modules/enable_wifi.dart
+++ b/starter/scripts/modules/enable_wifi.dart
@@ -31,10 +31,10 @@ ensemble_wifi:
 
   final androidPermissions = [
     '<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />',
+    '<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />',
     // Legacy WiFi permissions for API 28 and below
     '<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" android:maxSdkVersion="28" />',
     '<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" android:maxSdkVersion="28" />',
-    '<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" android:maxSdkVersion="28" />',
   ];
 
   try {

--- a/starter/scripts/modules/enable_wifi.dart
+++ b/starter/scripts/modules/enable_wifi.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import '../utils.dart';
+
+void main(List<String> arguments) async {
+  List<String> platforms = getPlatforms(arguments);
+  String? ensembleVersion = getArgumentValue(arguments, 'ensemble_version');
+
+  final statements = {
+    'moduleStatements': [
+      "import 'package:ensemble_wifi/ensemble_wifi.dart';",
+      'GetIt.I.registerSingleton<WifiManager>(WifiManagerImpl());',
+    ],
+    'useStatements': [
+      'static const useWifi = true;',
+    ],
+  };
+
+  final pubspecDependencies = [
+    {
+      'statement': '''
+ensemble_wifi:
+    git:
+      url: https://github.com/EnsembleUI/ensemble.git
+      ref: ${await packageVersion(version: ensembleVersion)}
+      path: modules/ensemble_wifi''',
+      'regex':
+          r'#\s*ensemble_wifi:\s*\n\s*#\s*git:\s*\n\s*#\s*url:\s*https:\/\/github\.com\/EnsembleUI\/ensemble\.git\s*\n\s*#\s*ref:\s*main\s*\n\s*#\s*path:\s*modules\/ensemble_wifi',
+    }
+  ];
+
+  final androidPermissions = [
+    '<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />',
+  ];
+
+  try {
+    updateEnsembleModules(
+      statements['moduleStatements'],
+      statements['useStatements'],
+    );
+
+    updatePubspec(pubspecDependencies);
+
+    if (platforms.contains('android')) {
+      updateAndroidPermissions(permissions: androidPermissions);
+    }
+
+    if (platforms.contains('ios')) {
+      final inUseLocationDescription = getArgumentValue(
+            arguments, 'inUseLocationDescription') ??
+          'Location access is required to connect to WiFi networks.';
+
+      addPermissionDescriptionToInfoPlist(
+        'NSLocationWhenInUseUsageDescription',
+        inUseLocationDescription,
+      );
+      updateRunnerEntitlements(module: 'wifi');
+    }
+
+    print('WiFi module enabled successfully for ${platforms.join(', ')}! 🎉');
+    exit(0);
+  } catch (e) {
+    print('Starter Error: $e');
+    exit(1);
+  }
+}

--- a/starter/scripts/modules/enable_wifi.dart
+++ b/starter/scripts/modules/enable_wifi.dart
@@ -31,6 +31,10 @@ ensemble_wifi:
 
   final androidPermissions = [
     '<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />',
+    // Legacy WiFi permissions for API 28 and below
+    '<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" android:maxSdkVersion="28" />',
+    '<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" android:maxSdkVersion="28" />',
+    '<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" android:maxSdkVersion="28" />',
   ];
 
   try {
@@ -46,9 +50,9 @@ ensemble_wifi:
     }
 
     if (platforms.contains('ios')) {
-      final inUseLocationDescription = getArgumentValue(
-            arguments, 'inUseLocationDescription') ??
-          'Location access is required to connect to WiFi networks.';
+      final inUseLocationDescription =
+          getArgumentValue(arguments, 'inUseLocationDescription') ??
+              'Location access is required to connect to WiFi networks.';
 
       addPermissionDescriptionToInfoPlist(
         'NSLocationWhenInUseUsageDescription',

--- a/starter/scripts/utils.dart
+++ b/starter/scripts/utils.dart
@@ -482,7 +482,59 @@ $deeplinkEntries
 </dict>''');
       entitlementsFile.writeAsStringSync(entitlementsContent);
     }
+  } else if (module == 'wifi') {
+    ensureCodeSignEntitlements();
+
+    var updated = false;
+    if (!entitlementsContent
+        .contains('<key>com.apple.developer.networking.wifi-info</key>')) {
+      entitlementsContent = entitlementsContent.replaceFirst('</dict>', '''
+    <key>com.apple.developer.networking.wifi-info</key>
+    <true/>
+</dict>''');
+      updated = true;
+    }
+    if (!entitlementsContent.contains(
+        '<key>com.apple.developer.networking.HotspotConfiguration</key>')) {
+      entitlementsContent = entitlementsContent.replaceFirst('</dict>', '''
+    <key>com.apple.developer.networking.HotspotConfiguration</key>
+    <true/>
+</dict>''');
+      updated = true;
+    }
+    if (updated) {
+      entitlementsFile.writeAsStringSync(entitlementsContent);
+    }
   }
+}
+
+/// Ensures the Xcode project links [Runner.entitlements] for code signing.
+void ensureCodeSignEntitlements() {
+  final pbxproj = File('ios/Runner.xcodeproj/project.pbxproj');
+  if (!pbxproj.existsSync()) {
+    return;
+  }
+  var content = pbxproj.readAsStringSync();
+  if (content.contains('CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;')) {
+    return;
+  }
+
+  // Insert before Runner's Info.plist reference — works for any bundle identifier.
+  const entitlementsLine =
+      'CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;\n\t\t\t\t';
+  content = content.replaceAll(
+    'INFOPLIST_FILE = Runner/Info.plist;',
+    '${entitlementsLine}INFOPLIST_FILE = Runner/Info.plist;',
+  );
+
+  if (!content.contains('CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;')) {
+    throw Exception(
+        'Could not link Runner.entitlements in Xcode project. '
+        'Add CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements; to the Runner target build settings.');
+  }
+
+  pbxproj.writeAsStringSync(content);
+  print('Linked Runner.entitlements in Xcode project.');
 }
 
 // Reads a specific key from ensemble.properties

--- a/starter/src/modules_scripts.ts
+++ b/starter/src/modules_scripts.ts
@@ -399,4 +399,17 @@ export const modules: Script[] = [
       ...firebaseWebParameters,
     ],
   },
+  {
+    name: 'wifi',
+    path: 'scripts/modules/enable_wifi.dart',
+    parameters: [
+      {
+        key: 'inUseLocationDescription',
+        question:
+          'Location usage description for iOS:',
+        platform: ['ios'],
+        type: 'text',
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

Adds `ensemble_wifi` module that lets Ensemble apps programmatically connect to WiFi networks on Android and iOS. This follows the same stub/impl + GetIt pattern used by other native capability modules (e.g. `ensemble_bluetooth`, `ensemble_network_info`).

- **New module** (`modules/ensemble_wifi/`) wrapping [`plugin_wifi_connect`](https://pub.dev/packages/plugin_wifi_connect) ^2.0.1
- **Core runtime** — `WifiManager` interface + `WifiManagerStub`, and a single `connectToWifi` YAML/JS action supporting `connect`, `disconnect`, `activate`, and `deactivate`
- **Starter wiring** — commented `ensemble_wifi` dependency, `useWifi` flag, and GetIt registration in `ensemble_modules.dart`
- **Enable script** — `starter/scripts/modules/enable_wifi.dart` (+ `enable wifi` CLI entry) configures Android location permission and iOS location description + WiFi/Hotspot entitlements
- **Documentation** — README with setup steps, action reference, examples, troubleshooting, and architecture diagrams

## Usage

Enable from the starter app:

```bash
cd starter
dart scripts/modules/enable_wifi.dart --platforms=android,ios
cd .. && melos bootstrap
```

## Example (EDL):

```yaml
connectToWifi:
  ssid: MyNetwork
  password: ${wifiPassword}
  saveNetwork: true
  onSuccess:
    showToast:
      message: Connected
  onError:
    showToast:
      message: ${event.error}
```

## Platform notes
- Android — requires runtime location permission (Android 10+)
- iOS — requires a physical device, location permission, Hotspot Configuration entitlement (Apple Developer portal), and user approval on the system “Join Network” prompt
- Web — not supported; action routes to onError