### PR TITLE
feat: add indicatorSpacing, indicatorLeadingWidget, and indicatorTrailingWidget to Carousel

### DIFF
--- a/modules/ensemble/assets/schema/ensemble_schema.json
+++ b/modules/ensemble/assets/schema/ensemble_schema.json
@@ -3460,6 +3460,18 @@
                     "indicatorPadding": {
                       "$ref": "#/$defs/Padding-payload",
                       "description": "The padding around the indicator"
+                    },
+                    "indicatorSpacing": {
+                      "type": "integer",
+                      "description": "The spacing between the side widgets and the indicator row or column"
+                    },
+                    "indicatorLeadingWidget": {
+                      "type": "object",
+                      "description": "Widget displayed before the indicator row or column"
+                    },
+                    "indicatorTrailingWidget": {
+                      "type": "object",
+                      "description": "Widget displayed after the indicator row or column"
                     }
                   }
                 }

--- a/modules/ensemble/assets/schema/ensemble_schema.json
+++ b/modules/ensemble/assets/schema/ensemble_schema.json
@@ -3461,10 +3461,6 @@
                       "$ref": "#/$defs/Padding-payload",
                       "description": "The padding around the indicator"
                     },
-                    "indicatorSpacing": {
-                      "type": "integer",
-                      "description": "The spacing between the side widgets and the indicator row or column"
-                    },
                     "indicatorLeadingWidget": {
                       "type": "object",
                       "description": "Widget displayed before the indicator row or column"

--- a/modules/ensemble/lib/widget/carousel.dart
+++ b/modules/ensemble/lib/widget/carousel.dart
@@ -70,6 +70,8 @@ class Carousel extends StatefulWidget
           _controller.indicatorMargin = Utils.getInsets(value),
       'indicatorPadding': (value) =>
           _controller.indicatorPadding = Utils.getInsets(value),
+      'indicatorSpacing': (value) =>
+          _controller.indicatorSpacing = Utils.optionalInt(value, min: 0),
       'indicatorColor': (value) =>
           _controller.indicatorColor = Utils.getColor(value),
       'currentIndex': (value) =>
@@ -85,6 +87,10 @@ class Carousel extends StatefulWidget
       'indicatorWidget': (widget) => _controller.indicatorWidget = widget,
       'selectedIndicatorWidget': (widget) =>
           _controller.selectedIndicatorWidget = widget,
+      'indicatorLeadingWidget': (widget) =>
+          _controller.indicatorLeadingWidget = widget,
+      'indicatorTrailingWidget': (widget) =>
+          _controller.indicatorTrailingWidget = widget,
       'aspectRatio': (value) =>
           _controller.aspectRatio = Utils.optionalDouble(value),
       'autoPlayAnimationDuration': (value) =>
@@ -173,6 +179,7 @@ class MyController extends BoxController {
   int? indicatorHeight;
   EdgeInsets? indicatorMargin;
   EdgeInsets? indicatorPadding;
+  int? indicatorSpacing;
   Color? indicatorColor;
   bool? autoplay;
   bool? enableLoop;
@@ -192,6 +199,8 @@ class MyController extends BoxController {
   // Custom Widget
   dynamic indicatorWidget;
   dynamic selectedIndicatorWidget;
+  dynamic indicatorLeadingWidget;
+  dynamic indicatorTrailingWidget;
 
   // for single view the current item index is dispatched,
   // for multi view this dispatch when clicking on a card
@@ -213,6 +222,8 @@ class CarouselState extends EWidgetState<Carousel>
 
   Widget? customIndicator;
   Widget? selectedCustomIndicator;
+  Widget? leadingIndicatorWidget;
+  Widget? trailingIndicatorWidget;
 
   int indicatorIndex = 0;
 
@@ -371,6 +382,10 @@ class CarouselState extends EWidgetState<Carousel>
         _buildIndicatorWidget(widget._controller.indicatorWidget, scopeManager);
     selectedCustomIndicator = _buildIndicatorWidget(
         widget._controller.selectedIndicatorWidget, scopeManager);
+    leadingIndicatorWidget = _buildIndicatorWidget(
+        widget._controller.indicatorLeadingWidget, scopeManager);
+    trailingIndicatorWidget = _buildIndicatorWidget(
+        widget._controller.indicatorTrailingWidget, scopeManager);
 
     // if we should display one at a time or multiple in the slider
     bool singleView = isSingleView();
@@ -398,6 +413,40 @@ class CarouselState extends EWidgetState<Carousel>
     if (widget._controller.indicatorType != null &&
         widget._controller.indicatorType != IndicatorType.none) {
       List<Widget> indicators = buildIndicators(items);
+      final bool isVertical =
+          widget._controller.direction == Axis.vertical.name;
+      final Widget indicatorRow = isVertical
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: indicators,
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: indicators,
+            );
+
+      final List<Widget> indicatorChildren = [];
+      final double indicatorSpacing =
+          (widget._controller.indicatorSpacing ?? 2).toDouble();
+      final Widget indicatorSpacer = isVertical
+          ? SizedBox(height: indicatorSpacing)
+          : SizedBox(width: indicatorSpacing);
+
+      if (leadingIndicatorWidget != null) {
+        indicatorChildren.add(leadingIndicatorWidget!);
+        if (indicators.isNotEmpty) {
+          indicatorChildren.add(indicatorSpacer);
+        }
+      }
+
+      indicatorChildren.add(indicatorRow);
+
+      if (trailingIndicatorWidget != null) {
+        if (indicators.isNotEmpty) {
+          indicatorChildren.add(indicatorSpacer);
+        }
+        indicatorChildren.add(trailingIndicatorWidget!);
+      }
 
       List<Widget> children = [
         carousel,
@@ -407,15 +456,19 @@ class CarouselState extends EWidgetState<Carousel>
                 widget._controller.indicatorPosition ?? Alignment.bottomCenter,
             child: Padding(
               padding: widget._controller.indicatorPadding ?? EdgeInsets.zero,
-              child: widget._controller.direction == Axis.vertical.name
-                  ? Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: indicators,
-                    )
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: indicators,
-                    ),
+              child: indicatorChildren.length == 1
+                  ? indicatorChildren.first
+                  : widget._controller.direction == Axis.vertical.name
+                      ? Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: indicatorChildren,
+                        )
+                      : Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: indicatorChildren,
+                        ),
             ),
           ),
         )

