### PR TITLE
[Fix} Allow beta versions in release workflow

### DIFF
--- a/.github/workflows/release-melos-version.yml
+++ b/.github/workflows/release-melos-version.yml
@@ -75,8 +75,8 @@ jobs:
             version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
           fi
 
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version must be a semver value like 1.2.39."
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?$ ]]; then
+            echo "::error::Version must be a semver value like 1.2.39 or 1.2.39-beta.1."
             exit 1
           fi
 


### PR DESCRIPTION
Fixes version validation regex to accept prerelease versions like `1.2.38-beta.8`.                                                  
                                                                                                                                      
Previously, the workflow rejected beta versions with "Version must be a semver value like 1.2.39".