### PR TITLE
Support .env.assets for local asset variables

### DIFF
--- a/modules/ensemble/lib/framework/assets_service.dart
+++ b/modules/ensemble/lib/framework/assets_service.dart
@@ -7,6 +7,9 @@ class LocalAssetsService {
   static List<String> localAssets = [];
   static bool _isInitialized = false;
 
+  /// Builds the env map used for local asset discovery.
+  /// Values from `.env.assets` intentionally override app config values so
+  /// local assets can replace remote URLs during local development.
   static Map<String, dynamic> mergeAssetEnvVariables(
     Map<String, dynamic>? envVariables,
     Iterable<Map<String, String>> envAssetSources,
@@ -21,6 +24,8 @@ class LocalAssetsService {
     return assetEnvVariables;
   }
 
+  /// Scans configured asset environment values and records only the assets
+  /// that are actually bundled with the app.
   static Future<void> initialize(
       Map<String, dynamic>? envVariables, YamlMap definations) async {
     final Map<String, String> envAssets = await _loadEnvAssets(definations);
@@ -55,6 +60,7 @@ class LocalAssetsService {
     _isInitialized = true;
   }
 
+  /// `.env.assets` is only supported for bundled local definitions
   static Future<Map<String, String>> _loadEnvAssets(YamlMap definations) async {
     try {
       String provider = definations['definitions']?['from'];
@@ -73,6 +79,7 @@ class LocalAssetsService {
     }
   }
 
+  /// Returns whether a candidate asset path can be loaded from Flutter's bundle.
   static Future<bool> _assetExists(String path) async {
     try {
       await rootBundle.load(path);
@@ -82,5 +89,6 @@ class LocalAssetsService {
     }
   }
 
+  /// Used by startup code to avoid repeating bundle scans.
   static bool get isInitialized => _isInitialized;
 }

--- a/modules/ensemble/lib/framework/assets_service.dart
+++ b/modules/ensemble/lib/framework/assets_service.dart
@@ -1,3 +1,4 @@
+import 'package:ensemble/framework/dotenv_bundle.dart';
 import 'package:ensemble/util/utils.dart';
 import 'package:flutter/services.dart';
 import 'package:yaml/yaml.dart';
@@ -6,11 +7,34 @@ class LocalAssetsService {
   static List<String> localAssets = [];
   static bool _isInitialized = false;
 
+  static Map<String, dynamic> mergeAssetEnvVariables(
+    Map<String, dynamic>? envVariables,
+    Iterable<Map<String, String>> envAssetSources,
+  ) {
+    final Map<String, dynamic> assetEnvVariables = {};
+    if (envVariables != null) {
+      assetEnvVariables.addAll(envVariables);
+    }
+    for (final source in envAssetSources) {
+      assetEnvVariables.addAll(source);
+    }
+    return assetEnvVariables;
+  }
+
   static Future<void> initialize(
       Map<String, dynamic>? envVariables, YamlMap definations) async {
+    final Map<String, String> envAssets = await _loadEnvAssets(definations);
+    if (envVariables != null && envAssets.isNotEmpty) {
+      envVariables.addAll(envAssets);
+    }
+    final Map<String, dynamic> assetEnvVariables = mergeAssetEnvVariables(
+      envVariables,
+      [envAssets],
+    );
+
     List<String> foundAssets = [];
-    if (envVariables != null) {
-      for (var entry in envVariables.entries) {
+    if (assetEnvVariables.isNotEmpty) {
+      for (var entry in assetEnvVariables.entries) {
         String assetName =
             Utils.getAssetName(entry.value); // Get the asset name
         String provider = definations['definitions']?['from'];
@@ -29,6 +53,24 @@ class LocalAssetsService {
 
     localAssets = foundAssets;
     _isInitialized = true;
+  }
+
+  static Future<Map<String, String>> _loadEnvAssets(YamlMap definations) async {
+    try {
+      String provider = definations['definitions']?['from'];
+      if (provider != 'local') {
+        return {};
+      }
+      String path = definations['definitions']?['local']['path'];
+      if (path.endsWith('/')) {
+        path = path.substring(0, path.length - 1);
+      }
+      final String assetPath = '$path/.env.assets';
+      final String content = await rootBundle.loadString(assetPath);
+      return parseDotEnvBundleContent(content);
+    } catch (_) {
+      return {};
+    }
   }
 
   static Future<bool> _assetExists(String path) async {

--- a/modules/ensemble/test/assets_service_test.dart
+++ b/modules/ensemble/test/assets_service_test.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ensemble/framework/assets_service.dart';
+import 'package:ensemble/framework/dotenv_bundle.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', null);
+    LocalAssetsService.localAssets = [];
+  });
+
+  group('LocalAssetsService.mergeAssetEnvVariables', () {
+    test('keeps app config env variables when there are no asset env sources',
+        () {
+      expect(
+        LocalAssetsService.mergeAssetEnvVariables(
+          {
+            'remoteLogo': 'https://example.com/logo.png',
+            'emptyPrefix': null,
+          },
+          const [],
+        ),
+        {
+          'remoteLogo': 'https://example.com/logo.png',
+          'emptyPrefix': null,
+        },
+      );
+    });
+
+    test('asset env sources override app config env variables', () {
+      expect(
+        LocalAssetsService.mergeAssetEnvVariables(
+          {'logo': 'https://example.com/logo.png'},
+          [
+            {'logo': 'logo.png'},
+          ],
+        ),
+        {'logo': 'logo.png'},
+      );
+    });
+
+    test('later asset env sources override earlier ones', () {
+      expect(
+        LocalAssetsService.mergeAssetEnvVariables(
+          {'logo': 'https://example.com/logo.png'},
+          [
+            {'logo': 'local-logo.png'},
+            {'logo': 'bundled-logo.png'},
+            {'icon': 'icon.png'},
+          ],
+        ),
+        {
+          'logo': 'bundled-logo.png',
+          'icon': 'icon.png',
+        },
+      );
+    });
+
+    test('merges parsed dotenv asset content', () {
+      expect(
+        LocalAssetsService.mergeAssetEnvVariables(
+          {'logo': 'https://example.com/logo.png'},
+          [
+            parseDotEnvBundleContent('''
+logo=local-logo.png
+icon="icons/app icon.png"
+'''),
+          ],
+        ),
+        {
+          'logo': 'local-logo.png',
+          'icon': 'icons/app icon.png',
+        },
+      );
+    });
+  });
+
+  group('LocalAssetsService.initialize', () {
+    test('loads .env.assets into provided env variables', () async {
+      const String path = 'ensemble/apps/helloApp';
+      final Map<String, String> assets = {
+        '$path/.env.assets': '''
+assets=
+logo_svg=logo.svg
+''',
+        '$path/assets/logo.svg': '<svg></svg>',
+      };
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler('flutter/assets', (ByteData? message) async {
+        final String key = utf8.decode(message!.buffer.asUint8List());
+        final String? asset = assets[key];
+        if (asset == null) {
+          return null;
+        }
+        final Uint8List encoded = Uint8List.fromList(utf8.encode(asset));
+        return ByteData.sublistView(encoded);
+      });
+
+      final Map<String, dynamic> envVariables = {
+        'apiURL': 'https://dummyjson.com',
+      };
+      final YamlMap definitions = loadYaml('''
+definitions:
+  from: local
+  local:
+    path: $path
+''');
+
+      await LocalAssetsService.initialize(envVariables, definitions);
+
+      expect(envVariables, {
+        'apiURL': 'https://dummyjson.com',
+        'assets': '',
+        'logo_svg': 'logo.svg',
+      });
+      expect(LocalAssetsService.localAssets, contains('logo.svg'));
+    });
+
+    test('does not mutate env variables when .env.assets is missing', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler('flutter/assets', (_) async => null);
+
+      final Map<String, dynamic> envVariables = {
+        'apiURL': 'https://dummyjson.com',
+      };
+      final YamlMap definitions = loadYaml('''
+definitions:
+  from: local
+  local:
+    path: ensemble/apps/missingAssetsApp
+''');
+
+      await LocalAssetsService.initialize(envVariables, definitions);
+
+      expect(envVariables, {'apiURL': 'https://dummyjson.com'});
+      expect(LocalAssetsService.localAssets, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds support for keeping local asset environment entries in `.env.assets`, separate from `.env.config`, while preserving existing local asset resolution behavior.

## Related Issue

Fixes #2303

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Load `.env.assets` during local asset initialization for local definitions.
- Merge `.env.assets` values into existing env variables so `${env.*}` asset references resolve.
- Add focused tests for merge behavior, missing `.env.assets`, and local asset discovery.

## How to Test

1. Run `flutter test test/assets_service_test.dart` from `modules/ensemble`.
2. Configure a local app with `.env.assets`.
3. Reference asset values with `${env.assets}${env.logo_svg}` and verify the local asset loads.

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [x] I have run `flutter test` and all tests pass
- [x] I have tested my changes on the relevant platform(s)
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors