### PR TITLE
Cache CDN-managed runtime assets locally

### DIFF
--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -9,6 +9,7 @@ import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/apiproviders/api_provider.dart';
 import 'package:ensemble/framework/app_info.dart';
 import 'package:ensemble/framework/bindings.dart';
+import 'package:ensemble/framework/cdn_asset_cache.dart';
 import 'package:ensemble/framework/config.dart';
 import 'package:ensemble/framework/data_context.dart';
 import 'package:ensemble/framework/definition_providers/provider.dart';
@@ -443,9 +444,15 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
       },
       home: content,
       useInheritedMediaQuery: widget.isPreview,
-      builder: (context, child) => widget.isPreview
-          ? DevicePreview.appBuilder(context, child)
-          : (child ?? SizedBox.shrink()),
+      builder: (context, child) {
+        final appChild = widget.isPreview
+            ? DevicePreview.appBuilder(context, child)
+            : (child ?? SizedBox.shrink());
+        return DefaultAssetBundle(
+          bundle: EnsembleAssetBundle(parent: DefaultAssetBundle.of(context)),
+          child: appChild,
+        );
+      },
     );
 
     // adjust for text scaling globally

--- a/modules/ensemble/lib/framework/cdn_asset_cache.dart
+++ b/modules/ensemble/lib/framework/cdn_asset_cache.dart
@@ -15,6 +15,23 @@ typedef CdnAssetHttpGet = Future<http.Response> Function(
 });
 typedef CdnAssetStorageDirectoryProvider = Future<io.Directory?> Function();
 
