### PR TITLE
feat(webview): add HTML content and JavaScript injection support

### DIFF
--- a/modules/ensemble/lib/widget/webview/native/webviewstate.dart
+++ b/modules/ensemble/lib/widget/webview/native/webviewstate.dart
@@ -157,13 +157,24 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
       height: widget.controller.height ?? calculatedHeight,
       width: widget.controller.width,
       child: InAppWebView(
-        key: ValueKey('webview_${widget.controller.url}'),
-        initialUrlRequest: widget.controller.url != null
-            ? URLRequest(
-                url: WebUri(widget.controller.url!),
-                headers: widget.controller.headers,
+        key: ValueKey(
+            'webview_${widget.controller.url ?? widget.controller.htmlBaseUrl ?? 'html'}'),
+        initialData: widget.controller.html != null
+            ? InAppWebViewInitialData(
+                data: widget.controller.html!,
+                baseUrl: WebUri(
+                    widget.controller.htmlBaseUrl ?? 'https://ensemble.local/'),
+                mimeType: 'text/html',
+                encoding: 'utf-8',
               )
             : null,
+        initialUrlRequest:
+            widget.controller.html == null && widget.controller.url != null
+                ? URLRequest(
+                    url: WebUri(widget.controller.url!),
+                    headers: widget.controller.headers,
+                  )
+                : null,
         initialSettings: InAppWebViewSettings(
           // Cross Platform Settings
           useShouldOverrideUrlLoading: true,
@@ -252,6 +263,12 @@ class WebViewState extends EWidgetState<EnsembleWebView> with CookieMethods {
           if (widget.controller.javascriptChannels.isNotEmpty) {
             String bridgeScript = _generateJavaScriptBridgeScript();
             await controller.evaluateJavascript(source: bridgeScript);
+          }
+
+          String? injectedJavaScript = widget.controller.injectedJavaScript;
+          if (injectedJavaScript != null &&
+              injectedJavaScript.trim().isNotEmpty) {
+            await controller.evaluateJavascript(source: injectedJavaScript);
           }
 
           if (widget.controller.onPageFinished != null && mounted) {

--- a/modules/ensemble/lib/widget/webview/webview.dart
+++ b/modules/ensemble/lib/widget/webview/webview.dart
@@ -40,6 +40,9 @@ class EnsembleWebView extends StatefulWidget
           _controller.singleCookie = Utils.optionalString(value),
       'cookies': (value) => _controller.cookies = getListOfMap(value),
       'url': (value) => _controller.url = Utils.getUrl(value),
+      'html': (value) => _controller.html = Utils.optionalString(value),
+      'htmlBaseUrl': (value) =>
+          _controller.htmlBaseUrl = Utils.optionalString(value),
       'height': (value) => _controller.height = Utils.optionalDouble(value),
       'width': (value) => _controller.width = Utils.optionalDouble(value),
       'onPageStart': (funcDefinition) => _controller.onPageStart =
@@ -55,6 +58,8 @@ class EnsembleWebView extends StatefulWidget
           parseHeaderRules(value),
       'javascriptChannels': (value) =>
           _controller.javascriptChannels = parseJavaScriptChannels(value),
+      'injectedJavaScript': (value) =>
+          _controller.injectedJavaScript = Utils.optionalString(value),
       // legacy
       'uri': (value) => _controller.url = Utils.getUrl(value),
       'allowedLaunchSchemes': (value) => _controller.schemes =
@@ -140,15 +145,29 @@ class EnsembleWebViewController extends WidgetController {
   List<HeaderOverrideRule> headerOverrideRules = [];
   List<JavaScriptChannel> javascriptChannels = [];
 
+  /// JavaScript injection (opt-in)
+  String? injectedJavaScript;
+
   ensemble.EnsembleAction? onPageStart,
       onPageFinished,
       onNavigationRequest,
       onWebResourceError;
 
+  String? _html;
+  String? get html => _html;
+  set html(String? value) {
+    _html = value;
+    _url = null;
+    error = null;
+  }
+
+  String? htmlBaseUrl;
+
   String? _url;
   String? get url => _url;
   set url(String? url) {
     _url = url;
+    _html = null;
     error = null;
 
     if (url != null) {


### PR DESCRIPTION
## Description

- Introduced new properties `html` and `htmlBaseUrl` to the `EnsembleWebView` for rendering HTML content directly.
- Enhanced `WebViewState` to support initial data loading from HTML and base URL.
- Added `injectedJavaScript` property to allow JavaScript code injection into the web view.
- Updated the web view initialization logic to handle both URL and HTML content appropriately.