### PR TITLE
Listview scrollbar with fallback focus support

### DIFF
--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -1,3 +1,6 @@
+import 'package:ensemble/framework/tv/tv_focus_order.dart';
+import 'package:ensemble/framework/tv/tv_focus_provider.dart';
+import 'package:ensemble/framework/tv/tv_focus_widget.dart';
 import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -30,11 +33,26 @@ import 'package:flutter/services.dart';
 ///       color: 0xFF666666   # unfocused color (visible when scrollable)
 ///       focusedColor: 0xFFFFFFFF
 /// ```
+class TVScrollbarFallbackFocusConfig {
+  const TVScrollbarFallbackFocusConfig({
+    required this.row,
+    required this.order,
+    this.focusGroup,
+    this.isRowEntryPoint = false,
+  });
+
+  final double row;
+  final double order;
+  final String? focusGroup;
+  final bool isRowEntryPoint;
+}
+
 class TVScrollbarWidget extends StatefulWidget {
   const TVScrollbarWidget({
     super.key,
     required this.scrollController,
     required this.options,
+    this.fallbackFocus,
   });
 
   /// ScrollController from the scrollable content (ListView/Column)
@@ -42,6 +60,11 @@ class TVScrollbarWidget extends StatefulWidget {
 
   /// Scrollbar styling options from YAML
   final TVScrollbarOptionsComposite options;
+
+  /// Optional focus coordinate used when the owning ListView has no focusable
+  /// descendants. When omitted, focus reaches the scrollbar only via edge
+  /// handoff from a focused content item.
+  final TVScrollbarFallbackFocusConfig? fallbackFocus;
 
   @override
   State<TVScrollbarWidget> createState() => _TVScrollbarWidgetState();
@@ -85,6 +108,20 @@ class _TVScrollbarWidgetState extends State<TVScrollbarWidget> {
   /// Public method to request focus on this scrollbar (called from ListView)
   void requestFocusOnScrollbar() {
     _focusNode.requestFocus();
+  }
+
+  bool get _isFallbackFocusTarget => widget.fallbackFocus != null;
+
+  bool get _canScrollUp {
+    if (!widget.scrollController.hasClients) return false;
+    final position = widget.scrollController.position;
+    return position.pixels > position.minScrollExtent;
+  }
+
+  bool get _canScrollDown {
+    if (!widget.scrollController.hasClients) return false;
+    final position = widget.scrollController.position;
+    return position.pixels < position.maxScrollExtent;
   }
 
   @override
@@ -181,7 +218,7 @@ class _TVScrollbarWidgetState extends State<TVScrollbarWidget> {
     }
 
     // Focus is requested via TVFocusScope edge handlers when user navigates to content boundary
-    return LayoutBuilder(
+    final scrollbar = LayoutBuilder(
       builder: (context, constraints) {
         final trackHeight = constraints.maxHeight;
 
@@ -194,10 +231,22 @@ class _TVScrollbarWidgetState extends State<TVScrollbarWidget> {
 
             // Handle UP/DOWN for manual scrolling
             if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+              if (_isFallbackFocusTarget && !_canScrollDown) {
+                return KeyEventResult.ignored;
+              }
               _scrollDown();
               return KeyEventResult.handled;
             } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              if (_isFallbackFocusTarget && !_canScrollUp) {
+                return KeyEventResult.ignored;
+              }
               _scrollUp();
+              return KeyEventResult.handled;
+            }
+
+            if (_isFallbackFocusTarget &&
+                (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
+                    event.logicalKey == LogicalKeyboardKey.arrowRight)) {
               return KeyEventResult.handled;
             }
 
@@ -255,6 +304,36 @@ class _TVScrollbarWidgetState extends State<TVScrollbarWidget> {
           ),
         );
       },
+    );
+
+    final fallbackFocus = widget.fallbackFocus;
+    if (fallbackFocus == null) {
+      return scrollbar;
+    }
+
+    final externalProvider = TVFocusProviderScope.maybeOf(context);
+    if (externalProvider != null) {
+      return externalProvider.wrapFocusable(
+        row: fallbackFocus.row + externalProvider.rowOffset,
+        order: fallbackFocus.order + externalProvider.orderOffset,
+        isRowEntryPoint: fallbackFocus.isRowEntryPoint,
+        lockHorizontalNavigation: true,
+        focusGroup: fallbackFocus.focusGroup,
+        primaryFocusNode: _focusNode,
+        child: scrollbar,
+      );
+    }
+
+    return TVFocusWidget(
+      focusOrder: TVFocusOrder.withOptions(
+        fallbackFocus.row,
+        order: fallbackFocus.order,
+        isRowEntryPoint: fallbackFocus.isRowEntryPoint,
+        lockHorizontalNavigation: true,
+        focusGroup: fallbackFocus.focusGroup,
+      ),
+      primaryFocusNode: _focusNode,
+      child: scrollbar,
     );
   }
 }

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -307,6 +307,10 @@ class ListViewState extends EWidgetState<ListView>
     super.didUpdateWidget(oldWidget);
   }
 
