### PR TITLE
feat: add TV focus support for Switch widget

### DIFF
--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -1121,10 +1121,12 @@ class _TVFocusOnlyWrapper extends StatefulWidget {
   const _TVFocusOnlyWrapper({
     required this.child,
     required this.boxController,
+    this.paintFocusBorderInForeground = false,
   });
 
   final Widget child;
   final BoxController boxController;
+  final bool paintFocusBorderInForeground;
 
   @override
   State<_TVFocusOnlyWrapper> createState() => _TVFocusOnlyWrapperState();
@@ -1280,15 +1282,19 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
     final focusAnimationDuration = stylingResolver.focusAnimationDuration;
 
     // Build focus indicator content
+    final focusDecoration = BoxDecoration(
+      border: Border.all(
+        color: _hasFocus ? focusBorderColor : Colors.transparent,
+        width: focusBorderWidth,
+      ),
+      borderRadius: borderRadius,
+    );
+
     Widget focusIndicatorContent = AnimatedContainer(
       duration: focusAnimationDuration,
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: _hasFocus ? focusBorderColor : Colors.transparent,
-          width: focusBorderWidth,
-        ),
-        borderRadius: borderRadius,
-      ),
+      decoration: widget.paintFocusBorderInForeground ? null : focusDecoration,
+      foregroundDecoration:
+          widget.paintFocusBorderInForeground ? focusDecoration : null,
       child: widget.child,
     );
 
@@ -1467,6 +1473,40 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
       // Register the hasFocus-tracking node itself (Case 1); see _scopeNode.
       primaryFocusNode: _scopeNode,
       child: wrappedChild,
+    );
+  }
+}
+
+class TVFocusOnlyBoxWrapper extends StatelessWidget {
+  const TVFocusOnlyBoxWrapper({
+    super.key,
+    required this.child,
+    required this.boxController,
+    this.paintFocusBorderInForeground = false,
+  });
+
+  final Widget child;
+  final BoxController boxController;
+  final bool paintFocusBorderInForeground;
+
+  @override
+  Widget build(BuildContext context) {
+    if (Device().isTV && boxController.tvOptions?.isEnabled == true) {
+      return wrapWithTVFocusContext(
+        context: context,
+        tvOptions: boxController.tvOptions,
+        child: _TVFocusOnlyWrapper(
+          boxController: boxController,
+          paintFocusBorderInForeground: paintFocusBorderInForeground,
+          child: child,
+        ),
+      );
+    }
+
+    return wrapWithTVFocusContext(
+      context: context,
+      tvOptions: boxController.tvOptions,
+      child: child,
     );
   }
 }

--- a/modules/ensemble/lib/widget/helpers/input_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/input_wrapper.dart
@@ -15,11 +15,13 @@ class InputWrapper extends StatelessWidget {
       {super.key,
       required this.type,
       required this.widget,
-      required this.controller});
+      required this.controller,
+      this.wrapTVFocus = true});
 
   final String type;
   final Widget widget;
   final FormFieldController controller;
+  final bool wrapTVFocus;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +51,9 @@ class InputWrapper extends StatelessWidget {
     }
 
     // TV focus support for form fields
-    if (Device().isTV && controller.tvOptions?.isEnabled == true) {
+    if (Device().isTV &&
+        controller.tvOptions?.isEnabled == true &&
+        wrapTVFocus) {
       rtn = _wrapWithTVFocus(context, rtn);
     }
 

--- a/modules/ensemble/lib/widget/switch.dart
+++ b/modules/ensemble/lib/widget/switch.dart
@@ -1,7 +1,10 @@
 import 'package:ensemble/framework/event.dart';
+import 'package:ensemble/framework/device.dart';
 import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
+import 'package:ensemble/widget/helpers/box_wrapper.dart';
+import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble/widget/helpers/input_wrapper.dart';
 import 'package:ensemble/widget/helpers/form_helper.dart';
 import 'package:ensemble/framework/action.dart' as framework;
@@ -103,7 +106,19 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
       )));
     }
 
