### PR TITLE
feat(tv): scroll focused scrollbar into view

### DIFF
--- a/modules/ensemble/lib/framework/tv/tv_focus_scroll.dart
+++ b/modules/ensemble/lib/framework/tv/tv_focus_scroll.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+// =============================================================================
+// TV Focus - Scroll Into View
+// =============================================================================
+// Scroll-into-view logic used by TVScrollbarWidget so a focused scrollbar is
+// always revealed by its nearest vertical scrollable ancestor. (Regular
+// focusable widgets implement the same rule in box_wrapper.dart.)
+
+const int kTVScrollAnimationDurationMs = 200; // Scroll animation duration
+const double kTVVerticalScrollPadding = 50.0; // Vertical visibility padding
+const double kTVScrollThreshold = 2.0; // Min delta to trigger scroll
+
+/// Finds the nearest vertical scrollable ancestor.
+ScrollableState? findNearestVerticalScrollable(BuildContext context) {
+  ScrollableState? scrollable;
+
+  context.visitAncestorElements((element) {
+    if (element.widget is Scrollable) {
+      final state = (element as StatefulElement).state;
+      if (state is ScrollableState) {
+        final axis = state.axisDirection;
+        if (axis == AxisDirection.up || axis == AxisDirection.down) {
+          scrollable = state;
+          return false; // Stop searching
+        }
+      }
+    }
+    return true; // Continue searching
+  });
+
+  return scrollable;
+}
+
+/// Scrolls ONLY the nearest vertical scrollable ancestor so that
+/// [widgetContext]'s render box is fully visible within the viewport.
+/// Unlike Scrollable.ensureVisible(), this does NOT affect horizontal scroll.
+/// [verticalPadding] controls the threshold from viewport edges (use larger
+/// values when there's a top nav bar that items might hide behind).
+/// [animationDurationMs] controls the scroll animation duration in milliseconds.
+/// [curve] controls the animation curve (defaults to easeInOut).
+void scrollWidgetIntoView(
+  BuildContext widgetContext, {
+  double verticalPadding = kTVVerticalScrollPadding,
+  int animationDurationMs = kTVScrollAnimationDurationMs,
+  Curve curve = Curves.easeInOut,
+}) {
+  final scrollable = findNearestVerticalScrollable(widgetContext);
+  if (scrollable == null) return;
+
+  final itemBox = widgetContext.findRenderObject() as RenderBox?;
+  if (itemBox == null || !itemBox.hasSize) return;
+
+  final scrollableBox = scrollable.context.findRenderObject() as RenderBox?;
+  if (scrollableBox == null || !scrollableBox.hasSize) return;
+
+  final position = scrollable.position;
+
+  // Get scrollable viewport position relative to screen
+  final Offset scrollableScreenPos = scrollableBox.localToGlobal(Offset.zero);
+  final double viewportTop = scrollableScreenPos.dy;
+  final double viewportBottom = viewportTop + scrollableBox.size.height;
+
+  // Get item position relative to screen
+  final Offset itemScreenPos = itemBox.localToGlobal(Offset.zero);
+  final double itemTop = itemScreenPos.dy;
+  final double itemBottom = itemTop + itemBox.size.height;
+
+  final bool isAboveScreen = itemTop < viewportTop;
+  final bool isBelowScreen = itemBottom > viewportBottom;
+
+  // If fully visible vertically, no need to scroll
+  if (!isAboveScreen && !isBelowScreen) {
+    return;
+  }
+
+  // Calculate how much to scroll
+  // Use verticalPadding to position the item nicely within the viewport,
+  // not as a trigger threshold - so horizontal navigation doesn't jitter.
+  double scrollDelta = 0.0;
+  if (isAboveScreen) {
+    // Item is above visible area - scroll up (decrease scroll position)
+    scrollDelta = itemTop - (viewportTop + verticalPadding);
+  } else if (isBelowScreen) {
+    // Item is below visible area - scroll down (increase scroll position)
+    scrollDelta = itemBottom - (viewportBottom - verticalPadding);
+  }
+
+  final double targetScroll =
+      (position.pixels + scrollDelta).clamp(0.0, position.maxScrollExtent);
+
+  // Only scroll if delta is significant (avoid micro-scrolls)
+  if ((targetScroll - position.pixels).abs() > kTVScrollThreshold) {
+    position.animateTo(
+      targetScroll,
+      duration: Duration(milliseconds: animationDurationMs),
+      curve: curve,
+    );
+  }
+}