--- a/modules/ensemble/lib/widget/carousel.dart
+++ b/modules/ensemble/lib/widget/carousel.dart
@@ -70,8 +70,6 @@ class Carousel extends StatefulWidget
           _controller.indicatorMargin = Utils.getInsets(value),
       'indicatorPadding': (value) =>
           _controller.indicatorPadding = Utils.getInsets(value),
-      'indicatorSpacing': (value) =>
-          _controller.indicatorSpacing = Utils.optionalInt(value, min: 0),
       'indicatorColor': (value) =>
           _controller.indicatorColor = Utils.getColor(value),
       'currentIndex': (value) =>
@@ -179,7 +177,6 @@ class MyController extends BoxController {
   int? indicatorHeight;
   EdgeInsets? indicatorMargin;
   EdgeInsets? indicatorPadding;
-  int? indicatorSpacing;
   Color? indicatorColor;
   bool? autoplay;
   bool? enableLoop;
@@ -426,25 +423,14 @@ class CarouselState extends EWidgetState<Carousel>
             );
 
       final List<Widget> indicatorChildren = [];
-      final double indicatorSpacing =
-          (widget._controller.indicatorSpacing ?? 2).toDouble();
-      final Widget indicatorSpacer = isVertical
-          ? SizedBox(height: indicatorSpacing)
-          : SizedBox(width: indicatorSpacing);
 
       if (leadingIndicatorWidget != null) {
         indicatorChildren.add(leadingIndicatorWidget!);
-        if (indicators.isNotEmpty) {
-          indicatorChildren.add(indicatorSpacer);
-        }
       }
 
       indicatorChildren.add(indicatorRow);
 
       if (trailingIndicatorWidget != null) {
-        if (indicators.isNotEmpty) {
-          indicatorChildren.add(indicatorSpacer);
-        }
         indicatorChildren.add(trailingIndicatorWidget!);
       }
 


### PR DESCRIPTION
## Description

This PR adds three new properties to the Carousel widget to enhance indicator customization:

- **indicatorLeadingWidget**: A custom widget displayed before the indicator row or column.
- **indicatorTrailingWidget**: A custom widget displayed after the indicator row or column.

These additions allow developers to place custom widgets alongside the carousel indicators for richer UI interactions.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `indicatorLeadingWidget`, and `indicatorTrailingWidget` fields to the Carousel schema definition (`ensemble_schema.json`)
- Implemented the corresponding controller fields and state widget builders in `carousel.dart`
- Updated the indicator rendering logic to support leading/trailing widgets with configurable spacing

## How to Test

1. Add `indicatorLeadingWidget` and/or `indicatorTrailingWidget` to a Carousel widget definition
3. Verify the widgets render correctly in both horizontal and vertical orientations

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings or errors