### PR TITLE
Ignore keyboard-only device metric changes

### DIFF
--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -104,6 +104,12 @@ class PageState extends State<Page>
   Timer? _titleBarHeightPollTimer;
   Timer? _headerVisibilityPollTimer;
 
+  // Last dispatched device metrics. We only want to notify bindings when the
+  // actual screen dimensions/orientation change, not when the keyboard opens.
+  int? _lastDeviceWidth;
+  int? _lastDeviceHeight;
+  String? _lastDeviceOrientation;
+
   @override
   bool get wantKeepAlive => true;
 
@@ -278,8 +284,26 @@ class PageState extends State<Page>
     if (!mounted) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      if (!_didDeviceMetricsChange()) return;
       _notifyDeviceMetricBindings();
     });
+  }
+
+  bool _didDeviceMetricsChange() {
+    final d = Device();
+    final width = d.screenWidth;
+    final height = d.screenHeight;
+    final orientation = d.screenOrientation;
+
+    final changed = width != _lastDeviceWidth ||
+        height != _lastDeviceHeight ||
+        orientation != _lastDeviceOrientation;
+
+    _lastDeviceWidth = width;
+    _lastDeviceHeight = height;
+    _lastDeviceOrientation = orientation;
+
+    return changed;
   }
 
   /// Re-evaluate ${device.width} / orientation after rotation.
@@ -436,6 +460,13 @@ class PageState extends State<Page>
     // Adding a listener for [viewGroupNotifier] so we can execute
     // onViewGroupUpdate when change in parent ViewGroup occurs
     viewGroupNotifier.addListener(executeOnViewGroupUpdate);
+
+    // Capture the initial device metrics after the first frame so later metric
+    // callbacks can ignore keyboard-only updates.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _didDeviceMetricsChange();
+    });
   }
 
   /// This is a callback because we need the widget to be first instantiate


### PR DESCRIPTION
## Description

Prevents keyboard open/close events from triggering unnecessary device metric updates. The page now tracks the last dispatched screen width, height, and orientation, and only notifies bindings when those values actually change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added caching for the last dispatched device metrics in `PageState`.
- Skipped device metric notifications when only keyboard-related metrics change.
- Captured the initial device metrics after the first frame so later updates can be compared correctly.

## How to Test

1. Open a page that listens to `${device.width}` or `${device.orientation}`.
2. Focus and unfocus a text input to show and hide the keyboard.
3. Confirm the bindings do not re-fire unless the screen size or orientation actually changes.