### PR TITLE
fix(assets): prefer bundled asset over CDN cache when resolving paths

### DIFF
--- a/modules/ensemble/lib/util/utils.dart
+++ b/modules/ensemble/lib/util/utils.dart
@@ -1137,12 +1137,18 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
             EnsembleConfigService.config["definitions"]?['local']?["path"];
         return '${path}/assets/${stripQueryParamsFromAsset(asset)}';
       } else if (provider == 'cdn') {
+        final assetName = stripQueryParamsFromAsset(asset);
+        // Prefer a bundled asset when present: renders instantly, no download.
+        if (LocalAssetsService.localAssets.contains(assetName)) {
+          return 'ensemble/assets/$assetName';
+        }
+        // Otherwise use the CDN cache (read via EnsembleAssetBundle).
         final cachedCdnAsset =
             CdnAssetCache.instance.getCachedFileIfValid(asset);
         if (cachedCdnAsset != null) {
           return cachedCdnAsset.path;
         }
-        return 'ensemble/assets/${stripQueryParamsFromAsset(asset)}';
+        return 'ensemble/assets/$assetName';
       } else {
         return 'ensemble/assets/${stripQueryParamsFromAsset(asset)}';
       }


### PR DESCRIPTION
## Problem

In CDN-provider apps, an asset that **is bundled in the app** could still be resolved to an on-device CDN-cache file path (e.g. `/data/user/0/<app>/files/asset_cache/assets/card_ERE.jpg`) instead of its bundle key. That file path is then handed to `Image.asset()`, which expects a bundle key — so the image renders **blank**, even though a perfectly good bundled copy ships in the app.

## Cause

`Utils.getLocalAssetFullPath()` (which picks the path to load) checked the **CDN cache first**, and only fell back to the bundled key:

```
cdn cache hit? -> /data/.../card_ERE.jpg          (file path)
else           -> ensemble/assets/card_ERE.jpg    (bundle key)
```

But `Utils.isAssetAvailableLocally()` (the "do we have it offline?" check) used the **opposite** order — bundled first, then cache. So the two disagreed: availability said *"yes, it's bundled,"* while resolution returned the cache **file path** → blank.

## Fix

Make the resolver agree with the availability check — **bundled first, then CDN cache**:

```dart
} else if (provider == 'cdn') {
  final assetName = stripQueryParamsFromAsset(asset);
  // Prefer a bundled asset when present: renders instantly, no download.
  if (LocalAssetsService.localAssets.contains(assetName)) {
    return 'ensemble/assets/$assetName';
  }
  // Otherwise use the CDN cache.
  final cachedCdnAsset = CdnAssetCache.instance.getCachedFileIfValid(asset);
  if (cachedCdnAsset != null) return cachedCdnAsset.path;
  return 'ensemble/assets/$assetName';
}
```

A bundled asset now resolves to its bundle key, so `Image.asset` reads it directly — no download, and no dependency on the cache path being readable.

## What this changes for a project

- **Bundled asset (present in the app):** now always resolves to the bundle key → renders instantly, offline, on any screen. *(Previously could resolve to a cache file path → blank.)*
- **Not bundled:** unchanged — resolves to the CDN cache if cached, otherwise the fallback bundle key.
- **Trade-off:** if an asset is *both* bundled **and** updated on CDN, the **bundled copy wins** — a CDN update won't override it. Intended: bundled = instant and static.

## Out of scope

This PR changes **lookup priority only**. It does **not** change how a *non-bundled* CDN-cached asset renders — that still resolves to a file path and needs a separate `*.file` loading fix to paint. Deliberately left out of this change.
