### PR TITLE
feat(tv): add keepAlive option to ListView and GridView for improved …

### DIFF
--- a/modules/ensemble/lib/layout/grid_view.dart
+++ b/modules/ensemble/lib/layout/grid_view.dart
@@ -6,6 +6,7 @@ import 'package:ensemble/framework/studio/studio_debugger.dart';
 import 'package:ensemble/framework/view/footer.dart';
 import 'package:ensemble/framework/widget/widget.dart';
 import 'package:ensemble/layout/templated.dart';
+import 'package:ensemble/layout/helpers/keep_alive.dart';
 import 'package:ensemble/model/pull_to_refresh.dart';
 import 'package:ensemble/model/item_template.dart';
 import 'package:ensemble/page_model.dart';
@@ -86,6 +87,8 @@ class GridView extends StatefulWidget
           _controller.direction = Utils.optionalString(value),
       'shrinkWrap': (value) =>
           controller.shrinkWrap = Utils.optionalBool(value),
+      'keepAlive': (value) =>
+          _controller.keepAlive = Utils.optionalBool(value),
     };
   }
 
@@ -112,6 +115,7 @@ class GridViewController extends BoxController {
   ScrollController? scrollController;
   String? direction;
   bool? shrinkWrap;
+  bool? keepAlive;
 
   PullToRefresh? pullToRefresh;
   @Deprecated("use pullToRefresh")
@@ -333,6 +337,10 @@ class GridViewState extends EWidgetState<GridView> with TemplatedWidgetState {
 
     if (itemWidget == null) {
       return const SizedBox.shrink();
+    }
+
+    if (widget._controller.keepAlive ?? false) {
+      itemWidget = KeepAliveWrapper(child: itemWidget);
     }
 
     if (widget._controller.onItemTap != null) {

--- a/modules/ensemble/lib/layout/helpers/keep_alive.dart
+++ b/modules/ensemble/lib/layout/helpers/keep_alive.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+
+class KeepAliveWrapper extends StatefulWidget {
+  const KeepAliveWrapper({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<KeepAliveWrapper> createState() => _KeepAliveWrapperState();
+}
+
+class _KeepAliveWrapperState extends State<KeepAliveWrapper>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}

--- a/modules/ensemble/lib/layout/helpers/list_view_core.dart
+++ b/modules/ensemble/lib/layout/helpers/list_view_core.dart
@@ -2,6 +2,7 @@ import 'package:ensemble/ensemble_app.dart';
 import 'package:ensemble/util/debouncer.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart' as flutter;
+import 'keep_alive.dart';
 
 typedef ItemBuilder = Widget Function(BuildContext context, int index);
 
@@ -72,6 +73,7 @@ class ListViewCore extends StatefulWidget {
     this.errorBuilder,
     this.separatorBuilder,
     this.onScroll,
+    this.keepAlive = false,
   });
 
   final bool shrinkWrap;
@@ -94,6 +96,7 @@ class ListViewCore extends StatefulWidget {
   final IndexedWidgetBuilder? separatorBuilder;
   final ItemBuilder itemBuilder;
   final void Function(double)? onScroll;
+  final bool keepAlive;
 
   @override
   State<ListViewCore> createState() => _ListViewCoreState();
@@ -239,19 +242,33 @@ class _ListViewCoreState extends State<ListViewCore> {
                 }
                 if (index == lastItemIndex && showBottomWidget) {
                   if (widget.hasError) {
-                    return errorBuilder(context);
+                    return widget.keepAlive
+                        ? KeepAliveWrapper(child: errorBuilder(context))
+                        : errorBuilder(context);
                   } else if (widget.isLoading) {
-                    return loadingBuilder(context);
+                    return widget.keepAlive
+                        ? KeepAliveWrapper(child: loadingBuilder(context))
+                        : loadingBuilder(context);
                   } else {
-                    return widget.emptyBuilder!(context);
+                    final emptyWidget = widget.emptyBuilder!(context);
+                    return widget.keepAlive
+                        ? KeepAliveWrapper(child: emptyWidget)
+                        : emptyWidget;
                   }
                 } else {
                   final itemIndex =
                       !showSeparator ? index : (index / 2).floor();
                   if (showSeparator && index.isOdd) {
-                    return widget.separatorBuilder!(context, itemIndex);
+                    final separatorWidget =
+                        widget.separatorBuilder!(context, itemIndex);
+                    return widget.keepAlive
+                        ? KeepAliveWrapper(child: separatorWidget)
+                        : separatorWidget;
                   } else {
-                    return widget.itemBuilder(context, itemIndex);
+                    final itemWidget = widget.itemBuilder(context, itemIndex);
+                    return widget.keepAlive
+                        ? KeepAliveWrapper(child: itemWidget)
+                        : itemWidget;
                   }
                 }
               },

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -91,6 +91,8 @@ class ListView extends StatefulWidget
           controller.shrinkWrap = Utils.optionalBool(value),
       'nestedScroll': (value) =>
           controller.nestedScroll = Utils.optionalBool(value),
+      'keepAlive': (value) =>
+          controller.keepAlive = Utils.optionalBool(value),
       'initialScrollOffset': (value) =>
           _controller.initialScrollOffset = Utils.optionalDouble(value),
       'initialScrollIndex': (value) =>
@@ -138,6 +140,7 @@ class ListViewController extends BoxLayoutController {
 
   bool? shrinkWrap;
   bool? nestedScroll;
+  bool? keepAlive;
 
   // scroll position control
   double? initialScrollOffset;
@@ -262,7 +265,7 @@ class ListViewState extends EWidgetState<ListView>
         _scrollControllerOutsideFooter = widget._controller.scrollController;
         _footerScrollControllerSubstituted = true;
       }
-      widget._controller.scrollController = footerScope!.scrollController;
+      widget._controller.scrollController = footerScope.scrollController;
     } else if (footerScope == null) {
       if (_footerScrollControllerSubstituted) {
         widget._controller.scrollController = _scrollControllerOutsideFooter;
@@ -383,6 +386,7 @@ class ListViewState extends EWidgetState<ListView>
       shrinkWrap: widget._controller.shrinkWrap ??
           (FooterScope.of(context) != null ? true : false),
       nestedScroll: widget._controller.nestedScroll?? false,
+      keepAlive: widget._controller.keepAlive ?? false,
       itemCount: itemCount,
       isLoading: showLoading,
       onFetchData: _fetchData,
@@ -471,7 +475,7 @@ class ListViewState extends EWidgetState<ListView>
 
     if (pullToRefresh != null) {
       listView = PullToRefreshContainer(
-          options: pullToRefresh!, contentWidget: listView);
+          options: pullToRefresh, contentWidget: listView);
     }
 
     // TV: Add focusable scrollbar if configured


### PR DESCRIPTION
## Description

This PR adds a `keepAlive` option to `ListView` and `GridView` for improved scrolling performance on TV. Previously, item widgets were rebuilt every time they scrolled out of and back into view, causing janky D-pad scrolling on long lists. The new option keeps item state alive so already-built items are reused when they re-enter the viewport, resulting in smoother and faster navigation.

A reusable `KeepAliveWrapper` helper is introduced (based on `AutomaticKeepAliveClientMixin`) and applied to the list/grid item, separator, empty, loading, and error widgets whenever the new `keepAlive` property is enabled.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `modules/ensemble/lib/layout/helpers/keep_alive.dart` with a new `KeepAliveWrapper` widget that keeps its child alive using `AutomaticKeepAliveClientMixin`
- Updated `ListView` (`list_view.dart`) and `GridView` (`grid_view.dart`) to expose a new `keepAlive` YAML property on their controllers
- Updated `ListViewCore` (`list_view_core.dart`) to accept a `keepAlive` flag and wrap the item, separator, empty, loading, and error widgets in `KeepAliveWrapper` when enabled
- Wrapped `GridView` item widgets in `KeepAliveWrapper` when the `keepAlive` option is enabled
- When `keepAlive` is disabled (default), behavior is unchanged

## How to Test

1. Run the relevant TV tests (if any): `flutter test modules/ensemble/test/widget/...`
2. On a TV/emulator, create a long `ListView` or `GridView` and set `keepAlive: true` in the YAML definition
3. Scroll quickly with the D-pad — items should retain their state and scroll smoothly without being rebuilt
4. Verify behavior with `keepAlive` unset/false — scrolling should behave exactly as before
5. Confirm item taps, separators, and empty/loading states still render correctly

## Screenshots / Videos

N/A

## Checklist

- [x] I have run `flutter analyze` and addressed any new warnings
- [x] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