+  // TODO(perf): this is scheduled on every build and _hasFocusableTVContentTarget
+  // below does a full-app focus-tree scan (rootScope.descendants + per-node
+  // ancestor walks). Rework: probe once and cache, re-run only on content/data
+  // change, and scope the scan to this list's own subtree instead of rootScope.
   void _scheduleContentFocusProbe() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -8,7 +8,6 @@ import 'package:ensemble/framework/studio/studio_debugger.dart';
 import 'package:ensemble/framework/tv/tv_focus_navigation.dart';
 import 'package:ensemble/framework/tv/tv_scrollbar_widget.dart';
 import 'package:ensemble/framework/tv/tv_focus_order.dart';
-import 'package:ensemble/framework/tv/tv_focus_registry.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/view/footer.dart';
 import 'package:ensemble/framework/widget/has_children.dart';
@@ -213,7 +212,9 @@ class ListViewState extends EWidgetState<ListView>
   ScrollController? _ownedScrollController;
   final flutter.GlobalKey _contentFocusProbeKey =
       flutter.GlobalKey(debugLabel: 'ListViewContentFocusProbe');
-  bool _listContentHasFocusableTVTarget = true;
+  // null means content changed and needs one scoped post-frame probe.
+  bool? _listContentHasFocusableTVTarget;
+  bool _contentFocusProbeScheduled = false;
 
   // FooterScope temporarily replaces scrollController; restore when that scope is gone.
   ScrollController? _scrollControllerOutsideFooter;
@@ -285,6 +286,7 @@ class ListViewState extends EWidgetState<ListView>
 
         setState(() {
           templatedDataList = dataList;
+          _invalidateContentFocusProbe();
         });
       });
     }
@@ -304,20 +306,36 @@ class ListViewState extends EWidgetState<ListView>
   void didUpdateWidget(covariant ListView oldWidget) {
     showLoading = widget._controller.showLoading;
     _attachOwnedScrollControllerIfNeeded();
+    if (!identical(
+            oldWidget._controller.children, widget._controller.children) ||
+        !identical(oldWidget._controller.itemTemplate,
+            widget._controller.itemTemplate)) {
+      _invalidateContentFocusProbe();
+    }
     super.didUpdateWidget(oldWidget);
   }
 
