### PR TITLE
feat(ensemble_test_runner): improve screenshot handling and text matching logic

### DIFF
--- a/tools/ensemble_test_runner/lib/actions/test_step_executor.dart
+++ b/tools/ensemble_test_runner/lib/actions/test_step_executor.dart
@@ -644,10 +644,10 @@ class TestStepExecutor {
           assertions.finderForId(id).hitTestable().evaluate().isNotEmpty) {
         return;
       }
-      if (textCandidates.isNotEmpty &&
-          assertions.isAnyTextVisible(textCandidates)) {
+      final matchedText = _firstVisibleText(textCandidates);
+      if (matchedText != null) {
         if (step?.type == 'waitForText' && onWaitForTextMatched != null) {
-          await onWaitForTextMatched!(step!);
+          await onWaitForTextMatched!(_stepWithMatchedText(step!, matchedText));
         }
         return;
       }
@@ -677,6 +677,23 @@ class TestStepExecutor {
         if (item != null && item.toString().trim().isNotEmpty) item.toString(),
     ];
   }
+
+  String? _firstVisibleText(List<String> candidates) {
+    for (final text in candidates) {
+      if (assertions.isTextVisible(text)) return text;
+    }
+    return null;
+  }
+
+  TestStep _stepWithMatchedText(TestStep step, String text) => TestStep(
+        type: step.type,
+        args: {
+          ...step.args,
+          'text': text,
+        }..remove('anyOf'),
+        mocks: step.mocks,
+        nestedSteps: step.nestedSteps,
+      );
 
   void _expectSingleWidget(Finder finder, String id, String stepType) {
     final count = finder.evaluate().length;

--- a/tools/ensemble_test_runner/lib/reporters/html_test_report_app_js.dart
+++ b/tools/ensemble_test_runner/lib/reporters/html_test_report_app_js.dart
@@ -992,7 +992,9 @@ const ensembleHtmlTestReportAppJs = r'''
     html += '<img src="' + escapeHtml(href) + '" alt="' + escapeHtml(label) + '" loading="lazy"/>';
     const highlight = frame.highlight || null;
     if (highlight) {
-      const kind = highlight.kind === 'assertion' ? 'assertion' : 'action';
+      const kind = highlight.kind === 'assertion' || highlight.kind === 'failure'
+        ? highlight.kind
+        : 'action';
       const left = Number(highlight.left || 0);
       const top = Number(highlight.top || 0);
       const width = Number(highlight.width || 0);

--- a/tools/ensemble_test_runner/lib/reporters/html_test_report_css.dart
+++ b/tools/ensemble_test_runner/lib/reporters/html_test_report_css.dart
@@ -1060,6 +1060,17 @@ body {
   outline: 3px solid #00d5ff;
   filter: drop-shadow(0 0 7px rgba(6, 182, 212, 0.55));
 }
+.screenshot-highlight.failure {
+  outline: 3px dashed var(--fail);
+  background: rgba(244, 63, 94, 0.14);
+  filter: drop-shadow(0 0 9px rgba(244, 63, 94, 0.75));
+  animation: failure-highlight-pulse 1.5s infinite;
+}
+@keyframes failure-highlight-pulse {
+  0% { outline-offset: 4px; opacity: 1; }
+  50% { outline-offset: 7px; opacity: 0.75; }
+  100% { outline-offset: 4px; opacity: 1; }
+}
 .screenshot-highlight-dot {
   display: none;
 }

--- a/tools/ensemble_test_runner/lib/runner/ensemble_test_runner.dart
+++ b/tools/ensemble_test_runner/lib/runner/ensemble_test_runner.dart
@@ -462,6 +462,7 @@ class EnsembleTestRunner {
               executor: executor,
               step: matchedStep,
               stepIndex: i,
+              pumpBeforeCapture: true,
               stabilize: false,
             );
             capturedStep = true;
@@ -511,6 +512,9 @@ class EnsembleTestRunner {
           executor.onWaitForNavigationMatched = null;
           executor.onBeforeActionStep = null;
           executor.onAfterActionStep = null;
+        }
+        if (ctx.config.screenshots.enabled && _isUserActionStep(step)) {
+          await _paintAfterUserAction(executor);
         }
         _drainPendingFlutterExceptions(tester);
         if (!captureBeforeStep && !capturedStep && optionalActionStep == null) {
@@ -575,6 +579,7 @@ class EnsembleTestRunner {
             stepIndex: i,
             pumpBeforeCapture: true,
             ensureTargetVisible: false,
+            forFailure: true,
           );
         }
         final failureMessage = _failureMessageWithFlutterErrors(
@@ -747,6 +752,7 @@ class EnsembleTestRunner {
     bool waitForTarget = false,
     bool waitForLottie = true,
     bool stabilize = true,
+    bool forFailure = false,
   }) async {
     final options = executor.context.config.screenshots;
     if (!options.shouldCaptureStep(step.type)) return;
@@ -778,6 +784,7 @@ class EnsembleTestRunner {
       image: image,
       step: step,
       device: device,
+      forFailure: forFailure,
     );
     executor.context.runtime.addScreenshotSheetFrame(
       ScreenshotSheetFrame(
@@ -822,6 +829,7 @@ class EnsembleTestRunner {
     bool waitForTarget = false,
     bool waitForLottie = true,
     bool stabilize = true,
+    bool forFailure = false,
   }) async {
     try {
       await _captureAutomaticScreenshotForStep(
@@ -833,6 +841,7 @@ class EnsembleTestRunner {
         waitForTarget: waitForTarget,
         waitForLottie: waitForLottie,
         stabilize: stabilize,
+        forFailure: forFailure,
       );
     } catch (_) {
       // Screenshot capture must never replace the real test failure.
@@ -859,7 +868,8 @@ class EnsembleTestRunner {
   bool _isTextVerificationStep(TestStep step) =>
       step.type == 'expectText' ||
       step.type == 'expectTextContains' ||
-      step.type == 'waitForText';
+      step.type == 'waitForText' ||
+      step.type == 'expectNoText';
 
   Future<void> _stabilizeScreenshotFrame(
     TestStepExecutor executor, {
@@ -937,7 +947,10 @@ class EnsembleTestRunner {
           ? null
           : executor.assertions.firstVisuallyActionableElement(finder);
       if (element == null) return;
-      if (_effectiveOpacity(element) >= 0.85) return;
+      if (_effectiveOpacity(element) >= 0.85) {
+        await executor.tester.pump();
+        return;
+      }
 
       await executor.tester.pump(const Duration(milliseconds: 50));
     }
@@ -980,8 +993,12 @@ class EnsembleTestRunner {
     return opacity;
   }
 
-  ui.Rect? _highlightRectForStep(TestStepExecutor executor, TestStep step) {
-    if (!_shouldHighlightStep(step)) return null;
+  ui.Rect? _highlightRectForStep(
+    TestStepExecutor executor,
+    TestStep step, {
+    bool forFailure = false,
+  }) {
+    if (!_shouldHighlightStep(step, forFailure: forFailure)) return null;
 
     final finder = _highlightFinder(executor, step);
     if (finder == null) return null;
@@ -1075,27 +1092,49 @@ class EnsembleTestRunner {
     ];
     for (final text in texts) {
       if (step.type == 'expectTextContains') {
-        final hitTestableText = find.textContaining(text).hitTestable();
-        if (hitTestableText.evaluate().isNotEmpty) {
-          return hitTestableText;
-        }
         final containing = find.textContaining(text);
-        if (containing.evaluate().isNotEmpty) return containing;
-      } else {
-        final hitTestableText = find.text(text).hitTestable();
-        if (hitTestableText.evaluate().isNotEmpty) {
-          return hitTestableText;
+        if (_hasHighlightRect(
+          executor,
+          containing,
+        )) {
+          return containing;
         }
+      } else {
         final exact = find.text(text);
-        if (exact.evaluate().isNotEmpty) return exact;
+        if (_hasHighlightRect(
+          executor,
+          exact,
+        )) {
+          return exact;
+        }
       }
     }
     return null;
   }
 
-  bool _shouldHighlightStep(TestStep step) {
+  bool _hasHighlightRect(
+    TestStepExecutor executor,
+    Finder finder, {
+    bool requireHitTestable = false,
+  }) {
+    return executor.assertions.rectForVisuallyActionable(
+          finder,
+          requireHitTestable: requireHitTestable,
+        ) !=
+        null;
+  }
+
+  bool _shouldHighlightStep(TestStep step, {bool forFailure = false}) {
+    // On success there is nothing to point at for expectNoText; on failure the
+    // unexpectedly visible text is exactly what the screenshot should mark.
+    if (step.type == 'expectNoText' &&
+        !forFailure &&
+        (step.args['id']?.toString().isEmpty ?? true)) {
+      return false;
+    }
     if (step.type == 'waitForText' ||
         step.type == 'expectText' ||
+        step.type == 'expectNoText' ||
         step.type == 'waitFor' ||
         step.type == 'expectTextContains' ||
         step.type == 'scrollUntilVisible' ||
@@ -1133,13 +1172,20 @@ class EnsembleTestRunner {
     }
   }
 
+  Future<void> _paintAfterUserAction(TestStepExecutor executor) async {
+    await executor.tester.pump();
+    await executor.tester.pump(const Duration(milliseconds: 100));
+    await executor.tester.pump();
+  }
+
   ScreenshotHighlight? _highlightForStep({
     required TestStepExecutor executor,
     required ui.Image image,
     required TestStep step,
     required TestDeviceTarget? device,
+    bool forFailure = false,
   }) {
-    final rect = _highlightRectForStep(executor, step);
+    final rect = _highlightRectForStep(executor, step, forFailure: forFailure);
     if (rect == null) return null;
 
     final tester = executor.tester;
@@ -1167,7 +1213,11 @@ class EnsembleTestRunner {
     if (framedRect == null) return null;
 
     return ScreenshotHighlight(
-      kind: isTapStep ? 'action' : 'assertion',
+      kind: forFailure
+          ? 'failure'
+          : isTapStep
+              ? 'action'
+              : 'assertion',
       left: framedRect.left,
       top: framedRect.top,
       width: framedRect.width,

--- a/tools/ensemble_test_runner/lib/runner/screenshot_contact_sheet.dart
+++ b/tools/ensemble_test_runner/lib/runner/screenshot_contact_sheet.dart
@@ -17,8 +17,6 @@ import 'package:path/path.dart' as p;
 const _maxReportScreenshotWidth = 360;
 const _reportScreenshotJpegQuality = 82;
 const _reportScreenshotWebPQuality = 82;
-const _visualHashSize = 12;
-const _visualHashMaxDistance = 2;
 
 String? _cachedCwebpPath;
 bool _didResolveCwebpPath = false;
@@ -49,7 +47,6 @@ Future<String?> writeScreenshotFrames({
   imageDirectory.createSync(recursive: true);
   final safeTestId = _safeFileName(testId);
   final frameEntries = <Map<String, dynamic>>[];
-  final visualDedup = <String, String>{};
 
   try {
     for (final frame in frames) {
@@ -61,11 +58,10 @@ Future<String?> writeScreenshotFrames({
           await _encodeFrameImage(frame, frameDevice);
       frame.encodedReportImage ??= encoded;
 
-      final frameFileName = _dedupedVisualFileName(
-        encoded: encoded,
-        exactFileName: _dedupedImageFileName(encoded),
-        visualDedup: visualDedup,
-      );
+      // Byte-exact dedup only: any real pixel difference keeps its own file.
+      // Perceptual hashing previously collapsed small UI changes (day-button
+      // selection, success toasts) into stale frames and broke report highlights.
+      final frameFileName = _dedupedImageFileName(encoded);
       final frameFile = File(p.join(imageDirectory.path, frameFileName));
       if (!frameFile.existsSync()) {
         frameFile.writeAsBytesSync(encoded.bytes);
@@ -191,7 +187,6 @@ Future<EncodedScreenshotImage> _compressedReportImage(
         img.Image(width: resized.width, height: resized.height, numChannels: 3);
     img.fill(background, color: img.ColorRgb8(10, 17, 31));
     img.compositeImage(background, resized);
-    final visualHash = _visualHash(background);
 
     final webPInputBytes = Uint8List.fromList(
       img.encodePng(background, level: 1),
@@ -201,7 +196,6 @@ Future<EncodedScreenshotImage> _compressedReportImage(
       return EncodedScreenshotImage(
         bytes: webPBytes,
         extension: 'webp',
-        visualHash: visualHash,
       );
     }
 
@@ -219,12 +213,10 @@ Future<EncodedScreenshotImage> _compressedReportImage(
       EncodedScreenshotImage(
         bytes: jpgBytes,
         extension: 'jpg',
-        visualHash: visualHash,
       ),
       EncodedScreenshotImage(
         bytes: optimizedPngBytes,
         extension: 'png',
-        visualHash: visualHash,
       ),
     ];
     candidates.sort((a, b) => a.bytes.length.compareTo(b.bytes.length));
@@ -329,68 +321,6 @@ String _safeFileName(String value) =>
     value.replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '_');
 
 String _dedupedImageFileName(EncodedScreenshotImage image) {
-  final visualHash = image.visualHash;
-  if (visualHash != null && visualHash.isNotEmpty) {
-    final digest = sha1.convert(utf8.encode(visualHash)).toString();
-    return 'shot_v_$digest.${image.extension}';
-  }
-
   final digest = sha256.convert(image.bytes).toString();
   return 'shot_${image.bytes.length}_$digest.${image.extension}';
-}
-
-String _dedupedVisualFileName({
-  required EncodedScreenshotImage encoded,
-  required String exactFileName,
-  required Map<String, String> visualDedup,
-}) {
-  final visualHash = encoded.visualHash;
-  if (visualHash == null || visualHash.isEmpty) return exactFileName;
-
-  final exactMatch = visualDedup[visualHash];
-  if (exactMatch != null) return exactMatch;
-
-  for (final entry in visualDedup.entries) {
-    if (_visualHashDistance(visualHash, entry.key) <= _visualHashMaxDistance) {
-      return entry.value;
-    }
-  }
-
-  visualDedup[visualHash] = exactFileName;
-  return exactFileName;
-}
-
-String _visualHash(img.Image image) {
-  final thumbnail = img.copyResize(
-    image,
-    width: _visualHashSize,
-    height: _visualHashSize,
-    interpolation: img.Interpolation.average,
-  );
-  final luminance = <int>[];
-  var total = 0;
-  for (var y = 0; y < thumbnail.height; y += 1) {
-    for (var x = 0; x < thumbnail.width; x += 1) {
-      final pixel = thumbnail.getPixel(x, y);
-      final value =
-          ((pixel.r * 299) + (pixel.g * 587) + (pixel.b * 114)) ~/ 1000;
-      luminance.add(value);
-      total += value;
-    }
-  }
-
-  final average = total / luminance.length;
-  return luminance.map((value) => value >= average ? '1' : '0').join();
-}
-
-int _visualHashDistance(String a, String b) {
-  if (a.length != b.length) return _visualHashMaxDistance + 1;
-  var distance = 0;
-  for (var i = 0; i < a.length; i += 1) {
-    if (a.codeUnitAt(i) != b.codeUnitAt(i)) {
-      distance += 1;
-      if (distance > _visualHashMaxDistance) return distance;
-    }
-  }
-  return distance;
 }

--- a/tools/ensemble_test_runner/lib/runner/test_runtime_state.dart
+++ b/tools/ensemble_test_runner/lib/runner/test_runtime_state.dart
@@ -124,12 +124,10 @@ class EncodedScreenshotImage {
   EncodedScreenshotImage({
     required this.bytes,
     required this.extension,
-    this.visualHash,
   });
 
   final Uint8List bytes;
   final String extension;
-  final String? visualHash;
 }
 
 class PerformanceMarker {

--- a/tools/ensemble_test_runner/test/screenshot_contact_sheet_test.dart
+++ b/tools/ensemble_test_runner/test/screenshot_contact_sheet_test.dart
@@ -165,15 +165,17 @@ void main() {
     _deleteArtifacts(framesManifest, frames);
   });
 
-  testWidgets('deduplicates visually equivalent screenshots', (tester) async {
+  testWidgets('keeps distinct files for small pixel differences', (tester) async {
     const testId = 'contact_sheet_visual_dedupe_test';
+    // Use a mid-frame accent large enough to survive report resize/WebP.
+    // Previously perceptual hashing collapsed this into one file.
     final image0 = await _testImage(
       color: Colors.teal,
-      noiseColor: Colors.red,
+      accentColor: const Color(0xFF00A0E3),
     );
     final image1 = await _testImage(
       color: Colors.teal,
-      noiseColor: Colors.blue,
+      accentColor: Colors.white,
     );
     final path = await tester.runAsync(
       () => writeScreenshotFrames(
@@ -217,9 +219,20 @@ void main() {
         jsonDecode(framesManifest.readAsStringSync()) as Map<String, dynamic>;
     final frames = framesJson['frames'] as List<dynamic>;
     expect(frames, hasLength(2));
-    expect(frames[0]['file'], frames[1]['file']);
+    // Byte-exact hashing must not collapse small UI differences.
+    expect(frames[0]['file'], isNot(frames[1]['file']));
     expect(frames[0]['highlight']['kind'], 'assertion');
     expect(frames[1]['highlight']['kind'], 'action');
+    expect(
+      File('build/ensemble_test_runner/report/screenshots/${frames[0]['file']}')
+          .existsSync(),
+      isTrue,
+    );
+    expect(
+      File('build/ensemble_test_runner/report/screenshots/${frames[1]['file']}')
+          .existsSync(),
+      isTrue,
+    );
 
     _deleteArtifacts(framesManifest, frames);
   });
@@ -318,6 +331,7 @@ void _deleteArtifacts(File framesManifest, List<dynamic> frames) {
 Future<ui.Image> _testImage({
   Color color = Colors.white,
   Color? noiseColor,
+  Color? accentColor,
 }) async {
   final recorder = ui.PictureRecorder();
   final canvas = Canvas(recorder);
@@ -337,6 +351,15 @@ Future<ui.Image> _testImage({
     canvas.drawRect(
       const Rect.fromLTWH(382, 836, 4, 4),
       Paint()..color = noiseColor,
+    );
+  }
+  if (accentColor != null) {
+    // Day-button sized accent (~40x40) — small relative to the frame but
+    // large enough to remain after report compression.
+    canvas.drawCircle(
+      const Offset(220, 300),
+      20,
+      Paint()..color = accentColor,
     );
   }
   final picture = recorder.endRecording();


### PR DESCRIPTION
- Introduced a method to find the first visible text from candidates.
- Enhanced the `waitForText` step to utilize matched text for better accuracy.
- Updated screenshot capturing logic to handle user actions and failures more effectively.
- Added CSS styles for failure highlights in HTML reports.
- Removed visual hash deduplication logic to prevent collapsing distinct screenshots with minor pixel differences.