--- a/modules/ensemble/lib/framework/tv/tv_focus_scroll.dart
+++ b/modules/ensemble/lib/framework/tv/tv_focus_scroll.dart
@@ -3,13 +3,49 @@ import 'package:flutter/material.dart';
 // =============================================================================
 // TV Focus - Scroll Into View
 // =============================================================================
-// Scroll-into-view logic used by TVScrollbarWidget so a focused scrollbar is
-// always revealed by its nearest vertical scrollable ancestor. (Regular
-// focusable widgets implement the same rule in box_wrapper.dart.)
+// Shared scroll-into-view primitives for TV D-pad focus. Both regular
+// focusables (box_wrapper.dart) and the focusable scrollbar
+// (tv_scrollbar_widget.dart) reveal a newly focused target through the SAME
+// axis-restricted rule defined here, so behavior stays consistent and a fix
+// only has to be made in one place.
 
+// TV scroll tuning defaults (single home; overridable via tvOptions in YAML).
+// Vertical/threshold/duration are used by the shared helpers below; the
+// horizontal/edge values are consumed by box_wrapper's horizontal helpers.
 const int kTVScrollAnimationDurationMs = 200; // Scroll animation duration
 const double kTVVerticalScrollPadding = 50.0; // Vertical visibility padding
 const double kTVScrollThreshold = 2.0; // Min delta to trigger scroll
+const double kTVHorizontalScrollPadding = 16.0; // Horizontal visibility padding
+const double kTVFixedFocusOffset = 48.0; // Netflix-style fixed position
+const double kTVEdgePadding = 8.0; // Edge visibility buffer
+
+/// Converts a curve name string to a Flutter [Curve].
+/// Supported: easeIn, easeOut, easeInOut, linear, decelerate, ease,
+/// fastOutSlowIn, bounceOut, elasticOut. Falls back to [defaultCurve].
+Curve curveFromName(String? curveName, {Curve defaultCurve = Curves.easeOut}) {
+  switch (curveName?.toLowerCase()) {
+    case 'easein':
+      return Curves.easeIn;
+    case 'easeout':
+      return Curves.easeOut;
+    case 'easeinout':
+      return Curves.easeInOut;
+    case 'linear':
+      return Curves.linear;
+    case 'decelerate':
+      return Curves.decelerate;
+    case 'ease':
+      return Curves.ease;
+    case 'fastoutslowin':
+      return Curves.fastOutSlowIn;
+    case 'bounceout':
+      return Curves.bounceOut;
+    case 'elasticout':
+      return Curves.elasticOut;
+    default:
+      return defaultCurve;
+  }
+}
 
 /// Finds the nearest vertical scrollable ancestor.
 ScrollableState? findNearestVerticalScrollable(BuildContext context) {
@@ -32,25 +68,19 @@ ScrollableState? findNearestVerticalScrollable(BuildContext context) {
   return scrollable;
 }
 
-/// Scrolls ONLY the nearest vertical scrollable ancestor so that
-/// [widgetContext]'s render box is fully visible within the viewport.
+/// Scrolls ONLY [scrollable] so that [itemBox] is fully visible vertically.
 /// Unlike Scrollable.ensureVisible(), this does NOT affect horizontal scroll.
 /// [verticalPadding] controls the threshold from viewport edges (use larger
 /// values when there's a top nav bar that items might hide behind).
 /// [animationDurationMs] controls the scroll animation duration in milliseconds.
 /// [curve] controls the animation curve (defaults to easeInOut).
-void scrollWidgetIntoView(
-  BuildContext widgetContext, {
+void scrollVerticalOnly(
+  ScrollableState scrollable,
+  RenderBox itemBox, {
   double verticalPadding = kTVVerticalScrollPadding,
   int animationDurationMs = kTVScrollAnimationDurationMs,
   Curve curve = Curves.easeInOut,
 }) {
-  final scrollable = findNearestVerticalScrollable(widgetContext);
-  if (scrollable == null) return;
-
-  final itemBox = widgetContext.findRenderObject() as RenderBox?;
-  if (itemBox == null || !itemBox.hasSize) return;
-
   final scrollableBox = scrollable.context.findRenderObject() as RenderBox?;
   if (scrollableBox == null || !scrollableBox.hasSize) return;
 
@@ -97,4 +127,28 @@ void scrollWidgetIntoView(
       curve: curve,
     );
   }
+}
+
+/// Convenience wrapper: resolves [widgetContext]'s nearest vertical scrollable
+/// ancestor and its render box, then reveals it via [scrollVerticalOnly].
+/// Unlike Scrollable.ensureVisible(), this does NOT affect horizontal scroll.
+void scrollWidgetIntoView(
+  BuildContext widgetContext, {
+  double verticalPadding = kTVVerticalScrollPadding,
+  int animationDurationMs = kTVScrollAnimationDurationMs,
+  Curve curve = Curves.easeInOut,
+}) {
+  final scrollable = findNearestVerticalScrollable(widgetContext);
+  if (scrollable == null) return;
+
+  final itemBox = widgetContext.findRenderObject() as RenderBox?;
+  if (itemBox == null || !itemBox.hasSize) return;
+
+  scrollVerticalOnly(
+    scrollable,
+    itemBox,
+    verticalPadding: verticalPadding,
+    animationDurationMs: animationDurationMs,
+    curve: curve,
+  );
 }

--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -1,5 +1,6 @@
 import 'package:ensemble/framework/tv/tv_focus_order.dart';
 import 'package:ensemble/framework/tv/tv_focus_provider.dart';
+import 'package:ensemble/framework/tv/tv_focus_scroll.dart';
 import 'package:ensemble/framework/tv/tv_focus_widget.dart';
 import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:flutter/material.dart';
@@ -278,6 +279,17 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
                 setState(() {
                   _isFocused = hasFocus;
                 });
+                // Reveal the scrollbar in its enclosing scrollable when it
+                // gains focus (same scroll-into-view rule as other focusables).
+                // Re-check `_isFocused` at callback time in case focus has
+                // already moved away before the frame completes.
+                if (hasFocus) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (mounted && context.mounted && _isFocused) {
+                      scrollWidgetIntoView(context);
+                    }
+                  });
+                }
               }
             },
             child: AnimatedContainer(

--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -54,6 +54,9 @@ class TVScrollbarWidget extends StatefulWidget {
     required this.scrollController,
     required this.options,
     this.fallbackFocus,
+    this.verticalScrollPadding,
+    this.scrollAnimationDuration,
+    this.scrollAnimationCurve,
   });
 
   /// ScrollController from the scrollable content (ListView/Column)