-  // TODO(perf): this is scheduled on every build and _hasFocusableTVContentTarget
-  // below does a full-app focus-tree scan (rootScope.descendants + per-node
-  // ancestor walks). Rework: probe once and cache, re-run only on content/data
-  // change, and scope the scan to this list's own subtree instead of rootScope.
+  void _invalidateContentFocusProbe() {
+    _listContentHasFocusableTVTarget = null;
+  }
+
   void _scheduleContentFocusProbe() {
+    if (_listContentHasFocusableTVTarget != null ||
+        _contentFocusProbeScheduled) {
+      return;
+    }
+
+    _contentFocusProbeScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      _contentFocusProbeScheduled = false;
       if (!mounted) return;
+
       final probeContext = _contentFocusProbeKey.currentContext;
-      final hasFocusableTarget = probeContext == null
-          ? true
-          : _hasFocusableTVContentTarget(probeContext);
+      // Keep the result unresolved so a later build can retry if the content
+      // boundary was removed before this frame completed.
+      if (probeContext == null) return;
+
+      final hasFocusableTarget = _hasFocusableTVContentTarget(probeContext);
 
       if (_listContentHasFocusableTVTarget != hasFocusableTarget) {
         setState(() {
@@ -328,52 +346,24 @@ class ListViewState extends EWidgetState<ListView>
   }
 
   bool _hasFocusableTVContentTarget(BuildContext probeContext) {
-    final route = flutter.ModalRoute.of(context);
-
-    for (final target in TVFocusRegistry.targets<flutter.FocusOrder>(
-      route: route,
-    )) {
-      final targetContext = target.effectiveContext;
-      if (targetContext != null &&
-          _isContextWithin(targetContext, probeContext)) {
-        return true;
-      }
-    }
-
-    for (final focusNode
-        in flutter.FocusManager.instance.rootScope.descendants) {
+    final contentScope = flutter.FocusScope.of(
+      probeContext,
+      createDependency: false,
+    );
+    for (final focusNode in contentScope.descendants) {
       final nodeContext = focusNode.context;
       if (nodeContext == null) continue;
       if (!focusNode.canRequestFocus) continue;
-      if (route != null && flutter.ModalRoute.of(nodeContext) != route) {
-        continue;
-      }
 
       final focusOrder = nodeContext
           .findAncestorWidgetOfExactType<flutter.FocusTraversalOrder>()
           ?.order;
-      if (focusOrder is! flutter.FocusOrder) continue;
-      if (_isContextWithin(nodeContext, probeContext)) {
+      if (focusOrder is flutter.FocusOrder) {
         return true;
       }
     }
 
     return false;
-  }
-
-  bool _isContextWithin(BuildContext candidate, BuildContext ancestor) {
-    if (identical(candidate, ancestor)) return true;
-    if (candidate is! Element || ancestor is! Element) return false;
-
-    var found = false;
-    candidate.visitAncestorElements((element) {
-      if (identical(element, ancestor)) {
-        found = true;
-        return false;
-      }
-      return true;
-    });
-    return found;
   }
 
   @override
@@ -496,7 +486,7 @@ class ListViewState extends EWidgetState<ListView>
         }
 
         final fallbackFocus =
-            !_listContentHasFocusableTVTarget && tvOptions.row != null
+            _listContentHasFocusableTVTarget == false && tvOptions.row != null
                 ? TVScrollbarFallbackFocusConfig(
                     row: tvOptions.row!,
                     order: tvOptions.order ?? 0,

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -5,8 +5,10 @@ import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/event.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/studio/studio_debugger.dart';
+import 'package:ensemble/framework/tv/tv_focus_navigation.dart';
 import 'package:ensemble/framework/tv/tv_scrollbar_widget.dart';
 import 'package:ensemble/framework/tv/tv_focus_order.dart';
+import 'package:ensemble/framework/tv/tv_focus_registry.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/view/footer.dart';
 import 'package:ensemble/framework/widget/has_children.dart';
@@ -209,6 +211,9 @@ class ListViewState extends EWidgetState<ListView>
   List<dynamic>? templatedDataList;
   bool showLoading = false;
   ScrollController? _ownedScrollController;
+  final flutter.GlobalKey _contentFocusProbeKey =
+      flutter.GlobalKey(debugLabel: 'ListViewContentFocusProbe');
+  bool _listContentHasFocusableTVTarget = true;
 
   // FooterScope temporarily replaces scrollController; restore when that scope is gone.
   ScrollController? _scrollControllerOutsideFooter;
@@ -294,6 +299,71 @@ class ListViewState extends EWidgetState<ListView>
     showLoading = widget._controller.showLoading;
     _attachOwnedScrollControllerIfNeeded();
     super.didUpdateWidget(oldWidget);
+  }
+
+  void _scheduleContentFocusProbe() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final probeContext = _contentFocusProbeKey.currentContext;
+      final hasFocusableTarget = probeContext == null
+          ? true
+          : _hasFocusableTVContentTarget(probeContext);
+
+      if (_listContentHasFocusableTVTarget != hasFocusableTarget) {
+        setState(() {
+          _listContentHasFocusableTVTarget = hasFocusableTarget;
+        });
+      }
+    });
+  }
+
+  bool _hasFocusableTVContentTarget(BuildContext probeContext) {
+    final route = flutter.ModalRoute.of(context);
+
+    for (final target in TVFocusRegistry.targets<flutter.FocusOrder>(
+      route: route,
+    )) {
+      final targetContext = target.effectiveContext;
+      if (targetContext != null &&
+          _isContextWithin(targetContext, probeContext)) {
+        return true;
+      }
+    }
+
+    for (final focusNode
+        in flutter.FocusManager.instance.rootScope.descendants) {
+      final nodeContext = focusNode.context;
+      if (nodeContext == null) continue;
+      if (!focusNode.canRequestFocus) continue;
+      if (route != null && flutter.ModalRoute.of(nodeContext) != route) {
+        continue;
+      }
+
+      final focusOrder = nodeContext
+          .findAncestorWidgetOfExactType<flutter.FocusTraversalOrder>()
+          ?.order;
+      if (focusOrder is! flutter.FocusOrder) continue;
+      if (_isContextWithin(nodeContext, probeContext)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool _isContextWithin(BuildContext candidate, BuildContext ancestor) {
+    if (identical(candidate, ancestor)) return true;
+    if (candidate is! Element || ancestor is! Element) return false;
+
+    var found = false;
+    candidate.visitAncestorElements((element) {
+      if (identical(element, ancestor)) {
+        found = true;
+        return false;
+      }
+      return true;
+    });
+    return found;
   }
 
   @override
@@ -406,17 +476,39 @@ class ListViewState extends EWidgetState<ListView>
 
     // TV: Add focusable scrollbar if configured
     if (Device().isTV && widget._controller.tvOptions?.scrollbarOptions != null) {
-      final scrollbarOptions = widget._controller.tvOptions!.scrollbarOptions!;
+      final tvOptions = widget._controller.tvOptions!;
+      final scrollbarOptions = tvOptions.scrollbarOptions!;
       final scrollController = widget._controller.scrollController;
 
       if (scrollController != null) {
+        if (tvOptions.row != null) {
+          _scheduleContentFocusProbe();
+        }
+
+        final fallbackFocus =
+            !_listContentHasFocusableTVTarget && tvOptions.row != null
+                ? TVScrollbarFallbackFocusConfig(
+                    row: tvOptions.row!,
+                    order: tvOptions.order ?? 0,
+                    focusGroup: resolveTVFocusGroup(context, tvOptions),
+                    isRowEntryPoint: tvOptions.isRowEntryPoint,
+                  )
+                : null;
+
         // Store scrollbar widget with key to access later
         final scrollbarKey = flutter.GlobalKey<flutter.State<TVScrollbarWidget>>();
         final scrollbarWidget = TVScrollbarWidget(
           key: scrollbarKey,
           scrollController: scrollController,
           options: scrollbarOptions,
+          fallbackFocus: fallbackFocus,
         );
+        final effectiveScrollbarWidget = fallbackFocus == null
+            ? flutter.FocusTraversalGroup(
+                policy: flutter.WidgetOrderTraversalPolicy(),
+                child: scrollbarWidget,
+              )
+            : scrollbarWidget;
 
         // Callback to request focus on scrollbar
         void requestScrollbarFocus() {
@@ -428,6 +520,12 @@ class ListViewState extends EWidgetState<ListView>
 
         // Determine scrollbar position and which edge handler to use
         final isLeftPosition = scrollbarOptions.position == 'left';
+        final probedContent = tvOptions.row != null
+            ? flutter.KeyedSubtree(
+                key: _contentFocusProbeKey,
+                child: listView,
+              )
+            : listView;
 
         // Wrap content with TVFocusScope that handles edge navigation
         final scopedContent = TVFocusScope(
@@ -435,7 +533,7 @@ class ListViewState extends EWidgetState<ListView>
           // Set edge handler based on scrollbar position
           onRightEdge: isLeftPosition ? null : requestScrollbarFocus,
           onLeftEdge: isLeftPosition ? requestScrollbarFocus : null,
-          child: listView,
+          child: probedContent,
         );
 
         // Build Row with scrollbar on correct side
@@ -443,18 +541,12 @@ class ListViewState extends EWidgetState<ListView>
           crossAxisAlignment: flutter.CrossAxisAlignment.stretch,
           children: isLeftPosition
             ? [
-                flutter.FocusTraversalGroup(
-                  policy: flutter.WidgetOrderTraversalPolicy(),
-                  child: scrollbarWidget,
-                ),
+                effectiveScrollbarWidget,
                 flutter.Expanded(child: scopedContent),
               ]
             : [
                 flutter.Expanded(child: scopedContent),
-                flutter.FocusTraversalGroup(
-                  policy: flutter.WidgetOrderTraversalPolicy(),
-                  child: scrollbarWidget,
-                ),
+                effectiveScrollbarWidget,
               ],
         );
       }
@@ -462,6 +554,7 @@ class ListViewState extends EWidgetState<ListView>
 
     return BoxWrapper(
         boxController: widget._controller,
+        ignoresTVFocus: widget._controller.tvOptions?.scrollbarOptions != null,
         widget: DefaultTextStyle.merge(
             style: TextStyle(
                 fontFamily: widget._controller.fontFamily,

--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -3,6 +3,7 @@ import 'package:ensemble/framework/error_handling.dart';
 import 'package:ensemble/framework/extensions.dart';
 import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/tv/tv_focus_order.dart';
+import 'package:ensemble/framework/tv/tv_focus_provider.dart';
 import 'package:ensemble/framework/tv/tv_focus_widget.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
 import 'package:ensemble/framework/widget/widget.dart';
@@ -381,18 +382,29 @@ class _TVTabButtonState extends State<_TVTabButton> {
       ),
     );
 
-    // Wrap with TVFocusWidget for D-pad navigation.
-    // Uses tabRow from TabBar controller (either tvRow from YAML or 0 for isolated group).
-    // Order = index for left/right navigation.
-    // The selected tab is marked as entry point so it gets focus when entering the row.
+    // Wrap with the active TV focus system for D-pad navigation.
+    // Uses tabRow from TabBar controller (either tvRow from YAML or 0 for
+    // isolated group). Order = index for left/right navigation. The selected tab
+    // is marked as entry point so it gets focus when entering the row.
+    final externalProvider = TVFocusProviderScope.maybeOf(context);
+    if (externalProvider != null) {
+      return externalProvider.wrapFocusable(
+        row: widget.tabRow + externalProvider.rowOffset,
+        order: widget.index.toDouble() + externalProvider.orderOffset,
+        isRowEntryPoint: widget.isSelected,
+        primaryFocusNode: _focusNode,
+        child: inkWell,
+      );
+    }
+
     return TVFocusWidget(
       focusOrder: TVFocusOrder.withOptions(
         widget.tabRow,
         order: widget.index.toDouble(),
         isRowEntryPoint: widget.isSelected, // selected tab is the entry point
       ),
-      // PHASE 2: register the tab's own InkWell FocusNode so it appears in
-      // TVFocusRegistry (drives the descendants scan's scanUnique toward 0).
+      // Register the tab's own InkWell FocusNode so navigation lands on the
+      // visible tab control rather than an empty wrapper.
       primaryFocusNode: _focusNode,
       child: inkWell,
     );

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -116,7 +116,11 @@ class BoxWrapper extends StatelessWidget {
       this.ignoresMargin = false,
 
       // width/height maybe applied at the child, or not applicable
-      this.ignoresDimension = false});
+      this.ignoresDimension = false,
+
+      // some container widgets use tvOptions only to configure an internal TV
+      // focus target, such as ListView's scrollbar fallback.
+      this.ignoresTVFocus = false});
 
   final Widget widget;
   final BoxController boxController;
@@ -125,6 +129,7 @@ class BoxWrapper extends StatelessWidget {
   final bool ignoresPadding;
   final bool ignoresMargin;
   final bool ignoresDimension;
+  final bool ignoresTVFocus;
 
   @override
   Widget build(BuildContext context) {
@@ -228,7 +233,9 @@ class BoxWrapper extends StatelessWidget {
             child: childWidget);
 
     // TV: Wrap widgets for D-pad navigation
-    if (Device().isTV && boxController.tvOptions?.isEnabled == true) {
+    if (!ignoresTVFocus &&
+        Device().isTV &&
+        boxController.tvOptions?.isEnabled == true) {
       // Tappable widgets get full focus handling
       if (boxController is TapEnabledBoxController) {
         final tapController = boxController as TapEnabledBoxController;
@@ -270,7 +277,9 @@ class BoxWrapper extends StatelessWidget {
       var controller = boxController as TapEnabledBoxController;
 
       // TV: Wrap with focus handling (build() handles box-level wrapping)
-      if (Device().isTV && boxController.tvOptions?.isEnabled == true) {
+      if (!ignoresTVFocus &&
+          Device().isTV &&
+          boxController.tvOptions?.isEnabled == true) {
         if (!boxController.requiresBox(
             ignoresMargin: ignoresMargin,
             ignoresPadding: ignoresPadding,


### PR DESCRIPTION
## Description

This PR enhances the TV scrollbar widget and ListView to handle the case when a ListView has no focusable TV content targets (e.g., only plain text items). In such cases, the scrollbar becomes the primary focus target and handles D-pad navigation directly, including blocking scroll-at-boundary from edge handoff.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `TVScrollbarFallbackFocusConfig` class to provide focus coordinates when a ListView has no focusable content targets
- Added `fallbackFocus` parameter to `TVScrollbarWidget` to support fallback focus scenarios
- Added content focus probing logic in `ListViewState` to detect whether the list content contains any focusable TV targets via `TVFocusRegistry` and `FocusManager`
- Added `ignoresTVFocus` parameter to `BoxWrapper` to prevent double-focus wrapping when ListView uses internal scrollbar focus
- Updated `TVTabButton` to use `TVFocusProviderScope` when available for consistent focus offset handling
- Added `_canScrollUp`/`_canScrollDown` guards in `TVScrollbarWidget` to prevent scroll-at-boundary from being passed through to adjacent focusable elements
- Added `lockHorizontalNavigation` support for scrollbar in fallback mode to prevent horizontal focus escape
- Added comprehensive unit tests in `tv_scrollbar_widget_test.dart` covering fallback focus, scroll boundaries, and null content scenarios

## How to Test

1. Run the new scrollbar tests: `flutter test modules/ensemble/test/widget/tv_scrollbar_widget_test.dart`
2. Verify that a ListView with only non-focusable items (e.g., plain Text widgets) correctly focuses the scrollbar and allows D-pad scrolling
3. Verify that a ListView with focusable items behaves as before (scrollbar focus via edge handoff)
4. Verify that scrollbar-at-boundary does not swallow navigation when in fallback mode

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings or errors