### PR TITLE
fix(tv): handle key repeat events for D-pad navigation

### DIFF
--- a/modules/ensemble/lib/framework/tv/tv_focus_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_focus_widget.dart
@@ -183,7 +183,7 @@ class TVFocusWidget extends StatelessWidget {
   /// uses it for ancestor/route lookups while this widget's [focusOrder]
   /// identifies the current grid position.
   KeyEventResult _handleScopeKeyEvent(FocusNode node, KeyEvent event) {
-    if (event is KeyDownEvent) {
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
       // Handle back button
       if (event.logicalKey == LogicalKeyboardKey.goBack) {
         final result = onBackPressed?.call(node);

--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -238,7 +238,9 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
         return Focus(
           onKeyEvent: (node, event) {
             // Only handle when we have focus
-            if (!_isFocused || event is! KeyDownEvent) return KeyEventResult.ignored;
+            if (!_isFocused || (event is! KeyDownEvent && event is! KeyRepeatEvent)) {
+              return KeyEventResult.ignored;
+            }
 
             // Handle UP/DOWN for manual scrolling
             if (event.logicalKey == LogicalKeyboardKey.arrowDown) {


### PR DESCRIPTION
## Description

This PR fixes TV D-pad navigation when the user holds down a key (auto-repeat).
Previously only `KeyDownEvent` was handled, so repeated key events generated
while holding the D-pad button were ignored, causing slow/erratic scrolling and
navigation on TV remotes.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Updated `_handleScopeKeyEvent` in `TVFocusWidget` to also handle `KeyRepeatEvent`, so held D-pad keys continuously trigger back/scope navigation instead of only the initial press
- Updated the `onKeyEvent` handler in `TVScrollbarWidget` to also handle `KeyRepeatEvent`, enabling smooth continuous scrolling while the UP/DOWN key is held

## How to Test

1. Run the relevant TV tests (if any): `flutter test modules/ensemble/test/widget/tv_scrollbar_widget_test.dart`
2. On a TV/emulator, focus a ListView and hold the D-pad DOWN button — the list should scroll continuously while held
3. Hold the BACK button — it should keep triggering the back handler rather than only once
4. Verify normal single-press navigation still works as before

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings or errors