+String? _normalizeCdnAssetKey(String key) {
+  var candidate = key.trim();
+  try {
+    candidate = Uri.decodeComponent(candidate);
+  } catch (_) {}
+
+  if (candidate.isEmpty || candidate.contains(r'\')) {
+    return null;
+  }
+  final segments = candidate.split('/');
+  if (segments
+      .any((segment) => segment.isEmpty || segment == '.' || segment == '..')) {
+    return null;
+  }
+  return candidate;
+}
+
 class CdnAssetCache {
   CdnAssetCache({
     CdnAssetHttpGet? httpGet,
@@ -41,7 +58,6 @@ class CdnAssetCache {
 
   bool get hasAssetManifest => _hasAssetManifest;
   int? get assetManifestUpdatedAt => _assetManifest?.updatedAt;
-
   Future<void> initialize({
     required String appId,
     required String baseUrl,
@@ -69,20 +85,25 @@ class CdnAssetCache {
   }
 
   bool isEligible(String source) {
-    final fileName = _fileNameFromSource(source);
-    return fileName != null && _assets.containsKey(fileName);
+    final assetKey = _assetKeyFromSource(source);
+    return assetKey != null && _assets.containsKey(assetKey);
+  }
+
+  bool isManagedSource(String source) {
+    final assetKey = _assetKeyFromManagedSource(source);
+    return assetKey != null && _assets.containsKey(assetKey);
   }
 
   io.File? getCachedFileIfValid(String source) {
     if (kIsWeb || !_initialized || _rootDirectory == null) {
       return null;
     }
-    final fileName = _fileNameFromSource(source);
-    if (fileName == null) {
+    final assetKey = _assetKeyFromSource(source);
+    if (assetKey == null) {
       return null;
     }
-    final metadata = _assets[fileName];
-    final state = _cacheState[fileName];
+    final metadata = _assets[assetKey];
+    final state = _cacheState[assetKey];
     if (metadata == null) {
       return null;
     }
@@ -93,7 +114,7 @@ class CdnAssetCache {
       return null;
     }
 
-    final file = _assetFile(fileName);
+    final file = _assetFile(assetKey);
     try {
       if (file.existsSync()) {
         return file;
@@ -109,8 +130,10 @@ class CdnAssetCache {
     final assetsPath = '${_assetsDirectory.path}${io.Platform.pathSeparator}';
     if (!key.startsWith(assetsPath)) return null;
 
-    final fileName = key.substring(assetsPath.length);
-    final cachedFile = getCachedFileIfValid(fileName);
+    final assetKey = key
+        .substring(assetsPath.length)
+        .replaceAll(io.Platform.pathSeparator, '/');
+    final cachedFile = getCachedFileIfValid(assetKey);
     if (cachedFile?.path == key) {
       return cachedFile;
     }
@@ -121,8 +144,9 @@ class CdnAssetCache {
     if (kIsWeb || !_initialized || _rootDirectory == null) {
       return Future.value(null);
     }
-    final fileName = _fileNameFromSource(source);
-    if (fileName == null || !_assets.containsKey(fileName)) {
+    final assetKey = _assetKeyFromSource(source);
+    final metadata = assetKey != null ? _assets[assetKey] : null;
+    if (assetKey == null || metadata == null) {
       return Future.value(null);
     }
 
@@ -131,11 +155,12 @@ class CdnAssetCache {
       return Future.value(cached);
     }
 
+    final inFlightKey = '$assetKey:${metadata.hash}';
     return _inFlightDownloads.putIfAbsent(
-      fileName,
-      () => _resolveFile(fileName).whenComplete(
+      inFlightKey,
+      () => _resolveFile(assetKey).whenComplete(
         () {
-          _inFlightDownloads.remove(fileName);
+          _inFlightDownloads.remove(inFlightKey);
         },
       ),
     );
@@ -157,6 +182,7 @@ class CdnAssetCache {
       }
       _replaceManifest(manifest);
       _hasAssetManifest = true;
+      await _validateCachedAssets();
     } catch (e) {
       debugPrint('CdnAssetCache: Failed to load asset manifest: $e');
       _assets.clear();
@@ -176,6 +202,7 @@ class CdnAssetCache {
     _hasAssetManifest = true;
     await _writeCacheFile();
     await cleanupStaleAssets();
+    await _validateCachedAssets();
   }
 
   Future<void> clearAssetManifest({bool removeCachedAssets = false}) async {
@@ -224,43 +251,62 @@ class CdnAssetCache {
     await _writeCacheFile();
   }
 
-  Future<io.File?> _resolveFile(String fileName) async {
-    final metadata = _assets[fileName];
+  Future<void> _validateCachedAssets() async {
+    if (kIsWeb || _rootDirectory == null) return;
+    var changed = false;
+    final cachedAssetKeys = _cacheState.keys.toList();
+    for (final assetKey in cachedAssetKeys) {
+      final metadata = _assets[assetKey];
+      if (metadata == null) {
+        _cacheState.remove(assetKey);
+        changed = true;
+        continue;
+      }
+      final validFile = await _validateCachedFile(
+        assetKey,
+        metadata,
+        writeCacheFile: false,
+      );
+      if (validFile == null) {
+        changed = true;
+      }
+    }
+    if (changed) {
+      await _writeCacheFile();
+    }
+  }
+
+  Future<io.File?> _resolveFile(String assetKey) async {
+    final metadata = _assets[assetKey];
     if (metadata == null) {
       return null;
     }
 
-    final validFile = await _validateCachedFile(fileName, metadata);
+    final validFile = await _validateCachedFile(assetKey, metadata);
     if (validFile != null) {
       return validFile;
     }
 
-    return _downloadAndStore(fileName, metadata);
+    return _downloadAndStore(assetKey, metadata);
   }
 
   Future<io.File?> _validateCachedFile(
-    String fileName,
-    CdnAssetMetadata metadata,
-  ) async {
-    final file = _assetFile(fileName);
+    String assetKey,
+    CdnAssetMetadata metadata, {
+    bool writeCacheFile = true,
+  }) async {
+    final file = _assetFile(assetKey);
     if (!await file.exists()) {
       return null;
     }
 
     try {
-      final state = _cacheState[fileName];
+      final state = _cacheState[assetKey];
       if (state != null && state.hash == metadata.hash) {
         return file;
       }
-
-      _cacheState[fileName] = CdnAssetCacheState(
-        hash: metadata.hash,
-        downloadedAt: DateTime.now().millisecondsSinceEpoch,
-      );
-      await _writeCacheFile();
-      return file;
     } catch (e) {
-      debugPrint('CdnAssetCache: Failed to validate asset $fileName: $e');
+      debugPrint('CdnAssetCache: Failed to validate asset $assetKey: $e');
     }
 
     try {
@@ -268,13 +314,15 @@ class CdnAssetCache {
         await file.delete();
       }
     } catch (_) {}
-    _cacheState.remove(fileName);
-    await _writeCacheFile();
+    _cacheState.remove(assetKey);
+    if (writeCacheFile) {
+      await _writeCacheFile();
+    }
     return null;
   }
 
   Future<io.File?> _downloadAndStore(
-    String fileName,
+    String assetKey,
     CdnAssetMetadata metadata,
   ) async {
     final appId = _appId;
@@ -285,23 +333,23 @@ class CdnAssetCache {
 
     try {
       final headers = await _headersProvider();
-      final uri = _assetUri(fileName, appId: appId, baseUrl: baseUrl);
+      final uri = _assetUri(assetKey, appId: appId, baseUrl: baseUrl);
       final response = await _httpGet(uri, headers: headers);
       if (response.statusCode != 200 || response.bodyBytes.isEmpty) {
         return null;
       }
       final bytes = response.bodyBytes;
 
-      final file = _assetFile(fileName);
+      final file = _assetFile(assetKey);
       await _writeFileAtomically(file, bytes);
-      _cacheState[fileName] = CdnAssetCacheState(
+      _cacheState[assetKey] = CdnAssetCacheState(
         hash: metadata.hash,
         downloadedAt: DateTime.now().millisecondsSinceEpoch,
       );
       await _writeCacheFile();
       return file;
     } catch (e) {
-      debugPrint('CdnAssetCache: Failed to download asset $fileName: $e');
+      debugPrint('CdnAssetCache: Failed to download asset $assetKey: $e');
       return null;
     }
   }
@@ -368,55 +416,76 @@ class CdnAssetCache {
       ..addAll(manifest.assets);
   }
 
-  String? _fileNameFromSource(String source) {
+  String? _assetKeyFromSource(String source) {
     final trimmed = source.trim();
     if (trimmed.isEmpty) return null;
 
-    String candidate;
-    try {
-      final uri = Uri.parse(trimmed);
-      candidate = uri.pathSegments.isNotEmpty
-          ? uri.pathSegments.last
-          : uri.path.split('/').last;
-    } catch (_) {
-      candidate = trimmed.split('?').first.split('/').last;
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && uri.hasScheme) {
+      if (uri.scheme != 'http' && uri.scheme != 'https') {
+        return null;
+      }
+      return _assetKeyFromManagedUri(uri);
     }
 
-    try {
-      candidate = Uri.decodeComponent(candidate);
-    } catch (_) {}
-
-    if (candidate.isEmpty ||
-        candidate == '.' ||
-        candidate == '..' ||
-        candidate.contains('/') ||
-        candidate.contains(r'\')) {
-      return null;
-    }
-    return candidate;
+    return _normalizeCdnAssetKey(trimmed.split('?').first.split('#').first);
   }
 
-  io.File _assetFile(String fileName) =>
-      io.File('${_assetsDirectory.path}/$fileName');
+  String? _assetKeyFromManagedSource(String source) {
+    final uri = Uri.tryParse(source.trim());
+    if (uri == null ||
+        !uri.hasScheme ||
+        (uri.scheme != 'http' && uri.scheme != 'https')) {
+      return null;
+    }
+    return _assetKeyFromManagedUri(uri);
+  }
 
-  Uri _assetUri(String fileName, {String? appId, String? baseUrl}) {
+  String? _assetKeyFromManagedUri(Uri uri) {
+    final appId = _appId;
+    final baseUrl = _baseUrl;
+    if (appId == null || baseUrl == null) return null;
+
+    final baseUri = Uri.tryParse('$baseUrl/$appId/assets/');
+    if (baseUri == null ||
+        uri.scheme != baseUri.scheme ||
+        uri.host != baseUri.host ||
+        uri.port != baseUri.port) {
+      return null;
+    }
+
+    final baseSegments =
+        baseUri.pathSegments.where((s) => s.isNotEmpty).toList();
+    final uriSegments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+    if (uriSegments.length <= baseSegments.length) return null;
+    for (var i = 0; i < baseSegments.length; i++) {
+      if (uriSegments[i] != baseSegments[i]) return null;
+    }
+    return _normalizeCdnAssetKey(
+        uriSegments.skip(baseSegments.length).join('/'));
+  }
+
+  io.File _assetFile(String assetKey) =>
+      io.File('${_assetsDirectory.path}/$assetKey');
+
+  Uri _assetUri(String assetKey, {String? appId, String? baseUrl}) {
     final resolvedAppId = appId ?? _appId;
     final resolvedBaseUrl = baseUrl ?? _baseUrl;
-    return Uri.parse(
-      '$resolvedBaseUrl/$resolvedAppId/assets/${Uri.encodeComponent(fileName)}',
-    );
+    final encodedPath = assetKey.split('/').map(Uri.encodeComponent).join('/');
+    return Uri.parse('$resolvedBaseUrl/$resolvedAppId/assets/$encodedPath');
   }
 
   void _evictImageCache(String fileName, io.File file) {
     try {
-      PaintingBinding.instance.imageCache.clear();
-      PaintingBinding.instance.imageCache.clearLiveImages();
-      unawaited(AssetImage(file.path).evict());
+      unawaited(AssetImage(file.path).evict().catchError((_) => false));
+      unawaited(FileImage(file).evict().catchError((_) => false));
 
       final appId = _appId;
       final baseUrl = _baseUrl;
       if (appId != null && baseUrl != null) {
-        unawaited(NetworkImage(_assetUri(fileName).toString()).evict());
+        unawaited(NetworkImage(_assetUri(fileName).toString())
+            .evict()
+            .catchError((_) => false));
       }
     } catch (_) {}
   }
@@ -455,7 +524,8 @@ class CdnAssetManifest {
     final assets = <String, CdnAssetMetadata>{};
     if (rawAssets is Map) {
       rawAssets.forEach((key, value) {
-        final fileName = key.toString();
+        final fileName = _normalizeCdnAssetKey(key.toString());
+        if (fileName == null) return;
         final metadata = CdnAssetMetadata.fromJson(value);
         if (metadata != null) {
           assets[fileName] = metadata;
@@ -498,7 +568,8 @@ class CdnAssetCacheFile {
     if (rawAssets is Map) {
       rawAssets.forEach((key, value) {
         if (value is Map) {
-          final fileName = key.toString();
+          final fileName = _normalizeCdnAssetKey(key.toString());
+          if (fileName == null) return;
           final metadata = manifest.assets[fileName];
           if (metadata == null) return;
           final cacheState = CdnAssetCacheState.fromJson(
@@ -571,13 +642,17 @@ class CdnAssetMetadata {
   final int size;
   final String? contentType;
   final int? updatedAt;
+  static final RegExp _sha256Pattern = RegExp(r'^[a-f0-9]{64}$');
 
   static CdnAssetMetadata? fromJson(dynamic value) {
     if (value is! Map) return null;
 
-    final hash = value['hash']?.toString().trim();
+    final hash = value['hash']?.toString().trim().toLowerCase();
     final size = _intFromJson(value['size']);
-    if (hash == null || hash.isEmpty || size == null || size < 0) {
+    if (hash == null ||
+        !_sha256Pattern.hasMatch(hash) ||
+        size == null ||
+        size < 0) {
       return null;
     }
 

--- a/modules/ensemble/lib/framework/cdn_asset_cache.dart
+++ b/modules/ensemble/lib/framework/cdn_asset_cache.dart
@@ -61,6 +61,7 @@ class CdnAssetCache {
       }
       _rootDirectory = io.Directory('${storageRoot.path}/asset_cache');
       await _assetsDirectory.create(recursive: true);
+      await _deleteTempFilesFor(_cacheFile);
       await loadAssetManifest();
     } catch (e) {
       debugPrint('CdnAssetCache: Failed to initialize: $e');
@@ -332,11 +333,32 @@ class CdnAssetCache {
     final tempFile = io.File(
       '${file.path}.tmp-${DateTime.now().microsecondsSinceEpoch}',
     );
-    await tempFile.writeAsBytes(bytes, flush: true);
-    if (await file.exists()) {
-      await file.delete();
+    try {
+      await tempFile.writeAsBytes(bytes, flush: true);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      await tempFile.rename(file.path);
+    } catch (_) {
+      if (await tempFile.exists()) {
+        await tempFile.delete();
+      }
+      rethrow;
     }
-    await tempFile.rename(file.path);
+  }
+
+  Future<void> _deleteTempFilesFor(io.File file) async {
+    final parent = file.parent;
+    if (!await parent.exists()) return;
+    final prefix = '${file.uri.pathSegments.last}.tmp-';
+    await for (final entity in parent.list()) {
+      if (entity is io.File &&
+          entity.uri.pathSegments.last.startsWith(prefix)) {
+        try {
+          await entity.delete();
+        } catch (_) {}
+      }
+    }
   }
 
   void _replaceManifest(CdnAssetManifest manifest) {

--- a/modules/ensemble/lib/framework/cdn_asset_cache.dart
+++ b/modules/ensemble/lib/framework/cdn_asset_cache.dart
@@ -201,8 +201,9 @@ class CdnAssetCache {
     _replaceManifest(manifest);
     _hasAssetManifest = true;
     await _writeCacheFile();
-    await cleanupStaleAssets();
+    final staleAssetKeys = await cleanupStaleAssets();
     await _validateCachedAssets();
+    await _downloadAssets(staleAssetKeys);
   }
 
   Future<void> clearAssetManifest({bool removeCachedAssets = false}) async {
@@ -225,8 +226,8 @@ class CdnAssetCache {
     }
   }
 
-  Future<void> cleanupStaleAssets() async {
-    if (kIsWeb || _rootDirectory == null) return;
+  Future<List<String>> cleanupStaleAssets() async {
+    if (kIsWeb || _rootDirectory == null) return const [];
     final staleFileNames = _cacheState.entries
         .where((entry) {
           final metadata = _assets[entry.key];
@@ -238,7 +239,7 @@ class CdnAssetCache {
     for (final fileName in staleFileNames) {
       try {
         final file = _assetFile(fileName);
-        _evictImageCache(fileName, file);
+        await _evictImageCache(file);
         if (await file.exists()) {
           await file.delete();
         }
@@ -249,6 +250,13 @@ class CdnAssetCache {
     }
 
     await _writeCacheFile();
+    return staleFileNames;
+  }
+
+  Future<void> _downloadAssets(List<String> assetKeys) async {
+    for (final assetKey in assetKeys) {
+      await resolve(assetKey);
+    }
   }
 
   Future<void> _validateCachedAssets() async {
@@ -475,18 +483,10 @@ class CdnAssetCache {
     return Uri.parse('$resolvedBaseUrl/$resolvedAppId/assets/$encodedPath');
   }
 
-  void _evictImageCache(String fileName, io.File file) {
+  Future<void> _evictImageCache(io.File file) async {
     try {
-      unawaited(AssetImage(file.path).evict().catchError((_) => false));
-      unawaited(FileImage(file).evict().catchError((_) => false));
-
-      final appId = _appId;
-      final baseUrl = _baseUrl;
-      if (appId != null && baseUrl != null) {
-        unawaited(NetworkImage(_assetUri(fileName).toString())
-            .evict()
-            .catchError((_) => false));
-      }
+      await AssetImage(file.path).evict();
+      await FileImage(file).evict();
     } catch (_) {}
   }
 

--- a/modules/ensemble/lib/framework/cdn_asset_cache.dart
+++ b/modules/ensemble/lib/framework/cdn_asset_cache.dart
@@ -1,0 +1,609 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+typedef CdnAssetHeadersProvider = Future<Map<String, String>> Function();
+typedef CdnAssetHttpGet = Future<http.Response> Function(
+  Uri uri, {
+  Map<String, String>? headers,
+});
+typedef CdnAssetStorageDirectoryProvider = Future<io.Directory?> Function();
+
+class CdnAssetCache {
+  CdnAssetCache({
+    CdnAssetHttpGet? httpGet,
+    CdnAssetStorageDirectoryProvider? storageDirectoryProvider,
+  })  : _httpGet = httpGet ?? http.get,
+        _storageDirectoryProvider =
+            storageDirectoryProvider ?? _defaultStorageDirectoryProvider;
+
+  static final CdnAssetCache instance = CdnAssetCache();
+
+  final CdnAssetHttpGet _httpGet;
+  final CdnAssetStorageDirectoryProvider _storageDirectoryProvider;
+  final Map<String, Future<io.File?>> _inFlightDownloads = {};
+  final Map<String, CdnAssetMetadata> _assets = {};
+  final Map<String, CdnAssetCacheState> _cacheState = {};
+
+  CdnAssetHeadersProvider _headersProvider = () async => const {};
+  CdnAssetManifest? _assetManifest;
+  String? _appId;
+  String? _baseUrl;
+  io.Directory? _rootDirectory;
+  bool _initialized = false;
+  bool _hasAssetManifest = false;
+
+  bool get hasAssetManifest => _hasAssetManifest;
+  int? get assetManifestUpdatedAt => _assetManifest?.updatedAt;
+
+  Future<void> initialize({
+    required String appId,
+    required String baseUrl,
+    required CdnAssetHeadersProvider headersProvider,
+  }) async {
+    _appId = appId;
+    _baseUrl = baseUrl;
+    _headersProvider = headersProvider;
+    _initialized = true;
+
+    if (kIsWeb) return;
+
+    try {
+      final storageRoot = await _storageDirectoryProvider();
+      if (storageRoot == null) {
+        return;
+      }
+      _rootDirectory = io.Directory('${storageRoot.path}/asset_cache');
+      await _assetsDirectory.create(recursive: true);
+      await loadAssetManifest();
+    } catch (e) {
+      debugPrint('CdnAssetCache: Failed to initialize: $e');
+    }
+  }
+
+  bool isEligible(String source) {
+    final fileName = _fileNameFromSource(source);
+    return fileName != null && _assets.containsKey(fileName);
+  }
+
+  io.File? getCachedFileIfValid(String source) {
+    if (kIsWeb || !_initialized || _rootDirectory == null) {
+      return null;
+    }
+    final fileName = _fileNameFromSource(source);
+    if (fileName == null) {
+      return null;
+    }
+    final metadata = _assets[fileName];
+    final state = _cacheState[fileName];
+    if (metadata == null) {
+      return null;
+    }
+    if (state == null) {
+      return null;
+    }
+    if (state.hash != metadata.hash) {
+      return null;
+    }
+
+    final file = _assetFile(fileName);
+    try {
+      if (file.existsSync()) {
+        return file;
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  io.File? getCachedFileForBundleKey(String key) {
+    if (kIsWeb || !_initialized || _rootDirectory == null) return null;
+    final assetsPath = '${_assetsDirectory.path}${io.Platform.pathSeparator}';
+    if (!key.startsWith(assetsPath)) return null;
+
+    final fileName = key.substring(assetsPath.length);
+    final cachedFile = getCachedFileIfValid(fileName);
+    if (cachedFile?.path == key) {
+      return cachedFile;
+    }
+    return null;
+  }
+
+  Future<io.File?> resolve(String source) {
+    if (kIsWeb || !_initialized || _rootDirectory == null) {
+      return Future.value(null);
+    }
+    final fileName = _fileNameFromSource(source);
+    if (fileName == null || !_assets.containsKey(fileName)) {
+      return Future.value(null);
+    }
+
+    final cached = getCachedFileIfValid(source);
+    if (cached != null) {
+      return Future.value(cached);
+    }
+
+    return _inFlightDownloads.putIfAbsent(
+      fileName,
+      () => _resolveFile(fileName).whenComplete(
+        () {
+          _inFlightDownloads.remove(fileName);
+        },
+      ),
+    );
+  }
+
+  Future<void> loadAssetManifest() async {
+    if (kIsWeb || _rootDirectory == null) return;
+
+    try {
+      final cacheFile = await _loadCacheFile();
+      _cacheState
+        ..clear()
+        ..addAll(cacheFile.cacheStates);
+      final manifest = cacheFile.manifest;
+      if (manifest == null) {
+        _assets.clear();
+        _hasAssetManifest = false;
+        return;
+      }
+      _replaceManifest(manifest);
+      _hasAssetManifest = true;
+    } catch (e) {
+      debugPrint('CdnAssetCache: Failed to load asset manifest: $e');
+      _assets.clear();
+      _cacheState.clear();
+      _hasAssetManifest = false;
+    }
+  }
+
+  Future<void> saveAssetManifest(String jsonString) async {
+    if (kIsWeb || _rootDirectory == null) return;
+    final manifest = CdnAssetManifest.fromJsonString(jsonString);
+    final cacheFile = await _loadCacheFile();
+    _cacheState
+      ..clear()
+      ..addAll(cacheFile.cacheStates);
+    _replaceManifest(manifest);
+    _hasAssetManifest = true;
+    await _writeCacheFile();
+    await cleanupStaleAssets();
+  }
+
+  Future<void> clearAssetManifest({bool removeCachedAssets = false}) async {
+    _assets.clear();
+    _assetManifest = null;
+    _hasAssetManifest = false;
+    if (kIsWeb || _rootDirectory == null) return;
+
+    try {
+      if (removeCachedAssets) {
+        _cacheState.clear();
+        if (await _assetsDirectory.exists()) {
+          await _assetsDirectory.delete(recursive: true);
+        }
+        await _assetsDirectory.create(recursive: true);
+      }
+      await _writeCacheFile();
+    } catch (e) {
+      debugPrint('CdnAssetCache: Failed to clear asset manifest: $e');
+    }
+  }
+
+  Future<void> cleanupStaleAssets() async {
+    if (kIsWeb || _rootDirectory == null) return;
+    final staleFileNames = _cacheState.entries
+        .where((entry) {
+          final metadata = _assets[entry.key];
+          return metadata == null || metadata.hash != entry.value.hash;
+        })
+        .map((entry) => entry.key)
+        .toList();
+
+    for (final fileName in staleFileNames) {
+      try {
+        final file = _assetFile(fileName);
+        _evictImageCache(fileName, file);
+        if (await file.exists()) {
+          await file.delete();
+        }
+      } catch (e) {
+        debugPrint('CdnAssetCache: Failed to delete stale asset $fileName: $e');
+      }
+      _cacheState.remove(fileName);
+    }
+
+    await _writeCacheFile();
+  }
+
+  Future<io.File?> _resolveFile(String fileName) async {
+    final metadata = _assets[fileName];
+    if (metadata == null) {
+      return null;
+    }
+
+    final validFile = await _validateCachedFile(fileName, metadata);
+    if (validFile != null) {
+      return validFile;
+    }
+
+    return _downloadAndStore(fileName, metadata);
+  }
+
+  Future<io.File?> _validateCachedFile(
+    String fileName,
+    CdnAssetMetadata metadata,
+  ) async {
+    final file = _assetFile(fileName);
+    if (!await file.exists()) {
+      return null;
+    }
+
+    try {
+      final state = _cacheState[fileName];
+      if (state != null && state.hash == metadata.hash) {
+        return file;
+      }
+
+      _cacheState[fileName] = CdnAssetCacheState(
+        hash: metadata.hash,
+        downloadedAt: DateTime.now().millisecondsSinceEpoch,
+      );
+      await _writeCacheFile();
+      return file;
+    } catch (e) {
+      debugPrint('CdnAssetCache: Failed to validate asset $fileName: $e');
+    }
+
+    try {
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (_) {}
+    _cacheState.remove(fileName);
+    await _writeCacheFile();
+    return null;
+  }
+
+  Future<io.File?> _downloadAndStore(
+    String fileName,
+    CdnAssetMetadata metadata,
+  ) async {
+    final appId = _appId;
+    final baseUrl = _baseUrl;
+    if (appId == null || baseUrl == null) {
+      return null;
+    }
+
+    try {
+      final headers = await _headersProvider();
+      final uri = _assetUri(fileName, appId: appId, baseUrl: baseUrl);
+      final response = await _httpGet(uri, headers: headers);
+      if (response.statusCode != 200 || response.bodyBytes.isEmpty) {
+        return null;
+      }
+      final bytes = response.bodyBytes;
+
+      final file = _assetFile(fileName);
+      await _writeFileAtomically(file, bytes);
+      _cacheState[fileName] = CdnAssetCacheState(
+        hash: metadata.hash,
+        downloadedAt: DateTime.now().millisecondsSinceEpoch,
+      );
+      await _writeCacheFile();
+      return file;
+    } catch (e) {
+      debugPrint('CdnAssetCache: Failed to download asset $fileName: $e');
+      return null;
+    }
+  }
+
+  Future<CdnAssetCacheFile> _loadCacheFile() async {
+    if (_rootDirectory == null) return const CdnAssetCacheFile();
+    final file = _cacheFile;
+    if (await file.exists()) {
+      return CdnAssetCacheFile.fromJsonString(await file.readAsString());
+    }
+
+    return const CdnAssetCacheFile();
+  }
+
+  Future<void> _writeCacheFile() async {
+    if (_rootDirectory == null) return;
+    final cacheFile = CdnAssetCacheFile(
+      manifest: _hasAssetManifest ? _assetManifest : null,
+      cacheStates: Map.of(_cacheState),
+    );
+    await _writeFileAtomically(
+      _cacheFile,
+      utf8.encode(jsonEncode(cacheFile.toJson())),
+    );
+  }
+
+  Future<void> _writeFileAtomically(io.File file, List<int> bytes) async {
+    await file.parent.create(recursive: true);
+    final tempFile = io.File(
+      '${file.path}.tmp-${DateTime.now().microsecondsSinceEpoch}',
+    );
+    await tempFile.writeAsBytes(bytes, flush: true);
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await tempFile.rename(file.path);
+  }
+
+  void _replaceManifest(CdnAssetManifest manifest) {
+    _assetManifest = manifest;
+    _assets
+      ..clear()
+      ..addAll(manifest.assets);
+  }
+
+  String? _fileNameFromSource(String source) {
+    final trimmed = source.trim();
+    if (trimmed.isEmpty) return null;
+
+    String candidate;
+    try {
+      final uri = Uri.parse(trimmed);
+      candidate = uri.pathSegments.isNotEmpty
+          ? uri.pathSegments.last
+          : uri.path.split('/').last;
+    } catch (_) {
+      candidate = trimmed.split('?').first.split('/').last;
+    }
+
+    try {
+      candidate = Uri.decodeComponent(candidate);
+    } catch (_) {}
+
+    if (candidate.isEmpty ||
+        candidate == '.' ||
+        candidate == '..' ||
+        candidate.contains('/') ||
+        candidate.contains(r'\')) {
+      return null;
+    }
+    return candidate;
+  }
+
+  io.File _assetFile(String fileName) =>
+      io.File('${_assetsDirectory.path}/$fileName');
+
+  Uri _assetUri(String fileName, {String? appId, String? baseUrl}) {
+    final resolvedAppId = appId ?? _appId;
+    final resolvedBaseUrl = baseUrl ?? _baseUrl;
+    return Uri.parse(
+      '$resolvedBaseUrl/$resolvedAppId/assets/${Uri.encodeComponent(fileName)}',
+    );
+  }
+
+  void _evictImageCache(String fileName, io.File file) {
+    try {
+      PaintingBinding.instance.imageCache.clear();
+      PaintingBinding.instance.imageCache.clearLiveImages();
+      unawaited(AssetImage(file.path).evict());
+
+      final appId = _appId;
+      final baseUrl = _baseUrl;
+      if (appId != null && baseUrl != null) {
+        unawaited(NetworkImage(_assetUri(fileName).toString()).evict());
+      }
+    } catch (_) {}
+  }
+
+  io.File get _cacheFile => io.File('${_rootDirectory!.path}/asset-cache.json');
+
+  io.Directory get _assetsDirectory =>
+      io.Directory('${_rootDirectory!.path}/assets');
+
+  static Future<io.Directory?> _defaultStorageDirectoryProvider() async {
+    if (kIsWeb) return null;
+    return getApplicationSupportDirectory();
+  }
+}
+
+class CdnAssetManifest {
+  const CdnAssetManifest({
+    required this.assets,
+    this.updatedAt,
+  });
+
+  final int? updatedAt;
+  final Map<String, CdnAssetMetadata> assets;
+
+  factory CdnAssetManifest.fromJsonString(String jsonString) {
+    final decoded = jsonDecode(jsonString);
+    return CdnAssetManifest.fromJson(decoded);
+  }
+
+  factory CdnAssetManifest.fromJson(dynamic decoded) {
+    if (decoded is! Map) {
+      throw const FormatException('Asset manifest root is not a JSON object.');
+    }
+
+    final rawAssets = decoded['assets'];
+    final assets = <String, CdnAssetMetadata>{};
+    if (rawAssets is Map) {
+      rawAssets.forEach((key, value) {
+        final fileName = key.toString();
+        final metadata = CdnAssetMetadata.fromJson(value);
+        if (metadata != null) {
+          assets[fileName] = metadata;
+        }
+      });
+    }
+
+    return CdnAssetManifest(
+      updatedAt: CdnAssetMetadata._intFromJson(decoded['updatedAt']),
+      assets: assets,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        if (updatedAt != null) 'updatedAt': updatedAt,
+        'assets': assets.map(
+          (key, value) => MapEntry(key, value.toJson()),
+        ),
+      };
+}
+
+class CdnAssetCacheFile {
+  const CdnAssetCacheFile({
+    this.manifest,
+    this.cacheStates = const {},
+  });
+
+  final CdnAssetManifest? manifest;
+  final Map<String, CdnAssetCacheState> cacheStates;
+
+  factory CdnAssetCacheFile.fromJsonString(String jsonString) {
+    final decoded = jsonDecode(jsonString);
+    if (decoded is! Map) {
+      throw const FormatException('Asset cache root is not a JSON object.');
+    }
+
+    final manifest = CdnAssetManifest.fromJson(decoded);
+    final cacheStates = <String, CdnAssetCacheState>{};
+    final rawAssets = decoded['assets'];
+    if (rawAssets is Map) {
+      rawAssets.forEach((key, value) {
+        if (value is Map) {
+          final fileName = key.toString();
+          final metadata = manifest.assets[fileName];
+          if (metadata == null) return;
+          final cacheState = CdnAssetCacheState.fromJson(
+            value['cache'],
+            hash: metadata.hash,
+          );
+          if (cacheState != null) {
+            cacheStates[fileName] = cacheState;
+          }
+        }
+      });
+    }
+
+    return CdnAssetCacheFile(
+      manifest: manifest.assets.isEmpty ? null : manifest,
+      cacheStates: cacheStates,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final json = manifest?.toJson() ?? <String, dynamic>{'assets': {}};
+    final assets = json['assets'];
+    if (assets is Map) {
+      cacheStates.forEach((key, value) {
+        final asset = assets[key];
+        if (asset is Map) {
+          asset['cache'] = value.toJson();
+        }
+      });
+    }
+    return json;
+  }
+}
+
+class EnsembleAssetBundle extends CachingAssetBundle {
+  EnsembleAssetBundle({required this.parent});
+
+  final AssetBundle parent;
+
+  @override
+  Future<ByteData> load(String key) async {
+    final cachedFile = CdnAssetCache.instance.getCachedFileForBundleKey(key);
+    if (cachedFile != null) {
+      final bytes = await cachedFile.readAsBytes();
+      final data = Uint8List.fromList(bytes);
+      return ByteData.view(data.buffer);
+    }
+    return parent.load(key);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    final cachedFile = CdnAssetCache.instance.getCachedFileForBundleKey(key);
+    if (cachedFile != null) {
+      return utf8.decode(await cachedFile.readAsBytes());
+    }
+    return parent.loadString(key, cache: cache);
+  }
+}
+
+class CdnAssetMetadata {
+  const CdnAssetMetadata({
+    required this.hash,
+    required this.size,
+    this.contentType,
+    this.updatedAt,
+  });
+
+  final String hash;
+  final int size;
+  final String? contentType;
+  final int? updatedAt;
+
+  static CdnAssetMetadata? fromJson(dynamic value) {
+    if (value is! Map) return null;
+
+    final hash = value['hash']?.toString().trim();
+    final size = _intFromJson(value['size']);
+    if (hash == null || hash.isEmpty || size == null || size < 0) {
+      return null;
+    }
+
+    return CdnAssetMetadata(
+      hash: hash,
+      size: size,
+      contentType: value['contentType']?.toString(),
+      updatedAt: _intFromJson(value['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'hash': hash,
+        'size': size,
+        if (contentType != null) 'contentType': contentType,
+        if (updatedAt != null) 'updatedAt': updatedAt,
+      };
+
+  static int? _intFromJson(dynamic value) {
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value.trim());
+    return null;
+  }
+}
+
+class CdnAssetCacheState {
+  const CdnAssetCacheState({
+    required this.hash,
+    required this.downloadedAt,
+  });
+
+  /// Manifest hash used as the version/invalidation token.
+  final String hash;
+  final int downloadedAt;
+
+  Map<String, dynamic> toJson() => {
+        'downloadedAt': downloadedAt,
+      };
+
+  static CdnAssetCacheState? fromJson(dynamic value, {required String hash}) {
+    if (value is! Map) return null;
+    final downloadedAt = CdnAssetMetadata._intFromJson(value['downloadedAt']);
+    if (downloadedAt == null) {
+      return null;
+    }
+    return CdnAssetCacheState(
+      hash: hash,
+      downloadedAt: downloadedAt,
+    );
+  }
+}

--- a/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:ensemble/action/action_scope_util.dart';
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/bindings.dart';
+import 'package:ensemble/framework/cdn_asset_cache.dart';
 import 'package:ensemble/framework/definition_providers/provider.dart';
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:encrypt/encrypt.dart' as enc;
@@ -48,6 +49,7 @@ class CdnDefinitionProvider extends DefinitionProvider {
   // HTTP caching (ETag) + freshness
   String? _etag;
   int? _lastUpdatedAt;
+  bool _shouldFetchAssetManifest = false;
 
   // Background update tracking
   bool _hasPendingUpdate = false;
@@ -73,9 +75,13 @@ class CdnDefinitionProvider extends DefinitionProvider {
     // ENSEMBLE_ENCRYPTION_KEY, regardless of whether dotenv was already
     // initialized (e.g. from `.env`).
     await _initEnvFromAssets();
+    await _initializeAssetCache();
 
     await _loadCachedState();
     if (_artifactCache.isNotEmpty) {
+      if (!CdnAssetCache.instance.hasAssetManifest) {
+        await _fetchAndSaveAssetManifest();
+      }
       unawaited(_refreshIfStale());
       return this;
     }
@@ -312,6 +318,7 @@ class CdnDefinitionProvider extends DefinitionProvider {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_artifactCacheKey);
+      await CdnAssetCache.instance.clearAssetManifest(removeCachedAssets: true);
     } catch (e) {
       debugPrint('CdnProvider: Failed to clear cache: $e');
     }
@@ -532,6 +539,10 @@ class CdnDefinitionProvider extends DefinitionProvider {
   Future<void> _doRefreshIfStale() async {
     try {
       final shouldFetch = await _shouldFetchManifest();
+      if (_shouldFetchAssetManifest ||
+          !CdnAssetCache.instance.hasAssetManifest) {
+        await _fetchAndSaveAssetManifest();
+      }
       if (!shouldFetch) {
         return;
       }
@@ -585,6 +596,10 @@ class CdnDefinitionProvider extends DefinitionProvider {
 
   Future<void> _loadManifest() async {
     final shouldFetch = await _shouldFetchManifest();
+    if (_shouldFetchAssetManifest ||
+        !CdnAssetCache.instance.hasAssetManifest) {
+      await _fetchAndSaveAssetManifest();
+    }
     if (!shouldFetch) {
       return;
     }
@@ -610,28 +625,80 @@ class CdnDefinitionProvider extends DefinitionProvider {
     );
   }
 
+  Future<void> _initializeAssetCache() async {
+    try {
+      await CdnAssetCache.instance.initialize(
+        appId: appId,
+        baseUrl: baseUrl,
+        headersProvider: _cdnRequestHeaders,
+      );
+    } catch (e) {
+      debugPrint('CdnProvider: Failed to initialize asset cache: $e');
+    }
+  }
+
+  Future<void> _fetchAndSaveAssetManifest() async {
+    final uri = Uri.parse('$baseUrl/$appId/asset-manifest.json');
+    try {
+      final response = await http.get(uri, headers: await _cdnRequestHeaders());
+      if (response.statusCode == 404) {
+        await CdnAssetCache.instance
+            .clearAssetManifest(removeCachedAssets: true);
+        return;
+      }
+      if (response.statusCode != 200 || response.bodyBytes.isEmpty) {
+        return;
+      }
+
+      final jsonString = _decodePossiblyBrotli(response);
+      if (jsonString == null || jsonString.isEmpty) {
+        return;
+      }
+
+      await CdnAssetCache.instance.saveAssetManifest(
+        _hasEncryptionKey()
+            ? _decryptEncryptedManifestEnvelope(jsonString)
+            : jsonString,
+      );
+    } catch (e) {
+      debugPrint('CdnProvider: Failed to fetch asset manifest: $e');
+    }
+  }
+
   Future<bool> _shouldFetchManifest() async {
     final lastUpdateUri = Uri.parse('$baseUrl/$appId/lastUpdateTime.json');
+    _shouldFetchAssetManifest = false;
 
     try {
       final headers = await _cdnRequestHeaders();
       final resp = await http.get(lastUpdateUri, headers: headers);
       if (resp.statusCode != 200) {
+        _shouldFetchAssetManifest = true;
         return true;
       }
 
       final jsonString = _decodePossiblyBrotli(resp);
       if (jsonString == null || jsonString.isEmpty) {
+        _shouldFetchAssetManifest = true;
         return true;
       }
 
       final lastUpdateData = jsonDecode(jsonString) as Map<String, dynamic>;
       final num? remoteLastUpdateNum = lastUpdateData['lastUpdatedAt'] as num?;
       final int? remoteLastUpdate = remoteLastUpdateNum?.toInt();
+      final num? remoteAssetsUpdateNum =
+          lastUpdateData['assetsUpdatedAt'] as num?;
+      final int? remoteAssetsUpdate = remoteAssetsUpdateNum?.toInt();
 
       if (remoteLastUpdate == null) {
+        _shouldFetchAssetManifest = true;
         return true;
       }
+
+      _shouldFetchAssetManifest = _isIncomingNewer(
+        remoteAssetsUpdate,
+        CdnAssetCache.instance.assetManifestUpdatedAt,
+      );
 
       if (_lastUpdatedAt == null) {
         _lastUpdatedAt = remoteLastUpdate;
@@ -646,6 +713,7 @@ class CdnDefinitionProvider extends DefinitionProvider {
     } catch (e) {
       debugPrint(
           'CdnProvider: Error checking lastUpdateTime: $e, will fetch manifest');
+      _shouldFetchAssetManifest = true;
       return true;
     }
   }

--- a/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
+++ b/modules/ensemble/lib/framework/definition_providers/cdn_provider.dart
@@ -539,11 +539,16 @@ class CdnDefinitionProvider extends DefinitionProvider {
   Future<void> _doRefreshIfStale() async {
     try {
       final shouldFetch = await _shouldFetchManifest();
+      final shouldFetchAssetManifest =
+          _shouldFetchAssetManifest || !CdnAssetCache.instance.hasAssetManifest;
       if (_shouldFetchAssetManifest ||
           !CdnAssetCache.instance.hasAssetManifest) {
         await _fetchAndSaveAssetManifest();
       }
       if (!shouldFetch) {
+        if (shouldFetchAssetManifest) {
+          _fireManifestRefreshEvent();
+        }
         return;
       }
 

--- a/modules/ensemble/lib/util/utils.dart
+++ b/modules/ensemble/lib/util/utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 import 'dart:ui';
@@ -5,6 +6,7 @@ import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/framework/action.dart';
 import 'package:ensemble/framework/assets_service.dart';
+import 'package:ensemble/framework/cdn_asset_cache.dart';
 import 'package:ensemble/framework/ensemble_config_service.dart';
 import 'package:ensemble/framework/stub/location_manager.dart';
 import 'package:ensemble/framework/theme/theme_manager.dart';
@@ -1137,6 +1139,13 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
         String path =
             EnsembleConfigService.config["definitions"]?['local']?["path"];
         return '${path}/assets/${stripQueryParamsFromAsset(asset)}';
+      } else if (provider == 'cdn') {
+        final cachedCdnAsset =
+            CdnAssetCache.instance.getCachedFileIfValid(asset);
+        if (cachedCdnAsset != null) {
+          return cachedCdnAsset.path;
+        }
+        return 'ensemble/assets/${stripQueryParamsFromAsset(asset)}';
       } else {
         return 'ensemble/assets/${stripQueryParamsFromAsset(asset)}';
       }
@@ -1146,7 +1155,20 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
   }
 
   static bool isAssetAvailableLocally(String? fileName) {
-    return LocalAssetsService.localAssets.contains(fileName);
+    if (fileName == null || fileName.isEmpty) return false;
+    if (LocalAssetsService.localAssets.contains(fileName)) {
+      return true;
+    }
+
+    if (CdnAssetCache.instance.getCachedFileIfValid(fileName) != null) {
+      return true;
+    }
+
+    if (CdnAssetCache.instance.isEligible(fileName)) {
+      unawaited(CdnAssetCache.instance.resolve(fileName));
+      return false;
+    }
+    return false;
   }
 
   static bool isMemoryPath(String path) {

--- a/modules/ensemble/test/cdn_asset_cache_test.dart
+++ b/modules/ensemble/test/cdn_asset_cache_test.dart
@@ -1,0 +1,329 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:ensemble/framework/cdn_asset_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  group('CdnAssetCache', () {
+    test('ignores assets that are not listed in asset manifest', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      var requestCount = 0;
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          requestCount++;
+          return http.Response.bytes(const [], 404);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({}));
+
+        final file = await cache.resolve('https://cdn.example.com/logo.png');
+
+        expect(file, isNull);
+        expect(requestCount, 0);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('dedupes downloads and reuses valid cached files', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final bytes = utf8.encode('cached image bytes');
+      final hash = sha256.convert(bytes).toString();
+      var requestCount = 0;
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          requestCount++;
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return http.Response.bytes(bytes, 200);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {'X-Test': '1'},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': hash, 'size': bytes.length},
+        }));
+        expect(_cacheFile(tempDir).existsSync(), isTrue);
+
+        final files = await Future.wait([
+          cache.resolve('https://cdn.example.com/assets/logo.png'),
+          cache.resolve('https://cdn.example.com/assets/logo.png'),
+          cache.resolve('https://cdn.example.com/assets/logo.png'),
+        ]);
+
+        expect(files.whereType<File>(), hasLength(3));
+        expect(files.map((file) => file?.path).toSet(), hasLength(1));
+        expect(requestCount, 1);
+        expect(await files.first!.readAsBytes(), bytes);
+        final cacheJson = jsonDecode(await _cacheFile(tempDir).readAsString());
+        expect(cacheJson['assets']['logo.png']['hash'], hash);
+        expect(cacheJson['assets']['logo.png']['cache']['downloadedAt'],
+            isA<int>());
+
+        final cachedFile = cache
+            .getCachedFileIfValid('https://cdn.example.com/assets/logo.png');
+        expect(cachedFile, isNotNull);
+
+        final secondResolve =
+            await cache.resolve('https://cdn.example.com/assets/logo.png');
+        expect(secondResolve?.path, files.first?.path);
+        expect(requestCount, 1);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('resolves assets by file name for shared Utils callers', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final bytes = utf8.encode('filename lookup bytes');
+      final hash = sha256.convert(bytes).toString();
+      var requestedUri = '';
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          requestedUri = uri.toString();
+          return http.Response.bytes(bytes, 200);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': hash, 'size': bytes.length},
+        }));
+
+        expect(cache.isEligible('logo.png'), isTrue);
+
+        final file = await cache.resolve('logo.png');
+
+        expect(file, isNotNull);
+        expect(requestedUri,
+            'https://cdn.example.com/manifests/apps/app-id/assets/logo.png');
+        expect(cache.getCachedFileIfValid('logo.png')?.path, file?.path);
+        expect(cache.getCachedFileForBundleKey(file!.path)?.path, file.path);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('loads saved manifest on initialize', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final bytes = utf8.encode('saved manifest bytes');
+      final hash = sha256.convert(bytes).toString();
+
+      try {
+        final firstCache = CdnAssetCache(
+          storageDirectoryProvider: () async => tempDir,
+          httpGet: (uri, {headers}) async => http.Response.bytes(bytes, 200),
+        );
+        await firstCache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await firstCache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': hash, 'size': bytes.length},
+        }));
+
+        final secondCache = CdnAssetCache(
+          storageDirectoryProvider: () async => tempDir,
+          httpGet: (uri, {headers}) async => http.Response.bytes(bytes, 200),
+        );
+        await secondCache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+
+        expect(secondCache.hasAssetManifest, isTrue);
+        expect(secondCache.isEligible('logo.png'), isTrue);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('accepts numeric manifest fields encoded as strings', () async {
+      final manifest = CdnAssetManifest.fromJsonString(jsonEncode({
+        'updatedAt': '1718380800000',
+        'assets': {
+          'logo.png': {
+            'hash': 'abc123',
+            'contentType': 'image/png',
+            'size': '42',
+            'updatedAt': '1718370000000',
+          },
+        },
+      }));
+
+      expect(manifest.assets.keys, contains('logo.png'));
+      expect(manifest.assets['logo.png']?.size, 42);
+      expect(manifest.assets['logo.png']?.updatedAt, 1718370000000);
+    });
+
+    test('caches asset when manifest size is stale but hash matches', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final bytes = utf8.encode('asset bytes with stale manifest size');
+      final hash = sha256.convert(bytes).toString();
+      var requestCount = 0;
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          requestCount++;
+          return http.Response.bytes(bytes, 200);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': hash, 'size': bytes.length + 100},
+        }));
+
+        final file = await cache.resolve('logo.png');
+
+        expect(file, isNotNull);
+        expect(await file!.readAsBytes(), bytes);
+        expect(cache.getCachedFileIfValid('logo.png')?.path, file.path);
+
+        final secondResolve = await cache.resolve('logo.png');
+        expect(secondResolve?.path, file.path);
+        expect(requestCount, 1);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('caches served asset when manifest size and hash are stale', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final bytes = utf8.encode('served CDN bytes');
+      final staleManifestHash =
+          sha256.convert(utf8.encode('old bytes')).toString();
+      var requestCount = 0;
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          requestCount++;
+          return http.Response.bytes(bytes, 200);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': staleManifestHash, 'size': bytes.length + 100},
+        }));
+
+        final file = await cache.resolve('logo.png');
+
+        expect(file, isNotNull);
+        expect(await file!.readAsBytes(), bytes);
+        expect(cache.getCachedFileIfValid('logo.png')?.path, file.path);
+
+        final secondResolve = await cache.resolve('logo.png');
+        expect(secondResolve?.path, file.path);
+        expect(requestCount, 1);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('removes cached files when manifest hash changes', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final originalBytes = utf8.encode('original bytes');
+      final originalHash = sha256.convert(originalBytes).toString();
+      final updatedHash =
+          sha256.convert(utf8.encode('updated bytes')).toString();
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async =>
+            http.Response.bytes(originalBytes, 200),
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': originalHash, 'size': originalBytes.length},
+        }));
+
+        final file =
+            await cache.resolve('https://cdn.example.com/assets/logo.png');
+        expect(await file!.exists(), isTrue);
+
+        await cache.saveAssetManifest(_assetManifest({
+          'logo.png': {'hash': updatedHash, 'size': originalBytes.length},
+        }));
+
+        expect(await file.exists(), isFalse);
+        expect(
+          cache.getCachedFileIfValid('https://cdn.example.com/assets/logo.png'),
+          isNull,
+        );
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+  });
+}
+
+String _assetManifest(Map<String, Map<String, Object>> assets) {
+  return jsonEncode({
+    'updatedAt': 1718380800000,
+    'assets': assets.map(
+      (key, value) => MapEntry(key, {
+        'hash': value['hash'],
+        'contentType': 'image/png',
+        'size': value['size'],
+        'updatedAt': 1718370000000,
+      }),
+    ),
+  });
+}
+
+File _cacheFile(Directory root) =>
+    File('${root.path}/asset_cache/asset-cache.json');

--- a/modules/ensemble/test/cdn_asset_cache_test.dart
+++ b/modules/ensemble/test/cdn_asset_cache_test.dart
@@ -64,9 +64,12 @@ void main() {
         expect(_cacheFile(tempDir).existsSync(), isTrue);
 
         final files = await Future.wait([
-          cache.resolve('https://cdn.example.com/assets/logo.png'),
-          cache.resolve('https://cdn.example.com/assets/logo.png'),
-          cache.resolve('https://cdn.example.com/assets/logo.png'),
+          cache.resolve(
+              'https://cdn.example.com/manifests/apps/app-id/assets/logo.png'),
+          cache.resolve(
+              'https://cdn.example.com/manifests/apps/app-id/assets/logo.png'),
+          cache.resolve(
+              'https://cdn.example.com/manifests/apps/app-id/assets/logo.png'),
         ]);
 
         expect(files.whereType<File>(), hasLength(3));
@@ -78,12 +81,12 @@ void main() {
         expect(cacheJson['assets']['logo.png']['cache']['downloadedAt'],
             isA<int>());
 
-        final cachedFile = cache
-            .getCachedFileIfValid('https://cdn.example.com/assets/logo.png');
+        final cachedFile = cache.getCachedFileIfValid(
+            'https://cdn.example.com/manifests/apps/app-id/assets/logo.png');
         expect(cachedFile, isNotNull);
 
-        final secondResolve =
-            await cache.resolve('https://cdn.example.com/assets/logo.png');
+        final secondResolve = await cache.resolve(
+            'https://cdn.example.com/manifests/apps/app-id/assets/logo.png');
         expect(secondResolve?.path, files.first?.path);
         expect(requestCount, 1);
       } finally {
@@ -117,6 +120,7 @@ void main() {
         }));
 
         expect(cache.isEligible('logo.png'), isTrue);
+        expect(cache.isManagedSource('logo.png'), isFalse);
 
         final file = await cache.resolve('logo.png');
 
@@ -125,6 +129,57 @@ void main() {
             'https://cdn.example.com/manifests/apps/app-id/assets/logo.png');
         expect(cache.getCachedFileIfValid('logo.png')?.path, file?.path);
         expect(cache.getCachedFileForBundleKey(file!.path)?.path, file.path);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('uses relative manifest paths to avoid filename collisions', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final iconBytes = utf8.encode('icon logo bytes');
+      final brandingBytes = utf8.encode('branding logo bytes');
+      final iconHash = sha256.convert(iconBytes).toString();
+      final brandingHash = sha256.convert(brandingBytes).toString();
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async {
+          if (uri.path.endsWith('/icons/logo.png')) {
+            return http.Response.bytes(iconBytes, 200);
+          }
+          if (uri.path.endsWith('/branding/logo.png')) {
+            return http.Response.bytes(brandingBytes, 200);
+          }
+          return http.Response.bytes(const [], 404);
+        },
+      );
+
+      try {
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+        await cache.saveAssetManifest(_assetManifest({
+          'icons/logo.png': {'hash': iconHash, 'size': iconBytes.length},
+          'branding/logo.png': {
+            'hash': brandingHash,
+            'size': brandingBytes.length
+          },
+        }));
+
+        final iconFile = await cache.resolve(
+            'https://cdn.example.com/manifests/apps/app-id/assets/icons/logo.png');
+        final brandingFile = await cache.resolve('branding/logo.png');
+
+        expect(iconFile, isNotNull);
+        expect(brandingFile, isNotNull);
+        expect(iconFile!.path, isNot(brandingFile!.path));
+        expect(await iconFile.readAsBytes(), iconBytes);
+        expect(await brandingFile.readAsBytes(), brandingBytes);
+        expect(cache.isEligible('https://other.example.com/assets/logo.png'),
+            isFalse);
       } finally {
         if (tempDir.existsSync()) {
           tempDir.deleteSync(recursive: true);
@@ -200,11 +255,13 @@ void main() {
     });
 
     test('accepts numeric manifest fields encoded as strings', () async {
+      final bytes = utf8.encode('numeric fields asset');
+      final hash = sha256.convert(bytes).toString();
       final manifest = CdnAssetManifest.fromJsonString(jsonEncode({
         'updatedAt': '1718380800000',
         'assets': {
           'logo.png': {
-            'hash': 'abc123',
+            'hash': hash,
             'contentType': 'image/png',
             'size': '42',
             'updatedAt': '1718370000000',
@@ -256,7 +313,8 @@ void main() {
       }
     });
 
-    test('caches served asset when manifest size and hash are stale', () async {
+    test('caches served asset when manifest hash differs from response bytes',
+        () async {
       final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
       final bytes = utf8.encode('served CDN bytes');
       final staleManifestHash =
@@ -285,9 +343,6 @@ void main() {
         expect(file, isNotNull);
         expect(await file!.readAsBytes(), bytes);
         expect(cache.getCachedFileIfValid('logo.png')?.path, file.path);
-
-        final secondResolve = await cache.resolve('logo.png');
-        expect(secondResolve?.path, file.path);
         expect(requestCount, 1);
       } finally {
         if (tempDir.existsSync()) {
@@ -318,8 +373,8 @@ void main() {
           'logo.png': {'hash': originalHash, 'size': originalBytes.length},
         }));
 
-        final file =
-            await cache.resolve('https://cdn.example.com/assets/logo.png');
+        final file = await cache.resolve(
+            'https://cdn.example.com/manifests/apps/app-id/assets/logo.png');
         expect(await file!.exists(), isTrue);
 
         await cache.saveAssetManifest(_assetManifest({
@@ -328,7 +383,8 @@ void main() {
 
         expect(await file.exists(), isFalse);
         expect(
-          cache.getCachedFileIfValid('https://cdn.example.com/assets/logo.png'),
+          cache.getCachedFileIfValid(
+              'https://cdn.example.com/manifests/apps/app-id/assets/logo.png'),
           isNull,
         );
       } finally {

--- a/modules/ensemble/test/cdn_asset_cache_test.dart
+++ b/modules/ensemble/test/cdn_asset_cache_test.dart
@@ -170,6 +170,35 @@ void main() {
       }
     });
 
+    test('removes stale cache temp files on initialize', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
+      final staleTempFile = File(
+        '${tempDir.path}/asset_cache/asset-cache.json.tmp-123',
+      );
+      final cache = CdnAssetCache(
+        storageDirectoryProvider: () async => tempDir,
+        httpGet: (uri, {headers}) async => http.Response.bytes(const [], 404),
+      );
+
+      try {
+        await staleTempFile.parent.create(recursive: true);
+        await staleTempFile.writeAsString('{}');
+        expect(await staleTempFile.exists(), isTrue);
+
+        await cache.initialize(
+          appId: 'app-id',
+          baseUrl: 'https://cdn.example.com/manifests/apps',
+          headersProvider: () async => const {},
+        );
+
+        expect(await staleTempFile.exists(), isFalse);
+      } finally {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
     test('accepts numeric manifest fields encoded as strings', () async {
       final manifest = CdnAssetManifest.fromJsonString(jsonEncode({
         'updatedAt': '1718380800000',

--- a/modules/ensemble/test/cdn_asset_cache_test.dart
+++ b/modules/ensemble/test/cdn_asset_cache_test.dart
@@ -351,16 +351,22 @@ void main() {
       }
     });
 
-    test('removes cached files when manifest hash changes', () async {
+    test('refreshes cached files when manifest hash changes', () async {
       final tempDir = await Directory.systemTemp.createTemp('cdn_asset_cache_');
       final originalBytes = utf8.encode('original bytes');
+      final updatedBytes = utf8.encode('updated bytes');
       final originalHash = sha256.convert(originalBytes).toString();
-      final updatedHash =
-          sha256.convert(utf8.encode('updated bytes')).toString();
+      final updatedHash = sha256.convert(updatedBytes).toString();
+      var requestCount = 0;
       final cache = CdnAssetCache(
         storageDirectoryProvider: () async => tempDir,
-        httpGet: (uri, {headers}) async =>
-            http.Response.bytes(originalBytes, 200),
+        httpGet: (uri, {headers}) async {
+          requestCount++;
+          return http.Response.bytes(
+            requestCount == 1 ? originalBytes : updatedBytes,
+            200,
+          );
+        },
       );
 
       try {
@@ -381,12 +387,14 @@ void main() {
           'logo.png': {'hash': updatedHash, 'size': originalBytes.length},
         }));
 
-        expect(await file.exists(), isFalse);
+        expect(await file.exists(), isTrue);
+        expect(await file.readAsBytes(), updatedBytes);
         expect(
           cache.getCachedFileIfValid(
               'https://cdn.example.com/manifests/apps/app-id/assets/logo.png'),
-          isNull,
+          isNotNull,
         );
+        expect(requestCount, 2);
       } finally {
         if (tempDir.existsSync()) {
           tempDir.deleteSync(recursive: true);


### PR DESCRIPTION
## Description

Adds local caching for CDN-managed runtime assets so eligible assets can be reused from disk after first load, while preserving existing behavior for bundled/local assets and non-Ensemble external URLs.

## Related Issue

Fixes #2280

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added a CDN asset cache service that loads `asset-manifest.json`, stores CDN-managed assets locally, dedupes in-flight downloads, and evicts stale cached files when manifest hashes change.
- Integrated cached CDN assets through shared asset helpers and `DefaultAssetBundle` via `EnsembleAssetBundle`, so image/SVG/Lottie and other asset consumers can resolve cached files without widget-specific CDN logic.
- Fetches `asset-manifest.json` based on `assetsUpdatedAt` and supports decrypting encrypted asset manifests using `ENSEMBLE_ENCRYPTION_KEY`.
- Stores asset manifest and download state in a single `asset-cache.json` file with minimal cache metadata.
- Added focused tests for manifest parsing, cache reuse, stale asset cleanup, duplicate download prevention, and stale CDN metadata handling.

## How to Test

1. Run `flutter test test/cdn_asset_cache_test.dart test/cdn_provider_test.dart --reporter compact` from `modules/ensemble`.
2. Configure the starter app with CDN definitions and verify CDN-managed assets render on first load and are cached locally for subsequent loads.
3. Update an asset on the CDN and verify the stale local file is evicted and the updated asset is rendered.

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [x] I have run `flutter test` and all tests pass
- [x] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors