### PR TITLE
Fix Indexed tab scrollbar focus

### DIFF
--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -126,6 +126,25 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
     _focusNode.requestFocus();
   }
 
+  /// Refresh visibility when the owning scrollable's content dimensions change.
+  /// A [ScrollController] only notifies listeners for scroll-position changes,
+  /// not for a new maxScrollExtent produced by asynchronous content.
+  void updateForScrollMetrics() {
+    if (!mounted ||
+        !widget.scrollController.hasClients ||
+        !widget.scrollController.position.hasContentDimensions) {
+      return;
+    }
+
+    final wasInitialized = _isInitialized;
+    final wasScrollable = _isScrollable;
+    _isInitialized = true;
+    _updateThumbPosition();
+    if (!wasInitialized || _isScrollable != wasScrollable) {
+      setState(() {});
+    }
+  }
+
   bool get _isFallbackFocusTarget => widget.fallbackFocus != null;
 
   bool get _canScrollUp {

--- a/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
+++ b/modules/ensemble/lib/framework/tv/tv_scrollbar_widget.dart
@@ -135,14 +135,7 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
         !widget.scrollController.position.hasContentDimensions) {
       return;
     }
-
-    final wasInitialized = _isInitialized;
-    final wasScrollable = _isScrollable;
-    _isInitialized = true;
-    _updateThumbPosition();
-    if (!wasInitialized || _isScrollable != wasScrollable) {
-      setState(() {});
-    }
+    _refreshVisibility(markInitialized: true);
   }
 
   bool get _isFallbackFocusTarget => widget.fallbackFocus != null;
@@ -169,11 +162,20 @@ class TVScrollbarWidgetState extends State<TVScrollbarWidget> {
 
   void _onScrollChange() {
     if (!mounted || !widget.scrollController.hasClients) return;
+    _refreshVisibility();
+  }
+
+  /// Updates the thumb and, if visibility should change, rebuilds. Shared by
+  /// [_onScrollChange] (scroll-position updates) and [updateForScrollMetrics]
+  /// (content-dimension updates) so their rebuild condition can't drift apart.
+  void _refreshVisibility({bool markInitialized = false}) {
+    final wasInitialized = _isInitialized;
     final wasScrollable = _isScrollable;
+    if (markInitialized) _isInitialized = true;
     _updateThumbPosition(); // updates _thumbVN + _isScrollable (no setState)
     // Full rebuild only when visibility toggles; thumb moves are handled by the
     // ValueListenableBuilder around the thumb.
-    if (_isScrollable != wasScrollable) {
+    if ((markInitialized && !wasInitialized) || _isScrollable != wasScrollable) {
       setState(() {});
     }
   }

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -545,11 +545,16 @@ class ListViewState extends EWidgetState<ListView>
         // Build Row with scrollbar on correct side
         listView = flutter.NotificationListener<
             flutter.ScrollMetricsNotification>(
-          onNotification: (_) {
+          onNotification: (notification) {
             // Content can grow after this cached ListView first initializes.
             // ScrollController listeners do not fire for that metrics-only
-            // change, so refresh the sibling TV scrollbar explicitly.
-            _scrollbarKey.currentState?.updateForScrollMetrics();
+            // change, so refresh the sibling TV scrollbar explicitly. Only
+            // for this list's own Scrollable (depth 0) -- a nested
+            // scrollable inside an item template bubbles this notification
+            // too, and its metrics don't affect this list's scrollbar.
+            if (notification.depth == 0) {
+              _scrollbarKey.currentState?.updateForScrollMetrics();
+            }
             return false;
           },
           child: flutter.Row(

--- a/modules/ensemble/lib/layout/list_view.dart
+++ b/modules/ensemble/lib/layout/list_view.dart
@@ -543,17 +543,27 @@ class ListViewState extends EWidgetState<ListView>
         );
 
         // Build Row with scrollbar on correct side
-        listView = flutter.Row(
-          crossAxisAlignment: flutter.CrossAxisAlignment.stretch,
-          children: isLeftPosition
-            ? [
-                effectiveScrollbarWidget,
-                flutter.Expanded(child: scopedContent),
-              ]
-            : [
-                flutter.Expanded(child: scopedContent),
-                effectiveScrollbarWidget,
-              ],
+        listView = flutter.NotificationListener<
+            flutter.ScrollMetricsNotification>(
+          onNotification: (_) {
+            // Content can grow after this cached ListView first initializes.
+            // ScrollController listeners do not fire for that metrics-only
+            // change, so refresh the sibling TV scrollbar explicitly.
+            _scrollbarKey.currentState?.updateForScrollMetrics();
+            return false;
+          },
+          child: flutter.Row(
+            crossAxisAlignment: flutter.CrossAxisAlignment.stretch,
+            children: isLeftPosition
+              ? [
+                  effectiveScrollbarWidget,
+                  flutter.Expanded(child: scopedContent),
+                ]
+              : [
+                  flutter.Expanded(child: scopedContent),
+                  effectiveScrollbarWidget,
+                ],
+          ),
         );
       }
     }


### PR DESCRIPTION
## Description

This PR fixes TV scrollbar focus for `ListView` widgets inside indexed TabBar bodies.

When `useIndexedTab: true`, a tab body remains alive while its content finishes laying out. The TV scrollbar could initialize before the ListView had a non-zero scroll extent, remain unavailable for focus, and only become focusable after manual trackpad scrolling.

The fix refreshes the scrollbar when the ListView’s scroll metrics change, so D-pad navigation can focus it as soon as the content becomes scrollable.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Updated `ListView` to observe `ScrollMetricsNotification` when TV `scrollbarOptions` are configured.
- Updated `TVScrollbarWidget` to refresh its scrollability and thumb state when content dimensions become available or change.
- The notification listener returns `false`, so existing scrolling, gestures, and notification propagation are unchanged.
- No YAML, ListView sizing, TabBar selection, or cached-tab behavior was changed.

## How to Test

1. Run the relevant framework widget tests:

   ```bash
   cd modules/ensemble
   flutter test --no-pub test/widget/list_view_core_test.dart test/widget/tab_bar_index_test.dart