-    children.add(widget is EnsembleSwitch ? switchWidget : tripleSwitch);
+    final Widget control =
+        widget is EnsembleSwitch ? switchWidget : tripleSwitch;
+    final bool tvFocusOnControl =
+        Device().isTV && widget._controller.tvOptions?.isEnabled == true;
+    children.add(
+      tvFocusOnControl
+          ? TVFocusOnlyBoxWrapper(
+              boxController: _SwitchTVFocusBoxController(widget._controller),
+              paintFocusBorderInForeground: true,
+              child: control,
+            )
+          : control,
+    );
 
     if (widget._controller.trailingText != null) {
       children.add(Expanded(
@@ -119,6 +134,7 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
           ? EnsembleSwitch.type
           : EnsembleTripleSwitch.type,
       controller: widget._controller,
+      wrapTVFocus: !tvFocusOnControl,
       widget: FormField<bool>(
         key: validatorKey,
         validator: (value) {
@@ -222,6 +238,23 @@ class SwitchBaseState extends FormFieldWidgetState<SwitchBase> {
         return widget._controller.inactiveThumbColor;
       },
     );
+    final bool tvFocusedSwitch =
+        Device().isTV && widget._controller.tvOptions?.isEnabled == true;
+    if (tvFocusedSwitch) {
+      return _TVSwitchControl(
+        value: widget._controller.value == true,
+        enabled: isEnabled(),
+        activeTrackColor: widget._controller.activeColor,
+        inactiveTrackColor: widget._controller.inactiveColor,
+        activeThumbColor: widget._controller.activeThumbColor,
+        inactiveThumbColor: widget._controller.inactiveThumbColor,
+        onChanged: (value) {
+          (widget as EnsembleSwitch?)?.onToggle(value);
+          onChange();
+        },
+      );
+    }
+
     return Switch(
         trackColor: trackColor,
         thumbColor: thumbColor,
@@ -256,6 +289,123 @@ class SwitchBaseController extends FormFieldController {
   bool useIOSStyle = false;
 
   framework.EnsembleAction? onChange;
+}
+
+class _SwitchTVFocusBoxController extends BoxController {
+  _SwitchTVFocusBoxController(SwitchBaseController source) : _source = source {
+    tvOptions = source.tvOptions;
+    borderColor = source.borderColor;
+    borderWidth = source.borderWidth;
+    borderRadius = source.borderRadius;
+    opacity = source.opacity;
+    elevation = source.elevation;
+    elevationShadowColor = source.elevationShadowColor;
+    elevationBorderRadius = source.elevationBorderRadius;
+    id = source.id;
+    autofocus = source.autofocus;
+  }
+
+  final SwitchBaseController _source;
+
+  @override
+  bool get hasFocus => _source.hasFocus;
+
+  @override
+  set hasFocus(bool value) => _source.hasFocus = value;
+}
+
+class _TVSwitchControl extends StatelessWidget {
+  const _TVSwitchControl({
+    required this.value,
+    required this.enabled,
+    required this.onChanged,
+    this.activeTrackColor,
+    this.inactiveTrackColor,
+    this.activeThumbColor,
+    this.inactiveThumbColor,
+  });
+
+  static const double _width = 52;
+  static const double _height = 32;
+  static const double _thumbSize = 24;
+  static const double _thumbInset = 4;
+
+  final bool value;
+  final bool enabled;
+  final ValueChanged<bool> onChanged;
+  final Color? activeTrackColor;
+  final Color? inactiveTrackColor;
+  final Color? activeThumbColor;
+  final Color? inactiveThumbColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final switchTheme = SwitchTheme.of(context);
+    final activeStates = <WidgetState>{WidgetState.selected};
+    final inactiveStates = <WidgetState>{};
+    if (!enabled) {
+      activeStates.add(WidgetState.disabled);
+      inactiveStates.add(WidgetState.disabled);
+    }
+
+    final trackColor = value
+        ? activeTrackColor ??
+            switchTheme.trackColor?.resolve(activeStates) ??
+            Theme.of(context).colorScheme.primary
+        : inactiveTrackColor ??
+            switchTheme.trackColor?.resolve(inactiveStates) ??
+            const Color(0xFF777777);
+    final thumbColor = value
+        ? activeThumbColor ??
+            switchTheme.thumbColor?.resolve(activeStates) ??
+            Colors.white
+        : inactiveThumbColor ??
+            switchTheme.thumbColor?.resolve(inactiveStates) ??
+            Colors.white;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        canRequestFocus: enabled,
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        onTap: enabled ? () => onChanged(!value) : null,
+        borderRadius: BorderRadius.circular(_height / 2),
+        child: SizedBox(
+          width: _width,
+          height: _height,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            decoration: BoxDecoration(
+              color: enabled ? trackColor : trackColor.withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(_height / 2),
+            ),
+            child: AnimatedAlign(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              alignment: value ? Alignment.centerRight : Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(_thumbInset),
+                child: Container(
+                  width: _thumbSize,
+                  height: _thumbSize,
+                  decoration: BoxDecoration(
+                    color: enabled
+                        ? thumbColor
+                        : thumbColor.withValues(alpha: 0.7),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class SwitchColors {


### PR DESCRIPTION
## Description

This PR adds TV focus support for the Switch widget, allowing it to properly participate in TV focus navigation with a dedicated focus border rendered in the foreground.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `paintFocusBorderInForeground` option to `_TVFocusOnlyWrapper` to render focus border using `foregroundDecoration` instead of `decoration`
- Created `TVFocusOnlyBoxWrapper` as a reusable StatelessWidget for wrapping any widget with TV focus support
- Added `wrapTVFocus` parameter to `InputWrapper` to prevent double TV focus wrapping when the child already handles it
- Implemented `_TVSwitchControl` and `_SwitchTVFocusBoxController` for TV-focused switch rendering with proper focus border

## How to Test

1. Run the app on a TV platform or TV emulator
2. Navigate to a Switch widget using the remote/d-pad
3. Verify the switch receives focus with a visible focus border painted in the foreground
4. Verify the toggle action still works correctly when focused

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings or errors