### PR TITLE
feat: add cacheExtent property to list and grid view

### DIFF
--- a/modules/ensemble/doc/layout-widgets.md
+++ b/modules/ensemble/doc/layout-widgets.md
@@ -88,6 +88,7 @@ the widget id.
 | `scrollToTop()` / `scrollToBottom()` | Convenience methods for the start and current maximum scroll extent. |
 | `scrollToIndex(index)` | Estimates the offset from the templated data length and clamps the index into range. |
 | `onScroll` | Receives the current pixel offset in `event.data.pixel`. |
+| `cacheExtent` | Pixel distance (before and after the viewport) in which children are built. 
 
 ### Example
 

--- a/modules/ensemble/lib/layout/grid_view.dart
+++ b/modules/ensemble/lib/layout/grid_view.dart
@@ -86,6 +86,8 @@ class GridView extends StatefulWidget
           _controller.direction = Utils.optionalString(value),
       'shrinkWrap': (value) =>
           controller.shrinkWrap = Utils.optionalBool(value),
+      'cacheExtent': (value) =>
+          controller.cacheExtent = Utils.optionalDouble(value),
     };
   }
 
@@ -112,6 +114,7 @@ class GridViewController extends BoxController {
   ScrollController? scrollController;
   String? direction;
   bool? shrinkWrap;
+  double? cacheExtent;
 
   PullToRefresh? pullToRefresh;
   @Deprecated("use pullToRefresh")
@@ -282,7 +285,7 @@ class GridViewState extends EWidgetState<GridView> with TemplatedWidgetState {
           scrollDirection: widget._controller.direction == 'horizontal'
               ? flutter.Axis.horizontal
               : flutter.Axis.vertical,
-          cacheExtent: cachedPixels,
+          cacheExtent: widget._controller.cacheExtent ?? cachedPixels,
           // if used inside CustomScrollView (scrollableView=true), the Grid will inject the top padding
           // to account for the titleBar's height https://github.com/flutter/flutter/issues/108222
           // We handle the titleBar ourselves already, so making sure the padding

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -91,6 +91,8 @@ class ListView extends StatefulWidget
           controller.shrinkWrap = Utils.optionalBool(value),
       'nestedScroll': (value) =>
           controller.nestedScroll = Utils.optionalBool(value),
+      'cacheExtent': (value) =>
+          controller.cacheExtent = Utils.optionalDouble(value),
       'initialScrollOffset': (value) =>
           _controller.initialScrollOffset = Utils.optionalDouble(value),
       'initialScrollIndex': (value) =>
@@ -138,6 +140,7 @@ class ListViewController extends BoxLayoutController {
 
   bool? shrinkWrap;
   bool? nestedScroll;
+  double? cacheExtent;
 
   // scroll position control
   double? initialScrollOffset;
@@ -383,6 +386,7 @@ class ListViewState extends EWidgetState<ListView>
       shrinkWrap: widget._controller.shrinkWrap ??
           (FooterScope.of(context) != null ? true : false),
       nestedScroll: widget._controller.nestedScroll?? false,
+      cacheExtent: widget._controller.cacheExtent,
       itemCount: itemCount,
       isLoading: showLoading,
       onFetchData: _fetchData,


### PR DESCRIPTION
## Description

Add `cacheExtent` property support to ListView and GridView widgets. This property controls the pixel distance (before and after the viewport) in which children are built, allowing developers to optimize rendering performance based on their specific use cases.

## Related Issue

<!-- Link to the GitHub issue this PR addresses, e.g. Fixes #123 -->

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added `cacheExtent` property to `ListViewController` and `GridViewController`
- Implemented `cacheExtent` parameter handling in ListView and GridView widgets
- Updated layout-widgets.md documentation to include `cacheExtent` field
- Default behavior preserved: uses cached pixel value when not specified

## How to Test

1. Update your YAML definition to include `cacheExtent` on ListView or GridView:
   ```yaml
   ListView:
     id: myList
     cacheExtent: 500
     item-template:
       data: ${items}
       template:
         Text:
           text: ${item.name}