@@ -66,6 +69,13 @@ class TVScrollbarWidget extends StatefulWidget {
   /// descendants. When omitted, focus reaches the scrollbar only via edge
   /// handoff from a focused content item.
   final TVScrollbarFallbackFocusConfig? fallbackFocus;
+
+  /// Scroll-into-view tuning inherited from the owning ListView's tvOptions so
+  /// the scrollbar reveals itself with the SAME padding/duration/curve as the
+  /// content items beside it. Null values fall back to the shared TV defaults.
+  final double? verticalScrollPadding;
+  final int? scrollAnimationDuration;
+  final String? scrollAnimationCurve;
 
   @override
   State<TVScrollbarWidget> createState() => TVScrollbarWidgetState();
@@ -286,7 +296,15 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
                 if (hasFocus) {
                   WidgetsBinding.instance.addPostFrameCallback((_) {
                     if (mounted && context.mounted && _isFocused) {
-                      scrollWidgetIntoView(context);
+                      scrollWidgetIntoView(
+                        context,
+                        verticalPadding: widget.verticalScrollPadding ??
+                            kTVVerticalScrollPadding,
+                        animationDurationMs: widget.scrollAnimationDuration ??
+                            kTVScrollAnimationDurationMs,
+                        curve: curveFromName(widget.scrollAnimationCurve,
+                            defaultCurve: Curves.easeInOut),
+                      );
                     }
                   });
                 }

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -502,6 +502,11 @@ class ListViewState extends EWidgetState<ListView>
           scrollController: scrollController,
           options: scrollbarOptions,
           fallbackFocus: fallbackFocus,
+          // Reveal the scrollbar with the same scroll tuning as the content
+          // items beside it (box_wrapper reads these same tvOptions).
+          verticalScrollPadding: tvOptions.verticalScrollPadding,
+          scrollAnimationDuration: tvOptions.scrollAnimationDuration,
+          scrollAnimationCurve: tvOptions.scrollAnimationCurve,
         );
         final effectiveScrollbarWidget = fallbackFocus == null
             ? flutter.FocusTraversalGroup(

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -7,6 +7,7 @@ import 'package:ensemble/framework/theme/theme_manager.dart';
 import 'package:ensemble/framework/tv/tv_focus_navigation.dart';
 import 'package:ensemble/framework/tv/tv_focus_order.dart';
 import 'package:ensemble/framework/tv/tv_focus_provider.dart';
+import 'package:ensemble/framework/tv/tv_focus_scroll.dart';
 import 'package:ensemble/framework/tv/tv_focus_theme.dart';
 import 'package:ensemble/framework/tv/tv_focus_widget.dart';
 import 'package:ensemble/framework/view/data_scope_widget.dart';
@@ -16,17 +17,9 @@ import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble/widget/helpers/widgets.dart';
 import 'package:flutter/material.dart';
 
-// =============================================================================
-// TV Focus - Scroll Constants
-// =============================================================================
-// These defaults are used when not overridden via tvOptions in YAML.
-
-const int kTVScrollAnimationDurationMs = 200; // Scroll animation duration
-const double kTVHorizontalScrollPadding = 16.0; // Horizontal visibility padding
-const double kTVVerticalScrollPadding = 50.0; // Vertical visibility padding
-const double kTVFixedFocusOffset = 48.0; // Netflix-style fixed position
-const double kTVEdgePadding = 8.0; // Edge visibility buffer
-const double kTVScrollThreshold = 2.0; // Min delta to trigger scroll
+// TV scroll tuning constants (kTVScrollAnimationDurationMs, kTV*ScrollPadding,
+// kTVScrollThreshold, kTVFixedFocusOffset, kTVEdgePadding) live in the shared
+// tv_focus_scroll.dart and are available via the import above.
 
 // =============================================================================
 // TV Focus - Styling Resolver
@@ -511,30 +504,10 @@ void _saveTVRowPositionOnFocus(
 /// Maps a curve name (from `tvOptions.scrollAnimationCurve`) to a [Curve].
 /// Supported: easeIn, easeOut, easeInOut, linear, decelerate, ease,
 /// fastOutSlowIn, bounceOut, elasticOut.
-Curve _curveFromName(String? curveName, {Curve defaultCurve = Curves.easeOut}) {
-  switch (curveName?.toLowerCase()) {
-    case 'easein':
-      return Curves.easeIn;
-    case 'easeout':
-      return Curves.easeOut;
-    case 'easeinout':
-      return Curves.easeInOut;
-    case 'linear':
-      return Curves.linear;
-    case 'decelerate':
-      return Curves.decelerate;
-    case 'ease':
-      return Curves.ease;
-    case 'fastoutslowin':
-      return Curves.fastOutSlowIn;
-    case 'bounceout':
-      return Curves.bounceOut;
-    case 'elasticout':
-      return Curves.elasticOut;
-    default:
-      return defaultCurve;
-  }
-}
+// Curve-name resolution lives in tv_focus_scroll.dart (shared with the
+// focusable scrollbar); this thin alias keeps the existing internal call sites.
+Curve _curveFromName(String? curveName, {Curve defaultCurve = Curves.easeOut}) =>
+    curveFromName(curveName, defaultCurve: defaultCurve);
 
 class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
   late final FocusNode _focusNode;
@@ -624,15 +597,15 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
         externalProvider?.handlesHorizontalScroll ?? false;
 
     // Handle vertical scrolling to ensure focused item is visible
-    final verticalScrollable = _findVerticalScrollable();
+    final verticalScrollable = findNearestVerticalScrollable(context);
     if (verticalScrollable != null) {
       final verticalPadding =
           tvOptions?.verticalScrollPadding ?? kTVVerticalScrollPadding;
       final verticalCurve =
           _getCurveFromName(scrollCurveName, defaultCurve: Curves.easeInOut);
-      _scrollVerticalOnly(verticalScrollable, itemBox,
+      scrollVerticalOnly(verticalScrollable, itemBox,
           verticalPadding: verticalPadding,
-          animationDuration: scrollAnimationDuration,
+          animationDurationMs: scrollAnimationDuration,
           curve: verticalCurve);
     }
 
@@ -684,86 +657,6 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
     return scrollable;
   }
 
-  /// Finds the nearest vertical scrollable ancestor.
-  ScrollableState? _findVerticalScrollable() {
-    ScrollableState? scrollable;
-
-    context.visitAncestorElements((element) {
-      if (element.widget is Scrollable) {
-        final state = (element as StatefulElement).state;
-        if (state is ScrollableState) {
-          final axis = state.axisDirection;
-          if (axis == AxisDirection.up || axis == AxisDirection.down) {
-            scrollable = state;
-            return false; // Stop searching
-          }
-        }
-      }
-      return true; // Continue searching
-    });
-
-    return scrollable;
-  }
-
-  /// Scrolls ONLY the vertical scrollable to bring row into view.
-  /// Unlike Scrollable.ensureVisible(), this does NOT affect horizontal scroll.
-  /// [verticalPadding] controls the threshold from screen edges (use larger
-  /// values when there's a top nav bar that items might hide behind).
-  /// [animationDuration] controls the scroll animation duration in milliseconds.
-  /// [curve] controls the animation curve (defaults to easeInOut).
-  void _scrollVerticalOnly(ScrollableState scrollable, RenderBox itemBox,
-      {double verticalPadding = kTVVerticalScrollPadding,
-      int animationDuration = kTVScrollAnimationDurationMs,
-      Curve curve = Curves.easeInOut}) {
-    final scrollableBox = scrollable.context.findRenderObject() as RenderBox?;
-    if (scrollableBox == null || !scrollableBox.hasSize) return;
-
-    final position = scrollable.position;
-
-    // Get scrollable viewport position relative to screen
-    final Offset scrollableScreenPos = scrollableBox.localToGlobal(Offset.zero);
-    final double viewportTop = scrollableScreenPos.dy;
-    final double viewportBottom = viewportTop + scrollableBox.size.height;
-
-    // Get item position relative to screen
-    final Offset itemScreenPos = itemBox.localToGlobal(Offset.zero);
-    final double itemHeight = itemBox.size.height;
-    final double itemTop = itemScreenPos.dy;
-    final double itemBottom = itemTop + itemHeight;
-
-    final bool isAboveScreen = itemTop < viewportTop;
-    final bool isBelowScreen = itemBottom > viewportBottom;
-
-    // If fully visible vertically, no need to scroll
-    if (!isAboveScreen && !isBelowScreen) {
-      return;
-    }
-
-    // Calculate how much to scroll
-    // Use verticalPadding to position the item nicely within the viewport,
-    // not as a trigger threshold - so horizontal navigation doesn't jitter.
-    double scrollDelta = 0.0;
-    if (isAboveScreen) {
-      // Item is above visible area - scroll up (decrease scroll position)
-      scrollDelta = itemTop - (viewportTop + verticalPadding);
-    } else if (isBelowScreen) {
-      // Item is below visible area - scroll down (increase scroll position)
-      scrollDelta = itemBottom - (viewportBottom - verticalPadding);
-    }
-
-    final double targetScroll =
-        (position.pixels + scrollDelta).clamp(0.0, position.maxScrollExtent);
-
-    // Only scroll if delta is significant (avoid micro-scrolls)
-    if ((targetScroll - position.pixels).abs() > kTVScrollThreshold) {
-      position.animateTo(
-        targetScroll,
-        duration: Duration(milliseconds: animationDuration),
-        curve: curve,
-      );
-    }
-  }
-
   /// Default horizontal scrolling: ensure item is visible, scroll only if needed.
   /// [padding] controls the horizontal padding for visibility checks.
   /// [animationDuration] controls the scroll animation duration in milliseconds.
@@ -799,7 +692,7 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
     // alignment: 0.5) but scrolls ONLY this horizontal scrollable. The old
     // ensureVisible(context) was not axis-restricted — it also scrolled every
     // enclosing vertical scrollable, undoing the padding-aware
-    // _scrollVerticalOnly done moments earlier and causing a vertical jerk.
+    // scrollVerticalOnly done moments earlier and causing a vertical jerk.
     final position = scrollable.position;
     final double itemCenter = itemLeft + itemWidth / 2;
     final double viewportCenter = scrollableLeft + scrollableBox.size.width / 2;
@@ -1179,84 +1072,12 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
         defaultCurve: Curves.easeInOut);
 
     // Handle vertical scrolling to ensure focused item is visible
-    final verticalScrollable = _findVerticalScrollable();
+    final verticalScrollable = findNearestVerticalScrollable(context);
     if (verticalScrollable != null) {
-      _scrollVerticalOnly(verticalScrollable, itemBox,
+      scrollVerticalOnly(verticalScrollable, itemBox,
           verticalPadding: verticalPadding,
-          animationDuration: scrollAnimationDuration,
+          animationDurationMs: scrollAnimationDuration,
           curve: curve);
-    }
-  }
-
-  /// Finds the nearest vertical scrollable ancestor.
-  ScrollableState? _findVerticalScrollable() {
-    ScrollableState? scrollable;
-
-    context.visitAncestorElements((element) {
-      if (element.widget is Scrollable) {
-        final state = (element as StatefulElement).state;
-        if (state is ScrollableState) {
-          final axis = state.axisDirection;
-          if (axis == AxisDirection.up || axis == AxisDirection.down) {
-            scrollable = state;
-            return false; // Stop searching
-          }
-        }
-      }
-      return true; // Continue searching
-    });
-
-    return scrollable;
-  }
-
-  /// Scrolls ONLY the vertical scrollable to bring item into view.
-  void _scrollVerticalOnly(ScrollableState scrollable, RenderBox itemBox,
-      {double verticalPadding = kTVVerticalScrollPadding,
-      int animationDuration = kTVScrollAnimationDurationMs,
-      Curve curve = Curves.easeInOut}) {
-    final scrollableBox = scrollable.context.findRenderObject() as RenderBox?;
-    if (scrollableBox == null || !scrollableBox.hasSize) return;
-
-    final position = scrollable.position;
-
-    // Get scrollable viewport position relative to screen
-    final Offset scrollableScreenPos = scrollableBox.localToGlobal(Offset.zero);
-    final double viewportTop = scrollableScreenPos.dy;
-    final double viewportBottom = viewportTop + scrollableBox.size.height;
-
-    // Get item position relative to screen
-    final Offset itemScreenPos = itemBox.localToGlobal(Offset.zero);
-    final double itemHeight = itemBox.size.height;
-    final double itemTop = itemScreenPos.dy;
-    final double itemBottom = itemTop + itemHeight;
-
-    final bool isAboveScreen = itemTop < viewportTop;
-    final bool isBelowScreen = itemBottom > viewportBottom;
-
-    // If fully visible vertically, no need to scroll
-    if (!isAboveScreen && !isBelowScreen) {
-      return;
-    }
-
-    // Calculate how much to scroll
-    // Use verticalPadding to position the item nicely within the viewport,
-    // not as a trigger threshold - so horizontal navigation doesn't jitter.
-    double scrollDelta = 0.0;
-    if (isAboveScreen) {
-      scrollDelta = itemTop - (viewportTop + verticalPadding);
-    } else if (isBelowScreen) {
-      scrollDelta = itemBottom - (viewportBottom - verticalPadding);
-    }
-
-    final double targetScroll =
-        (position.pixels + scrollDelta).clamp(0.0, position.maxScrollExtent);
-
-    if ((targetScroll - position.pixels).abs() > kTVScrollThreshold) {
-      position.animateTo(
-        targetScroll,
-        duration: Duration(milliseconds: animationDuration),
-        curve: curve,
-      );
     }
   }
 


### PR DESCRIPTION
## Description

This PR ensures a focused scrollbar is always revealed within its enclosing vertical scrollable on TV. Previously, when the scrollbar gained focus while positioned outside the visible viewport of a parent scrollable (e.g. a long ListView), it could remain hidden off-screen, making D-pad navigation confusing.

The change adds a reusable scroll-into-view helper that scrolls **only** the nearest vertical scrollable ancestor, so vertical positioning is fixed without jittering horizontal navigation.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `modules/ensemble/lib/framework/tv/tv_focus_scroll.dart` with:
  - `findNearestVerticalScrollable(BuildContext)` — finds the nearest vertical `Scrollable` ancestor
  - `scrollWidgetIntoView(BuildContext, {verticalPadding, animationDurationMs, curve})` — scrolls only the nearest vertical scrollable so a widget's render box is fully visible, using padding from the viewport edges and clamping to valid scroll extents
  - Configurable constants: `kTVScrollAnimationDurationMs`, `kTVVerticalScrollPadding`, `kTVScrollThreshold`
- Updated `TVScrollbarWidget` in `tv_scrollbar_widget.dart` to call `scrollWidgetIntoView(context)` when the scrollbar gains focus, via a post-frame callback that re-checks `_isFocused` so stale callbacks are ignored
- This matches the same scroll-into-view rule already implemented for regular focusable widgets in `box_wrapper.dart`

## How to Test

1. Run the relevant TV tests (if any): `flutter test modules/ensemble/test/widget/tv_scrollbar_widget_test.dart`
2. On a TV/emulator, focus a scrollbar whose parent is a long vertical scrollable — the scrollbar should be scrolled into view when focused
3. Move focus to an item that is fully visible — no scroll should occur (no jitter)
4. Navigate horizontally — vertical scroll position should remain unchanged
5. Verify regular focus navigation still works as before

## Screenshots / Videos

N/A

## Checklist

- [x] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [x] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
