### PR TITLE
feat(navigation): add declarative navigation stack support

### DIFF
--- a/modules/ensemble/doc/navigation-architecture.md
+++ b/modules/ensemble/doc/navigation-architecture.md
@@ -1,0 +1,576 @@
+# Ensemble Runtime Navigation Architecture
+
+This document describes how navigation works in the Ensemble runtime.
+
+The runtime uses Flutter Navigator 1.0. Declarative navigation stacks are layered
+on top of that imperative Navigator; Ensemble does not use `MaterialApp.router`.
+
+## Scope
+
+This document covers:
+
+- regular, modal, external-screen, and host-navigator navigation;
+- declarative `navigateScreen.stack` reconciliation;
+- route identity and input matching;
+- lazy historical routes;
+- transition and screen-tracking behavior;
+- action completion and exit reasons;
+- Flutter Web Back/Forward integration;
+- startup, deep links, and host child mode;
+- invariants, extension guidance, diagnostics, and tests.
+
+The implementation is primarily under [`lib/navigation`](../lib/navigation),
+with integration in `ScreenController`, `EnsembleApp`, and the route observers.
+
+## Architecture at a glance
+
+```mermaid
+flowchart TD
+    EDL["EDL navigateScreen action"] --> Parse["NavigateScreenAction parsing"]
+    Parse --> Execute["ScreenController.executeAction"]
+    Execute -->|"stack omitted"| Imperative["navigateToScreen"]
+    Execute -->|"stack present"| Evaluate["Evaluate names and nested inputs"]
+    Evaluate --> Validate["Validate all screen definitions"]
+    Validate --> Manager["EnsembleNavigationManager"]
+    Manager --> Reconciler["NavigationReconciler"]
+    Reconciler --> Factory["EnsembleRouteFactory"]
+    Factory --> Lazy["Lazy historical routes"]
+    Factory --> Destination["Animated destination route"]
+    Lazy --> Navigator["Canonical Flutter Navigator"]
+    Destination --> Navigator
+    Navigator --> Observers["Route and screen-tracking observers"]
+    Manager <--> Browser["Web browser-history adapter"]
+```
+
+
+
+
+
+## The navigators
+
+Ensemble can interact with two navigator domains. They must not be conflated.
+
+
+| Navigator                    | Key/access               | Purpose                                                            | Managed declarative history |
+| ---------------------------- | ------------------------ | ------------------------------------------------------------------ | --------------------------- |
+| Canonical Ensemble navigator | `Utils.globalAppKey`     | Normal Ensemble screens, modals, startup route, declarative stacks | Yes                         |
+| Host/external navigator      | `externalAppNavigateKey` | Embedding Ensemble inside another Flutter application              | No                          |
+
+
+`asExternal: true` selects the host navigator. It is rejected when `stack` is
+present because the declarative history manager only owns the canonical Ensemble
+navigator.
+
+The `external: true` action property is different: it selects a screen registered
+in `Ensemble().externalScreenWidgets`. That screen may still be pushed on the
+canonical navigator. Historical `stack` entries themselves represent
+Ensemble-defined screens and do not expose an external flag.
+
+## Route metadata
+
+Every managed Ensemble route uses two compatible forms of metadata:
+
+- `EnsembleRouteDescriptor` is the typed internal representation.
+- `ScreenPayload` remains in `RouteSettings.arguments` for existing consumers.
+- `EnsembleRouteSettings` holds both forms.
+
+An `EnsembleRouteDescriptor` contains:
+
+- screen ID and/or screen name;
+- evaluated inputs;
+- the external-screen flag;
+- a unique route ID.
+
+The descriptor is used for reconciliation and browser snapshots. Widgets continue
+to receive a `ScreenPayload` so older route observers and screen code do not need
+to understand the navigation subsystem.
+
+### Initial route
+
+When `EnsembleApp` owns the screen (`widget.child == null`), it creates the root
+through `onGenerateInitialRoutes` with `EnsembleRouteSettings`. This lets the
+manager observe Home as the first canonical route.
+
+`home` is intentionally null in this mode. A non-null `onGenerateRoute` callback
+must still be supplied because Flutter's `WidgetsApp` constructor assertion does
+not count `onGenerateInitialRoutes` as a route provider. The callback is present
+to satisfy that Flutter invariant; the typed initial route remains authoritative.
+
+When a host supplies `widget.child`, `EnsembleApp` uses the normal `home` path.
+That route is not given Ensemble metadata and is therefore not treated as
+declarative Ensemble history.
+
+## Action types and routing paths
+
+
+
+### Regular `navigateScreen` without `stack`
+
+This remains the legacy imperative path:
+
+1. `NavigateScreenAction` is parsed.
+2. `ScreenController.executeAction` evaluates destination inputs.
+3. Toasts, dialogs, and bottom sheets are dismissed according to options.
+4. `ScreenController.navigateToScreen` constructs the screen and route.
+5. Navigator performs push, replacement, or clear-all.
+6. The returned `Navigator.push` future completes when the route is popped.
+
+The supported imperative options are:
+
+- normal push;
+- `options.replaceCurrentScreen`;
+- `options.clearAllScreens`;
+- `asExternal` host navigation;
+- `external` registered-screen navigation.
+
+
+
+### `navigateModalScreen`
+
+Modal navigation continues through `navigateToScreen` with `PageType.modal`.
+The declarative `stack` API is only parsed for `NavigateScreenAction`; modal
+actions are not reconciled declaratively. Modal routes still carry typed metadata
+when they are pushed on the canonical navigator.
+
+### Declarative `navigateScreen.stack`
+
+Only the extensible object form is accepted:
+
+```yaml
+navigateScreen:
+  name: ScreenC
+  inputs:
+    recordId: ${record.id}
+  stack:
+    - name: Home
+    - name: ScreenB
+      inputs:
+        source: example
+```
+
+String-only entries are rejected. `stack` omitted and `stack: []` have different
+meanings:
+
+- omitted: use existing imperative navigation unchanged;
+- empty array: remove all preceding Ensemble history and make the destination
+the new root.
+
+`stack` cannot be combined with `clearAllScreens`, `replaceCurrentScreen`, or
+`asExternal`.
+
+## Evaluation and validation
+
+Declarative stack processing occurs before Navigator is mutated.
+
+1. The destination name and every stack-entry name are evaluated against the
+  initiating `DataContext`.
+2. Names must evaluate to non-empty strings.
+3. Nested maps and lists in `inputs` are recursively evaluated against the same
+  context.
+4. All historical definitions and the destination definition are validated.
+5. Independent definition lookups run concurrently to avoid one cache/network
+  round trip per historical entry.
+6. Errors are inspected in declaration order so diagnostics remain deterministic.
+
+Example diagnostic:
+
+```text
+navigateScreen.stack[1] references unknown screen "MissingScreen".
+```
+
+Validation is all-or-nothing. No route is pushed or removed if any requested
+screen is invalid.
+
+## Route matching and reconciliation
+
+`NavigationReconciler` is pure: it compares the current managed history with the
+requested history and returns four values:
+
+- `prefixLength`;
+- retained existing routes;
+- obsolete existing suffix;
+- missing requested suffix.
+
+Only the longest compatible prefix is retained. The reconciler never searches
+later in the stack, reorders routes, or deduplicates repeated screens.
+
+### Input matching is directional
+
+Inputs in the requested stack control whether an existing route can be reused:
+
+
+| Requested entry               | Existing same screen       | Result                             |
+| ----------------------------- | -------------------------- | ---------------------------------- |
+| Inputs omitted                | Any existing inputs        | Keep existing route and its inputs |
+| `inputs: {}`                  | Any existing inputs        | Keep existing route and its inputs |
+| Non-empty inputs equal deeply | Same evaluated values      | Keep existing route                |
+| Non-empty inputs differ       | Different evaluated values | Drop from mismatch onward          |
+
+
+This is intentionally different from exact descriptor equality.
+`satisfiesHistoryRequest` implements the directional wildcard rule used by the
+reconciler. `isEquivalentTo` remains exact and is used for browser snapshots and
+restoration comparisons.
+
+When an input-less request retains a route, browser history uses the retained
+route's real descriptor. It must not replace the preserved inputs with the
+input-less requested descriptor.
+
+### Example
+
+```text
+Current:   Home(inputs: user=42) -> ScreenA
+Requested: Home                   -> ScreenB -> ScreenC
+```
+
+The result is:
+
+```text
+KEEP:   Home(inputs: user=42)
+DROP:   ScreenA
+INSERT: ScreenB
+PUSH:   ScreenC
+```
+
+
+
+## Lazy historical routes
+
+A requested historical route does not imply that its screen should be visited.
+Missing history is represented by `LazyEnsemblePageRouteBuilder`.
+
+The lazy route is a real Flutter route, which preserves native Navigator Back
+semantics, but its child is dormant until the route becomes visible. Insertion
+does not:
+
+- construct the Ensemble `Screen`;
+- fetch/build its screen widget through the screen factory;
+- create screen scope and page lifecycle state;
+- run screen APIs or `onLoad` work;
+- publish a screen-tracking event.
+
+Only the destination is constructed eagerly during forward navigation.
+
+```text
+Flutter route stack after reconciliation
+
+Materialized(Home)
+Lazy(ScreenB)
+Materialized(ScreenC)
+```
+
+
+
+### Materialization on Back
+
+When the destination is popped, Flutter calls `didPopNext` on the lazy route.
+The route activates its screen builder while the outgoing destination is still
+covering it. This gives the historical screen time to initialize during the
+reverse transition.
+
+For iOS interactive Back gestures, the manager's observer materializes the
+previous lazy route in `didStartUserGesture`, because it can become partially
+visible before `didPopNext` is delivered.
+
+Once materialized, a lazy route stays materialized. It behaves like a normal
+retained route for the remainder of its lifetime.
+
+## Transaction ordering
+
+`EnsembleNavigationManager` serializes declarative transactions FIFO. Identical
+requests already pending are coalesced so rapid repeated taps do not create
+duplicate routes.
+
+The transaction has two completion concepts:
+
+1. **Destination accepted:** the route returned to `ScreenController` as soon as
+  Navigator accepts the push.
+2. **Internal completion:** transition cleanup and browser synchronization finish;
+  the next queued declarative transaction may then start.
+
+The mutation sequence is:
+
+1. Snapshot current canonical history.
+2. Calculate the longest compatible prefix.
+3. Construct dormant routes for the missing history.
+4. Construct the animated destination route.
+5. Push all missing lazy routes synchronously.
+6. Push the destination synchronously.
+7. If a synchronous push fails, remove the newly pushed routes in reverse order.
+8. Keep the obsolete current suffix alive through the destination's forward
+  transition.
+9. Remove the obsolete suffix after the transition completes.
+10. Finish browser-history reconciliation before starting the next queued
+  declarative transaction.
+
+The old visible route is deliberately removed after the destination transition.
+Removing it immediately would leave a dormant transparent route underneath the
+destination and could expose the Navigator background as a black frame.
+
+Lazy routes also return false from `canTransitionFrom` and `canTransitionTo`.
+This prevents their zero-duration animations from driving an adjacent real
+route's `secondaryAnimation` and producing an unexpected transition or flash.
+
+## Observer topology and canonical history
+
+`EnsembleRouteObserver.initializeRouteObservers` registers observers in this
+order:
+
+1. `AppRouteObserver` tracks the top-most route for overlay dismissal.
+2. Flutter `RouteObserver<PageRoute>` supports `RouteAware` widgets.
+3. `ScreenTrackingNavigatorObserver` publishes visible screens.
+4. `EnsembleNavigationManager.observer` maintains canonical route history.
+
+The manager observer handles `didPush`, `didPop`, `didRemove`, and `didReplace`.
+Only routes with `EnsembleRouteSettings` enter canonical Ensemble history.
+Host child-mode routes and routes owned by the external host navigator are
+ignored.
+
+During a multi-route declarative push, per-route browser publication is
+suppressed. The manager publishes the final logical state as one transaction.
+
+## Screen tracking
+
+Screen tracking represents visibility, not structural Navigator membership.
+
+Normal routes are tracked by `ScreenTrackingNavigatorObserver.didPush`. The
+`Screen` widget avoids duplicate tracking when the observer has already published
+the same screen.
+
+Lazy historical routes are special:
+
+- their structural `didPush` is ignored by screen tracking;
+- reconciliation removal silently purges stale routes from tracking history;
+- popping onto a lazy route removes the outgoing tracked route without restoring
+a stale screen;
+- the materialized `Screen` publishes itself when it is actually revealed.
+
+For a forward rewrite, the expected log is therefore:
+
+```text
+INSERT: ScreenB
+PUSH: ScreenC
+SCREEN TRACKER: ScreenC
+```
+
+After Back:
+
+```text
+SCREEN TRACKER: ScreenB
+```
+
+Do not make screen tracking respond to every lazy route push. That corrupts
+analytics by reporting screens the user has never seen.
+
+## Exit reasons and callbacks
+
+`EnsembleRouteExitReason` distinguishes:
+
+- `back`;
+- `replaced`;
+- `historyReconciled`;
+- `rootCleared`.
+
+The manager records a programmatic exit reason before removing or replacing a
+route. A real `didPop` defaults to `back`.
+
+`onNavigateBack` is attached to the destination route's `popped` future, but it
+runs only when the recorded reason is `back`. Reconciliation, replacement, and
+clear-all still dispose route widgets normally without invoking the callback.
+The real Back payload is passed through unchanged.
+
+Legacy `navigateScreen` waits for its pushed route to pop before the action
+completes. The declarative path preserves that action timing by awaiting
+`route.popped` in `ScreenController`, separately from the manager's internal
+transaction completion.
+
+## Imperative replacement and clear-all
+
+Stack-less replacement and clear-all remain on the legacy path:
+
+- `Navigator.pushReplacement` is marked `replaced` before mutation.
+- `Navigator.pushAndRemoveUntil` is marked `rootCleared` before mutation.
+
+The manager observer then updates canonical history from the resulting Navigator
+events. The exit reason prevents these operations from being mistaken for Back.
+
+## Flutter Web browser history
+
+The browser adapter is conditionally imported:
+
+- native platforms use a no-op implementation;
+- Flutter Web uses the session-only `dart:html` adapter.
+
+The visible URL is never changed to a public screen URL. Browser state stores only
+an opaque token such as `ensemble_history_3`. The descriptor snapshot, including
+inputs, remains in an in-memory map keyed by that token.
+
+### Normal navigation
+
+- The first managed route replaces the current browser entry.
+- A normal route push adds a browser entry containing the new snapshot token.
+- A normal Flutter pop calls browser `back()` unless it originated from
+`popstate`.
+
+
+
+### Declarative reconciliation
+
+The adapter moves browser history back to the retained prefix, then pushes tokens
+for reconstructed history and the destination. If no prefix is retained, it
+reuses the earliest reachable entry as the new root. Calling `pushState` after
+moving backward truncates the obsolete forward branch.
+
+### Back and Forward
+
+A known token received through `popstate` is resolved to its in-memory snapshot.
+The manager then either:
+
+- pops Navigator routes when the snapshot is a strict current prefix; or
+- runs the normal reconciler in browser-restore mode for Forward or a changed
+branch.
+
+Browser-restore mode suppresses duplicate browser entries.
+
+After refresh, in-memory snapshots no longer exist. Unknown or stale tokens are
+ignored and normal application startup wins. Public URL serialization and
+refresh restoration are intentionally out of scope.
+
+## Deep links
+
+Platform and app-link handling lives in `deep_link_manager.dart` and
+`ios_deep_link_manager.dart`.
+
+Current deep-link handlers call the imperative `ScreenController.navigateToScreen`
+path directly after resolving either a global handler result or legacy query
+parameters. They do not invoke declarative stack reconciliation. Any future work
+that allows deep links to provide `stack` must route through the same evaluation,
+validation, and manager pipeline as `ScreenController.executeAction`; passing a
+parsed `NavigateScreenAction` to the imperative helper is insufficient.
+
+## PageGroup and retained state
+
+PageGroup, bottom navigation, and other `RouteAware` widgets use the existing
+`RouteObserver<PageRoute>`. Declarative reconciliation does not recreate retained
+routes, so their widget tree, scroll position, PageGroup index, and local state
+survive.
+
+Missing lazy routes have no state to preserve until materialized. Once built,
+they follow normal route and PageGroup lifecycle behavior.
+
+## Diagnostics
+
+Debug builds log one summary per declarative transaction:
+
+```text
+[Navigation] Transaction: nav_0
+Current: Home -> ScreenA
+Requested: Home -> ScreenB -> ScreenC
+KEEP: Home
+DROP: ScreenA
+INSERT: ScreenB
+PUSH: ScreenC
+```
+
+Diagnostics include route names and operations but must not include raw inputs,
+which may contain secrets or personal data.
+
+Interpretation:
+
+- `KEEP` means the exact live Flutter route and widget state are retained.
+- `DROP` means removal after the destination's forward transition.
+- `INSERT` means a dormant Flutter history route, not a visited screen.
+- `PUSH` is the only eagerly constructed destination.
+
+
+
+## Failure and race behavior
+
+- Validation failure: no Navigator mutation occurs.
+- Synchronous push failure: newly pushed routes are removed in reverse order;
+the old suffix has not yet been removed.
+- Rapid distinct requests: processed FIFO.
+- Rapid identical requests: share the pending destination future.
+- Missing browser `popstate` during an internal history move: a short timeout
+prevents the transaction queue from hanging indefinitely.
+- Unmounted browser-restore navigator: restoration is ignored.
+- Unknown browser token: normal current/startup state is retained.
+
+
+
+## Rules for modifying navigation
+
+Preserve these invariants:
+
+1. Do not mutate Navigator until every requested descriptor validates.
+2. Do not treat omitted `stack` as `stack: []`.
+3. Do not change exact equality to implement requested-input wildcards; use the
+  directional reconciliation matcher.
+4. Never reuse a route after the first prefix mismatch.
+5. Do not eagerly build historical screens.
+6. Do not let lazy routes participate in adjacent transition animations.
+7. Keep the outgoing route visible until the destination transition completes.
+8. Do not publish lazy route insertion as a screen view.
+9. Record programmatic exit reasons before Navigator mutation.
+10. Invoke `onNavigateBack` only for a real Back pop.
+11. Keep route inputs out of URLs and serialized browser state.
+12. Do not add host-child or host-navigator routes to canonical Ensemble history.
+13. Preserve `ScreenPayload` in route arguments for compatibility.
+14. Keep the root route typed, and retain the non-null `onGenerateRoute` callback
+  required by Flutter when `home` is null.
+
+
+
+## Key source files
+
+
+| Area                                      | File                                                                           |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
+| Action parsing                            | `modules/ensemble/lib/framework/action.dart`                                   |
+| Action execution and legacy navigation    | `modules/ensemble/lib/screen_controller.dart`                                  |
+| App/root Navigator setup                  | `modules/ensemble/lib/ensemble_app.dart`                                       |
+| Observer registration                     | `modules/ensemble/lib/framework/route_observer.dart`                           |
+| Screen visibility tracking                | `modules/ensemble/lib/framework/screen_tracker.dart`                           |
+| Transition route implementations          | `modules/ensemble/lib/layout/ensemble_page_route.dart`                         |
+| Route models and exit reasons             | `modules/ensemble/lib/navigation/navigation_models.dart`                       |
+| Pure prefix calculation                   | `modules/ensemble/lib/navigation/navigation_reconciler.dart`                   |
+| Route construction                        | `modules/ensemble/lib/navigation/ensemble_route_factory.dart`                  |
+| Transaction and canonical history manager | `modules/ensemble/lib/navigation/ensemble_navigation_manager.dart`             |
+| Browser abstraction and adapters          | `modules/ensemble/lib/navigation/browser/`                                     |
+| Public schema                             | `modules/ensemble/assets/schema/ensemble_schema.json`                          |
+| Native/app deep links                     | `modules/ensemble/lib/deep_link_manager.dart` and `ios_deep_link_manager.dart` |
+
+
+
+
+## Tests and verification
+
+Focused coverage lives in:
+
+- `modules/ensemble/test/action_test.dart`;
+- `modules/ensemble/test/navigation_reconciler_test.dart`;
+- `modules/ensemble/test/ensemble_navigation_manager_test.dart`.
+
+The tests cover parsing, option conflicts, prefix matching, wildcard inputs,
+state retention, lazy materialization, transition isolation, tracking, exit
+reasons, transaction coalescing, and browser snapshot publication.
+
+Run focused tests from `modules/ensemble`:
+
+```bash
+flutter test \
+  test/action_test.dart \
+  test/navigation_reconciler_test.dart \
+  test/ensemble_navigation_manager_test.dart
+```
+
+Then run the broader module checks:
+
+```bash
+flutter test
+flutter analyze
+```
+
+The module currently has documented pre-existing analyzer warnings. Compare
+results against the baseline and treat new errors or warnings in navigation files
+as regressions.

--- a/modules/ensemble/doc/navigation-architecture.md
+++ b/modules/ensemble/doc/navigation-architecture.md
@@ -79,6 +79,7 @@ An `EnsembleRouteDescriptor` contains:
 - screen ID and/or screen name;
 - evaluated inputs;
 - the external-screen flag;
+- the route page type (`regular` or `modal`);
 - a unique route ID.
 
 The descriptor is used for reconciliation and browser snapshots. Widgets continue
@@ -193,6 +194,9 @@ requested history and returns four values:
 
 Only the longest compatible prefix is retained. The reconciler never searches
 later in the stack, reorders routes, or deduplicates repeated screens.
+Requested screen names are matched against canonical screen names, while
+requested IDs are matched against IDs. Route page type and the external-screen
+flag must also match, so a modal cannot be retained as a regular stack entry.
 
 ### Input matching is directional
 
@@ -266,7 +270,8 @@ Materialized(ScreenC)
 When the destination is popped, Flutter calls `didPopNext` on the lazy route.
 The route activates its screen builder while the outgoing destination is still
 covering it. This gives the historical screen time to initialize during the
-reverse transition.
+reverse transition. Screen tracking waits for the outgoing transition route's
+`completed` future before publishing the materialized screen as visible.
 
 For iOS interactive Back gestures, the manager's observer materializes the
 previous lazy route in `didStartUserGesture`, because it can become partially
@@ -279,7 +284,8 @@ retained route for the remainder of its lifetime.
 
 `EnsembleNavigationManager` serializes declarative transactions FIFO. Identical
 requests already pending are coalesced so rapid repeated taps do not create
-duplicate routes.
+duplicate routes. Coalescing uses deep structural equality, so map insertion
+order does not make otherwise equivalent inputs different.
 
 The transaction has two completion concepts:
 
@@ -306,6 +312,9 @@ The mutation sequence is:
 The old visible route is deliberately removed after the destination transition.
 Removing it immediately would leave a dormant transparent route underneath the
 destination and could expose the Navigator background as a black frame.
+If another navigation removes the destination mid-transition, its `popped`
+future releases the transaction queue even though Flutter disposes the animation
+without sending a final status notification.
 
 Lazy routes also return false from `canTransitionFrom` and `canTransitionTo`.
 This prevents their zero-duration animations from driving an adjacent real

--- a/modules/ensemble/lib/ensemble_app.dart
+++ b/modules/ensemble/lib/ensemble_app.dart
@@ -21,6 +21,8 @@ import 'package:ensemble/framework/theme_manager.dart';
 import 'package:ensemble/framework/widget/error_screen.dart';
 import 'package:ensemble/framework/widget/screen.dart';
 import 'package:ensemble/ios_deep_link_manager.dart';
+import 'package:ensemble/layout/ensemble_page_route.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/upload_utils.dart';
 import 'package:ensemble/util/utils.dart';
@@ -453,6 +455,18 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
     }
 
     StorageManager().setIsPreview(widget.isPreview);
+    // The root route must carry the same typed metadata as subsequently pushed
+    // Ensemble routes so reconciliation can treat it as canonical history.
+    final rootDescriptor = widget.child == null
+        ? EnsembleRouteDescriptor(
+            screenId: widget.screenPayload?.screenId,
+            screenName: widget.screenPayload?.screenName ??
+                config.definitionProvider.getHomeScreenName(),
+            inputs: widget.screenPayload?.arguments,
+            isExternal: widget.screenPayload?.isExternal ?? false,
+          )
+        : null;
+    final rootPayload = rootDescriptor?.toPayload();
     Widget app = MaterialApp(
       key: appKey,
       navigatorObservers: Ensemble().routeObservers,
@@ -468,7 +482,22 @@ class EnsembleAppState extends State<EnsembleApp> with WidgetsBindingObserver {
             definitionProvider: config.definitionProvider);
         return Ensemble().locale;
       },
-      home: content,
+      home: widget.child != null ? content : null,
+      onGenerateInitialRoutes: widget.child == null
+          ? (_) => <Route<dynamic>>[
+                EnsemblePageRouteNoTransitionBuilder(
+                  screenWidget: content,
+                  settings: EnsembleRouteSettings(
+                    descriptor: rootDescriptor!,
+                    payload: rootPayload!,
+                  ),
+                ),
+              ]
+          : null,
+      // WidgetsApp's constructor assertion does not consider
+      // onGenerateInitialRoutes a route provider. Keep this callback non-null
+      // when `home` is null; the typed root route above remains authoritative.
+      onGenerateRoute: widget.child == null ? (_) => null : null,
       useInheritedMediaQuery: widget.isPreview,
       builder: (context, child) {
         final appChild = widget.isPreview

--- a/modules/ensemble/lib/framework/action.dart
+++ b/modules/ensemble/lib/framework/action.dart
@@ -50,6 +50,7 @@ import 'package:ensemble/framework/scope.dart';
 import 'package:ensemble/framework/stub/plaid_link_manager.dart';
 import 'package:ensemble/framework/view/page_group.dart';
 import 'package:ensemble/framework/widget/view_util.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
 import 'package:ensemble/receive_intent_manager.dart';
 import 'package:ensemble/screen_controller.dart';
 import 'package:ensemble/util/utils.dart';
@@ -101,11 +102,15 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       required super.screenName,
       super.payload,
       super.options,
+      this.stack,
       this.onNavigateBack,
       super.transition,
       super.isExternal,
       super.asExternal})
       : super(asModal: false);
+
+  /// Unevaluated history requested immediately before the destination.
+  final List<NavigationStackEntry>? stack;
   EnsembleAction? onNavigateBack;
 
   factory NavigateScreenAction.fromMap({Invokable? initiator, Map? payload}) {
@@ -113,16 +118,40 @@ class NavigateScreenAction extends BaseNavigateScreenAction {
       throw LanguageError(
           "${ActionType.navigateScreen.name} requires the 'name' of the screen to navigate to.");
     }
+    List<NavigationStackEntry>? stack;
+    if (payload.containsKey('stack')) {
+      final rawStack = payload['stack'];
+      if (rawStack is! List) {
+        throw LanguageError('navigateScreen.stack must be an array.');
+      }
+      stack = <NavigationStackEntry>[
+        for (var index = 0; index < rawStack.length; index++)
+          NavigationStackEntry.from(rawStack[index], index),
+      ];
+    }
+    final options = Utils.getMap(payload['options']);
+    final asExternal = Utils.getBool(payload['asExternal'], fallback: false);
+    if (stack != null &&
+        (options?['clearAllScreens'] == true ||
+            options?['replaceCurrentScreen'] == true)) {
+      throw LanguageError(
+          'navigateScreen.stack cannot be combined with options.clearAllScreens or options.replaceCurrentScreen.');
+    }
+    if (stack != null && asExternal) {
+      throw LanguageError(
+          'navigateScreen.stack cannot be used with asExternal.');
+    }
     return NavigateScreenAction(
       initiator: initiator,
       screenName: payload['name'].toString(),
       payload:
           Utils.getMap(payload['payload']) ?? Utils.getMap(payload['inputs']),
-      options: Utils.getMap(payload['options']),
+      options: options,
+      stack: stack,
       onNavigateBack: EnsembleAction.from(payload['onNavigateBack']),
       transition: Utils.getMap(payload['transition']),
       isExternal: Utils.getBool(payload['external'], fallback: false),
-      asExternal: Utils.getBool(payload['asExternal'], fallback: false),
+      asExternal: asExternal,
     );
   }
 

--- a/modules/ensemble/lib/framework/route_observer.dart
+++ b/modules/ensemble/lib/framework/route_observer.dart
@@ -1,5 +1,6 @@
 import 'package:ensemble/ensemble.dart';
 import 'package:ensemble/framework/screen_tracker.dart';
+import 'package:ensemble/navigation/ensemble_navigation_manager.dart';
 import 'package:flutter/cupertino.dart';
 
 // handle the listeners to listen for Route changes
@@ -24,6 +25,10 @@ mixin EnsembleRouteObserver on WithEnsemble {
 
     _screenTrackingObserver = ScreenTrackingNavigatorObserver();
     routeObservers.add(_screenTrackingObserver);
+
+    // Register last so tracking observes the same Navigator event before the
+    // manager publishes its canonical history snapshot.
+    routeObservers.add(EnsembleNavigationManager.instance.observer);
   }
 
   // return the current top-most Route for our App

--- a/modules/ensemble/lib/framework/screen_tracker.dart
+++ b/modules/ensemble/lib/framework/screen_tracker.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+
+import 'package:ensemble/layout/ensemble_page_route.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -151,6 +153,24 @@ class ScreenTracker {
     _setCurrentScreen(null);
   }
 
+  /// Removes a route from tracking without publishing another screen.
+  ///
+  /// This is used while Navigator is exposing a lazy historical route. The
+  /// lazy route's Screen widget will publish itself when it materializes.
+  void _removeRouteSilently(Route route) {
+    _screenStack.removeWhere((screen) => screen.route == route);
+    if (_currentScreen?.route == route) _currentScreen = null;
+  }
+
+  /// Handles programmatic removal of a route that may not be the visible one.
+  void _handleScreenRemove(Route removedRoute, Route? previousRoute) {
+    if (_currentScreen?.route == removedRoute) {
+      handleScreenPop(removedRoute, previousRoute);
+      return;
+    }
+    _screenStack.removeWhere((screen) => screen.route == removedRoute);
+  }
+
   /// Extract screen info from route and track it (helper method)
   void _extractAndTrackScreenFromRoute(Route route) {
     final settings = route.settings;
@@ -278,6 +298,10 @@ class ScreenTrackingNavigatorObserver extends NavigatorObserver {
   void didPush(Route route, Route? previousRoute) {
     super.didPush(route, previousRoute);
 
+    // Lazy routes are structural history only. They become trackable when the
+    // real Ensemble screen is materialized after Back navigation.
+    if (route is LazyEnsemblePageRouteBuilder<dynamic>) return;
+
     // Extract screen info from route if available
     _extractAndTrackScreenFromRoute(route);
   }
@@ -285,6 +309,11 @@ class ScreenTrackingNavigatorObserver extends NavigatorObserver {
   @override
   void didPop(Route route, Route? previousRoute) {
     super.didPop(route, previousRoute);
+
+    if (previousRoute is LazyEnsemblePageRouteBuilder<dynamic>) {
+      _tracker._removeRouteSilently(route);
+      return;
+    }
 
     // Handle screen pop with previous route info
     _tracker.handleScreenPop(route, previousRoute);
@@ -303,8 +332,7 @@ class ScreenTrackingNavigatorObserver extends NavigatorObserver {
   void didRemove(Route route, Route? previousRoute) {
     super.didRemove(route, previousRoute);
 
-    // Handle screen removal with previous route info
-    _tracker.handleScreenPop(route, previousRoute);
+    _tracker._handleScreenRemove(route, previousRoute);
   }
 
   void _extractAndTrackScreenFromRoute(Route route) {

--- a/modules/ensemble/lib/framework/widget/screen.dart
+++ b/modules/ensemble/lib/framework/widget/screen.dart
@@ -13,6 +13,7 @@ import 'package:ensemble/framework/theme/theme_loader.dart';
 import 'package:ensemble/framework/theme_manager.dart';
 import 'package:ensemble/framework/view/page_group.dart';
 import 'package:ensemble/framework/view/page.dart' as ensemble;
+import 'package:ensemble/layout/ensemble_page_route.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -44,6 +45,7 @@ class _ScreenState extends State<Screen> {
   Widget? externalScreen;
   Key _contentKey = UniqueKey();
   ScreenPayload? _enhancedPayload; // Store enhanced payload for refresh matching
+  bool _screenTrackingScheduled = false;
 
   @override
   void initState() {
@@ -129,18 +131,7 @@ class _ScreenState extends State<Screen> {
     // Track screen after we have the pageModel - this ensures we can check if it's a ViewGroup
     // Only track if NOT a ViewGroup container (ViewGroup tabs track themselves)
     if (pageModel is! PageGroupModel) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          final inViewGroup = PageGroupWidget.getScope(context) != null;
-          final isCurrentRoute = ModalRoute.of(context)?.isCurrent ?? false;
-
-          if (!inViewGroup && isCurrentRoute) {
-            if (!_isScreenAlreadyTracked()) {
-              _trackScreenWithEnhancement();
-            }
-          }
-        }
-      });
+      _scheduleScreenTracking();
     }
 
     //here add the js code
@@ -176,6 +167,38 @@ class _ScreenState extends State<Screen> {
       dataContext: dataContext,
       screenPayload: _enhancedPayload ?? widget.screenPayload,
     );
+  }
+
+  void _scheduleScreenTracking() {
+    if (_screenTrackingScheduled) return;
+    _screenTrackingScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final route = ModalRoute.of(context);
+      if (route is LazyEnsemblePageRouteBuilder<dynamic> && !route.isCurrent) {
+        // didPopNext materializes lazy history before the outgoing route has
+        // finished reversing. Wait for the route's explicit reveal signal so
+        // the one-shot visibility check cannot miss screen tracking.
+        route.revealed.whenComplete(_trackCurrentScreenAfterFrame);
+        return;
+      }
+      _trackCurrentScreen();
+    });
+  }
+
+  void _trackCurrentScreenAfterFrame() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _trackCurrentScreen();
+    });
+  }
+
+  void _trackCurrentScreen() {
+    if (PageGroupWidget.getScope(context) != null ||
+        !(ModalRoute.of(context)?.isCurrent ?? false) ||
+        _isScreenAlreadyTracked()) {
+      return;
+    }
+    _trackScreenWithEnhancement();
   }
 
   /// Check if the current screen is already being tracked

--- a/modules/ensemble/lib/layout/ensemble_page_route.dart
+++ b/modules/ensemble/lib/layout/ensemble_page_route.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 /// Route transition animations supported by Ensemble navigation.
@@ -126,6 +128,11 @@ class LazyEnsemblePageRouteBuilder<T> extends PageRouteBuilder<T> {
         );
 
   final ValueNotifier<bool> _activation;
+  final Completer<void> _revealed = Completer<void>();
+
+  /// Completes once the route above has finished popping and this route can be
+  /// treated as visible by screen tracking.
+  Future<void> get revealed => _revealed.future;
 
   /// Starts building the real screen. Calling this more than once is harmless.
   void materialize() {
@@ -146,7 +153,16 @@ class LazyEnsemblePageRouteBuilder<T> extends PageRouteBuilder<T> {
     // didPopNext runs as the route above starts its reverse transition, so the
     // historical screen can initialize while the outgoing screen is visible.
     materialize();
+    if (nextRoute is TransitionRoute<dynamic>) {
+      nextRoute.completed.whenComplete(_completeReveal);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _completeReveal());
+    }
     super.didPopNext(nextRoute);
+  }
+
+  void _completeReveal() {
+    if (!_revealed.isCompleted) _revealed.complete();
   }
 
   @override

--- a/modules/ensemble/lib/layout/ensemble_page_route.dart
+++ b/modules/ensemble/lib/layout/ensemble_page_route.dart
@@ -88,6 +88,74 @@ class EnsemblePageRouteNoTransitionBuilder extends PageRouteBuilder {
         );
 }
 
+/// A lightweight route used for declaratively reconstructed history.
+///
+/// The route occupies its normal position in Flutter's Navigator stack, but
+/// does not construct its Ensemble screen until a later route is popped and
+/// this route is about to become visible.
+class LazyEnsemblePageRouteBuilder<T> extends PageRouteBuilder<T> {
+  factory LazyEnsemblePageRouteBuilder({
+    required WidgetBuilder screenBuilder,
+    RouteSettings? settings,
+  }) {
+    final activation = ValueNotifier<bool>(false);
+    return LazyEnsemblePageRouteBuilder<T>._(
+      activation: activation,
+      screenBuilder: screenBuilder,
+      settings: settings,
+    );
+  }
+
+  LazyEnsemblePageRouteBuilder._({
+    required ValueNotifier<bool> activation,
+    required WidgetBuilder screenBuilder,
+    RouteSettings? settings,
+  })  : _activation = activation,
+        super(
+          settings: settings,
+          opaque: false,
+          maintainState: true,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              ValueListenableBuilder<bool>(
+            valueListenable: activation,
+            builder: (context, active, _) =>
+                active ? screenBuilder(context) : const SizedBox.shrink(),
+          ),
+        );
+
+  final ValueNotifier<bool> _activation;
+
+  /// Starts building the real screen. Calling this more than once is harmless.
+  void materialize() {
+    if (!_activation.value) _activation.value = true;
+  }
+
+  // A lazy history entry is structural, not visual. Linking its zero-duration
+  // animation to adjacent routes can instantly drive the outgoing route's
+  // secondary animation and expose the Navigator background for a frame.
+  @override
+  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) => false;
+
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) => false;
+
+  @override
+  void didPopNext(Route<dynamic> nextRoute) {
+    // didPopNext runs as the route above starts its reverse transition, so the
+    // historical screen can initialize while the outgoing screen is visible.
+    materialize();
+    super.didPopNext(nextRoute);
+  }
+
+  @override
+  void dispose() {
+    _activation.dispose();
+    super.dispose();
+  }
+}
+
 /// Page route builder that applies Ensemble-configured transition animations.
 class EnsemblePageRouteBuilder<T> extends PageRouteBuilder<T> {
   /// Widget displayed by the generated page route.

--- a/modules/ensemble/lib/navigation/browser/navigation_browser_history.dart
+++ b/modules/ensemble/lib/navigation/browser/navigation_browser_history.dart
@@ -1,0 +1,11 @@
+import 'package:ensemble/navigation/browser/navigation_browser_history_base.dart';
+import 'package:ensemble/navigation/browser/navigation_browser_history_stub.dart'
+    if (dart.library.html) 'package:ensemble/navigation/browser/navigation_browser_history_web.dart'
+    as platform;
+
+export 'navigation_browser_history_base.dart';
+
+/// Creates the web adapter or a no-op adapter on native platforms.
+NavigationBrowserHistory createNavigationBrowserHistory(
+        BrowserHistoryRestore onRestore) =>
+    platform.createNavigationBrowserHistory(onRestore);

--- a/modules/ensemble/lib/navigation/browser/navigation_browser_history_base.dart
+++ b/modules/ensemble/lib/navigation/browser/navigation_browser_history_base.dart
@@ -1,0 +1,27 @@
+import 'package:ensemble/navigation/navigation_models.dart';
+
+/// Restores a descriptor snapshot selected by browser Back or Forward.
+typedef BrowserHistoryRestore = Future<void> Function(
+    List<EnsembleRouteDescriptor> snapshot);
+
+/// Platform abstraction for session-only browser navigation history.
+abstract class NavigationBrowserHistory {
+  /// Whether a browser popstate callback is currently restoring Navigator.
+  bool get isHandlingPopState;
+
+  /// Associates the current browser entry with the initial route snapshot.
+  void replaceInitial(List<EnsembleRouteDescriptor> snapshot);
+
+  /// Adds one browser entry for a normal Ensemble route push.
+  void recordPush(List<EnsembleRouteDescriptor> snapshot);
+
+  /// Mirrors a normal Ensemble route pop in browser history.
+  void recordPop();
+
+  /// Rewrites browser entries to match one committed declarative transaction.
+  Future<void> reconcile({
+    required int currentDepth,
+    required int prefixLength,
+    required List<EnsembleRouteDescriptor> finalHistory,
+  });
+}

--- a/modules/ensemble/lib/navigation/browser/navigation_browser_history_stub.dart
+++ b/modules/ensemble/lib/navigation/browser/navigation_browser_history_stub.dart
@@ -1,0 +1,28 @@
+import 'package:ensemble/navigation/browser/navigation_browser_history_base.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
+
+/// Creates the native no-op implementation; Navigator owns native Back state.
+NavigationBrowserHistory createNavigationBrowserHistory(
+        BrowserHistoryRestore onRestore) =>
+    _NoopNavigationBrowserHistory();
+
+class _NoopNavigationBrowserHistory implements NavigationBrowserHistory {
+  @override
+  bool get isHandlingPopState => false;
+
+  @override
+  void recordPop() {}
+
+  @override
+  void recordPush(List<EnsembleRouteDescriptor> snapshot) {}
+
+  @override
+  Future<void> reconcile({
+    required int currentDepth,
+    required int prefixLength,
+    required List<EnsembleRouteDescriptor> finalHistory,
+  }) async {}
+
+  @override
+  void replaceInitial(List<EnsembleRouteDescriptor> snapshot) {}
+}

--- a/modules/ensemble/lib/navigation/browser/navigation_browser_history_web.dart
+++ b/modules/ensemble/lib/navigation/browser/navigation_browser_history_web.dart
@@ -1,0 +1,128 @@
+// ignore_for_file: deprecated_member_use
+
+import 'dart:async';
+import 'dart:html' as html;
+
+import 'package:ensemble/navigation/browser/navigation_browser_history_base.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
+
+/// Creates the session-only Flutter Web history adapter.
+NavigationBrowserHistory createNavigationBrowserHistory(
+        BrowserHistoryRestore onRestore) =>
+    _WebNavigationBrowserHistory(onRestore);
+
+class _WebNavigationBrowserHistory implements NavigationBrowserHistory {
+  _WebNavigationBrowserHistory(this.onRestore) {
+    html.window.onPopState.listen(_handlePopState);
+  }
+
+  static const _stateKey = 'ensembleNavigationToken';
+
+  final BrowserHistoryRestore onRestore;
+
+  // Inputs remain only in memory. Browser state receives an opaque token so
+  // neither route inputs nor a public URL format are exposed.
+  final Map<String, List<EnsembleRouteDescriptor>> _snapshots = {};
+  int _sequence = 0;
+  bool _publishing = false;
+  bool _handlingPopState = false;
+  Completer<void>? _pendingMove;
+
+  @override
+  bool get isHandlingPopState => _handlingPopState;
+
+  String _store(List<EnsembleRouteDescriptor> snapshot) {
+    final token = 'ensemble_history_${_sequence++}';
+    _snapshots[token] = List<EnsembleRouteDescriptor>.unmodifiable(snapshot);
+    return token;
+  }
+
+  Object _state(String token) => <String, dynamic>{_stateKey: token};
+
+  String get _url => html.window.location.href;
+
+  @override
+  void replaceInitial(List<EnsembleRouteDescriptor> snapshot) {
+    final token = _store(snapshot);
+    html.window.history.replaceState(_state(token), '', _url);
+  }
+
+  @override
+  void recordPush(List<EnsembleRouteDescriptor> snapshot) {
+    if (_publishing) return;
+    final token = _store(snapshot);
+    html.window.history.pushState(_state(token), '', _url);
+  }
+
+  @override
+  void recordPop() {
+    if (!_publishing) html.window.history.back();
+  }
+
+  @override
+  Future<void> reconcile({
+    required int currentDepth,
+    required int prefixLength,
+    required List<EnsembleRouteDescriptor> finalHistory,
+  }) async {
+    if (finalHistory.isEmpty) return;
+    _publishing = true;
+    try {
+      if (prefixLength > 0) {
+        // Return to the retained prefix before pushing the rewritten suffix;
+        // pushState naturally truncates the obsolete forward branch.
+        await _moveBack(currentDepth - prefixLength);
+        for (var index = prefixLength; index < finalHistory.length; index++) {
+          final token = _store(finalHistory.take(index + 1).toList());
+          html.window.history.pushState(_state(token), '', _url);
+        }
+      } else {
+        // With no retained root, reuse the earliest reachable browser entry
+        // for the new root and append the rest of the requested history.
+        await _moveBack(currentDepth > 0 ? currentDepth - 1 : 0);
+        final firstToken =
+            _store(<EnsembleRouteDescriptor>[finalHistory.first]);
+        html.window.history.replaceState(_state(firstToken), '', _url);
+        for (var index = 1; index < finalHistory.length; index++) {
+          final token = _store(finalHistory.take(index + 1).toList());
+          html.window.history.pushState(_state(token), '', _url);
+        }
+      }
+    } finally {
+      _publishing = false;
+    }
+  }
+
+  Future<void> _moveBack(int count) async {
+    if (count <= 0) return;
+    _pendingMove = Completer<void>();
+    html.window.history.go(-count);
+    // Some test hosts and embedded webviews may not emit popstate. Do not let
+    // one missing platform event permanently block the transaction queue.
+    await _pendingMove!.future.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () {},
+    );
+    _pendingMove = null;
+  }
+
+  void _handlePopState(html.PopStateEvent event) {
+    final pendingMove = _pendingMove;
+    if (pendingMove != null && !pendingMove.isCompleted) {
+      pendingMove.complete();
+      return;
+    }
+    if (_publishing) return;
+    final state = event.state;
+    if (state is! Map) return;
+    final token = state[_stateKey];
+    if (token is! String) return;
+    final snapshot = _snapshots[token];
+    if (snapshot != null) {
+      _handlingPopState = true;
+      unawaited(onRestore(snapshot).whenComplete(() {
+        _handlingPopState = false;
+      }));
+    }
+  }
+}

--- a/modules/ensemble/lib/navigation/ensemble_navigation_manager.dart
+++ b/modules/ensemble/lib/navigation/ensemble_navigation_manager.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+
+import 'package:ensemble/layout/ensemble_page_route.dart';
+import 'package:ensemble/navigation/browser/navigation_browser_history.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
+import 'package:ensemble/navigation/navigation_reconciler.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// Constructs either a lazy history route or the animated destination route.
+typedef EnsembleRouteCreator = PageRouteBuilder<dynamic> Function(
+  EnsembleRouteDescriptor descriptor, {
+  required bool animate,
+});
+
+/// Owns the canonical Ensemble route history and custom-stack transactions.
+class EnsembleNavigationManager {
+  EnsembleNavigationManager._();
+
+  /// Shared manager for the canonical Ensemble navigator.
+  static final EnsembleNavigationManager instance =
+      EnsembleNavigationManager._();
+
+  final List<ManagedEnsembleRoute> _history = [];
+  final Expando<EnsembleRouteExitReason> _exitReasons =
+      Expando<EnsembleRouteExitReason>('ensembleRouteExitReason');
+  final NavigationReconciler _reconciler = const NavigationReconciler();
+  final Map<String, Future<PageRouteBuilder<dynamic>>> _pendingTransactions =
+      {};
+  Future<void> _transactionTail = Future<void>.value();
+  int _transactionSequence = 0;
+  bool _isCommitting = false;
+  bool _browserHasInitialEntry = false;
+  bool _browserRestoring = false;
+  NavigatorState? _lastNavigator;
+  EnsembleRouteCreator? _lastRouteCreator;
+
+  NavigationBrowserHistory? _browserHistoryInstance;
+
+  NavigationBrowserHistory get _browserHistory => _browserHistoryInstance ??=
+      createNavigationBrowserHistory(_restoreFromBrowser);
+
+  /// Observer that keeps [_history] synchronized with Navigator 1.0 events.
+  late final NavigatorObserver observer = _EnsembleNavigationObserver(this);
+
+  /// Snapshot of the currently managed Ensemble routes, from root to top.
+  List<ManagedEnsembleRoute> get history => List.unmodifiable(_history);
+
+  /// Returns the semantic exit reason used by `onNavigateBack` filtering.
+  EnsembleRouteExitReason exitReasonFor(Route<dynamic> route) =>
+      _exitReasons[route] ?? EnsembleRouteExitReason.back;
+
+  /// Queues a declarative history rewrite and returns its destination route.
+  ///
+  /// The returned future completes once the destination has been accepted by
+  /// Navigator. Internal cleanup remains serialized so rapid
+  /// requests cannot observe or modify a partially reconciled stack.
+  Future<PageRouteBuilder<dynamic>> navigateWithHistory({
+    required NavigatorState navigator,
+    required List<EnsembleRouteDescriptor> history,
+    required EnsembleRouteDescriptor destination,
+    required EnsembleRouteCreator createRoute,
+  }) {
+    _lastNavigator = navigator;
+    _lastRouteCreator = createRoute;
+    final key = _transactionKey(history, destination);
+    final pending = _pendingTransactions[key];
+    // Coalesce rapid identical taps while their transaction is still queued or
+    // completing its visual cleanup.
+    if (pending != null) return pending;
+
+    final completer = Completer<PageRouteBuilder<dynamic>>();
+    final transaction = completer.future;
+    _pendingTransactions[key] = transaction;
+    _transactionTail =
+        _transactionTail.catchError((Object _) {}).then((_) async {
+      try {
+        final commit = _startCommit(
+          navigator: navigator,
+          desiredHistory: history,
+          destination: destination,
+          createRoute: createRoute,
+        );
+        completer.complete(commit.destinationRoute);
+        await commit.completion;
+      } catch (error, stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      } finally {
+        _pendingTransactions.remove(key);
+      }
+    });
+    return transaction;
+  }
+
+  _StartedNavigationCommit _startCommit({
+    required NavigatorState navigator,
+    required List<EnsembleRouteDescriptor> desiredHistory,
+    required EnsembleRouteDescriptor destination,
+    required EnsembleRouteCreator createRoute,
+  }) {
+    final transactionId = 'nav_${_transactionSequence++}';
+    final current = List<ManagedEnsembleRoute>.of(_history);
+    final reconciliation = _reconciler.reconcile(current, desiredHistory);
+    // A wildcard-retained route keeps its actual inputs. Browser snapshots must
+    // therefore use retained descriptors rather than the input-less request.
+    final resolvedHistory = <EnsembleRouteDescriptor>[
+      ...reconciliation.retained.map((route) => route.descriptor),
+      ...reconciliation.missing,
+    ];
+    final newHistoricalRoutes = reconciliation.missing
+        .map((descriptor) => createRoute(descriptor, animate: false))
+        .toList(growable: false);
+    final destinationRoute = createRoute(destination, animate: true);
+    final pushed = <Route<dynamic>>[];
+
+    _debugTransaction(
+      transactionId,
+      current,
+      desiredHistory,
+      destination,
+      reconciliation,
+    );
+
+    _isCommitting = true;
+    try {
+      // All pushes occur in one synchronous block before obsolete routes are
+      // touched, allowing a synchronous failure to roll back safely.
+      for (final route in newHistoricalRoutes) {
+        navigator.push(route);
+        pushed.add(route);
+      }
+      navigator.push(destinationRoute);
+      pushed.add(destinationRoute);
+    } catch (_) {
+      for (final route in pushed.reversed) {
+        _exitReasons[route] = EnsembleRouteExitReason.historyReconciled;
+        if (route.isActive) navigator.removeRoute(route);
+      }
+      rethrow;
+    } finally {
+      _isCommitting = false;
+    }
+
+    final browserUpdate = _browserRestoring
+        ? Future<void>.value()
+        : _browserHistory.reconcile(
+            currentDepth: current.length,
+            prefixLength: reconciliation.prefixLength,
+            finalHistory: <EnsembleRouteDescriptor>[
+              ...resolvedHistory,
+              destination,
+            ],
+          );
+
+    final completion = () async {
+      // Keep the old visible route alive under the destination transition.
+      // Removing it immediately would expose a dormant transparent history
+      // entry and briefly show the Navigator background.
+      await _waitForForwardTransition(destinationRoute);
+      for (final managed in reconciliation.obsolete.reversed) {
+        if (!managed.route.isActive) continue;
+        _exitReasons[managed.route] = EnsembleRouteExitReason.historyReconciled;
+        navigator.removeRoute(managed.route);
+      }
+      await browserUpdate;
+    }();
+
+    return _StartedNavigationCommit(destinationRoute, completion);
+  }
+
+  Future<void> _waitForForwardTransition(
+      PageRouteBuilder<dynamic> route) async {
+    if (route.transitionDuration == Duration.zero) return;
+
+    // Navigator.push can briefly expose the controller's pre-animation status
+    // before the first frame. Keep the outgoing route through that frame so a
+    // dormant historical route can never become the transition background.
+    await SchedulerBinding.instance.endOfFrame;
+
+    final animation = route.animation;
+    if (animation == null || animation.status == AnimationStatus.completed) {
+      return;
+    }
+
+    final completer = Completer<void>();
+    var transitionStarted = animation.status != AnimationStatus.dismissed;
+    void listener(AnimationStatus status) {
+      if (status == AnimationStatus.forward ||
+          status == AnimationStatus.reverse) {
+        transitionStarted = true;
+        return;
+      }
+      if (status != AnimationStatus.completed &&
+          !(status == AnimationStatus.dismissed && transitionStarted)) {
+        return;
+      }
+      animation.removeStatusListener(listener);
+      if (!completer.isCompleted) completer.complete();
+    }
+
+    animation.addStatusListener(listener);
+    await completer.future;
+  }
+
+  Future<void> _restoreFromBrowser(
+      List<EnsembleRouteDescriptor> snapshot) async {
+    // Defer out of the browser event callback before mutating Navigator.
+    await Future<void>.delayed(Duration.zero);
+    if (snapshot.isEmpty || _historyMatches(snapshot)) return;
+    final navigator = _lastNavigator;
+    final createRoute = _lastRouteCreator;
+    if (navigator == null || createRoute == null || !navigator.mounted) return;
+
+    _browserRestoring = true;
+    try {
+      if (_isHistoryPrefix(snapshot)) {
+        // Browser Back to a strict prefix maps directly to normal route pops.
+        while (_history.length > snapshot.length && navigator.canPop()) {
+          navigator.pop();
+        }
+        return;
+      }
+      await navigateWithHistory(
+        // Browser Forward or a changed branch uses the same reconciler as an
+        // application-triggered navigation, without publishing new entries.
+        navigator: navigator,
+        history: snapshot.sublist(0, snapshot.length - 1),
+        destination: snapshot.last,
+        createRoute: createRoute,
+      );
+    } finally {
+      _browserRestoring = false;
+    }
+  }
+
+  bool _isHistoryPrefix(List<EnsembleRouteDescriptor> snapshot) {
+    if (snapshot.length >= _history.length) return false;
+    for (var index = 0; index < snapshot.length; index++) {
+      if (!_history[index].descriptor.isEquivalentTo(snapshot[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool _historyMatches(List<EnsembleRouteDescriptor> snapshot) {
+    if (_history.length != snapshot.length) return false;
+    for (var index = 0; index < snapshot.length; index++) {
+      if (!_history[index].descriptor.isEquivalentTo(snapshot[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  String _transactionKey(
+    List<EnsembleRouteDescriptor> history,
+    EnsembleRouteDescriptor destination,
+  ) {
+    String descriptorKey(EnsembleRouteDescriptor descriptor) =>
+        '${descriptor.screenId}|${descriptor.screenName}|'
+        '${descriptor.isExternal}|${descriptor.inputs}';
+    return [...history, destination].map(descriptorKey).join('>');
+  }
+
+  void _didPush(Route<dynamic> route) {
+    final settings = route.settings;
+    if (settings is! EnsembleRouteSettings) return;
+    _history.add(
+      ManagedEnsembleRoute(route: route, descriptor: settings.descriptor),
+    );
+    if (!_isCommitting && !_browserRestoring) {
+      // A declarative transaction publishes one final snapshot itself; only
+      // standalone Navigator pushes are mirrored here.
+      final snapshot = _history.map((entry) => entry.descriptor).toList();
+      if (_browserHasInitialEntry) {
+        _browserHistory.recordPush(snapshot);
+      } else {
+        _browserHistory.replaceInitial(snapshot);
+        _browserHasInitialEntry = true;
+      }
+    }
+  }
+
+  void _didPop(Route<dynamic> route) {
+    _exitReasons[route] ??= EnsembleRouteExitReason.back;
+    _history.removeWhere((managed) => identical(managed.route, route));
+    if (!_isCommitting &&
+        !_browserRestoring &&
+        !_browserHistory.isHandlingPopState) {
+      _browserHistory.recordPop();
+    }
+  }
+
+  void _didRemove(Route<dynamic> route) {
+    _history.removeWhere((managed) => identical(managed.route, route));
+  }
+
+  void _didReplace(Route<dynamic>? newRoute, Route<dynamic>? oldRoute) {
+    final index = oldRoute == null
+        ? -1
+        : _history.indexWhere((entry) => identical(entry.route, oldRoute));
+    if (oldRoute != null) {
+      _exitReasons[oldRoute] = EnsembleRouteExitReason.replaced;
+    }
+    if (index < 0) {
+      if (newRoute != null) _didPush(newRoute);
+      return;
+    }
+    if (newRoute?.settings is EnsembleRouteSettings) {
+      final settings = newRoute!.settings as EnsembleRouteSettings;
+      _history[index] = ManagedEnsembleRoute(
+        route: newRoute,
+        descriptor: settings.descriptor,
+      );
+    } else {
+      _history.removeAt(index);
+    }
+  }
+
+  void markExitReason(
+      Route<dynamic> route, EnsembleRouteExitReason exitReason) {
+    _exitReasons[route] = exitReason;
+  }
+
+  void markCurrentRoute(EnsembleRouteExitReason exitReason) {
+    if (_history.isEmpty) return;
+    markExitReason(_history.last.route, exitReason);
+  }
+
+  void markAllRoutes(EnsembleRouteExitReason exitReason) {
+    for (final managed in List<ManagedEnsembleRoute>.of(_history)) {
+      markExitReason(managed.route, exitReason);
+    }
+  }
+
+  void _debugTransaction(
+    String id,
+    List<ManagedEnsembleRoute> current,
+    List<EnsembleRouteDescriptor> desired,
+    EnsembleRouteDescriptor destination,
+    NavigationReconciliation reconciliation,
+  ) {
+    if (!kDebugMode) return;
+    debugPrint('[Navigation] Transaction: $id');
+    debugPrint(
+        'Current: ${current.map((r) => r.descriptor.identifier).join(' -> ')}');
+    debugPrint('Requested: ${[
+      ...desired,
+      destination
+    ].map((r) => r.identifier).join(' -> ')}');
+    debugPrint(
+        'KEEP: ${reconciliation.retained.map((r) => r.descriptor.identifier).join(', ')}');
+    debugPrint(
+        'DROP: ${reconciliation.obsolete.map((r) => r.descriptor.identifier).join(', ')}');
+    debugPrint(
+        'INSERT: ${reconciliation.missing.map((r) => r.identifier).join(', ')}');
+    debugPrint('PUSH: ${destination.identifier}');
+  }
+
+  /// Clears singleton state between widget tests.
+  @visibleForTesting
+  void reset() {
+    _history.clear();
+    _pendingTransactions.clear();
+    _transactionTail = Future<void>.value();
+    _isCommitting = false;
+    _browserHasInitialEntry = false;
+    _browserRestoring = false;
+    _lastNavigator = null;
+    _lastRouteCreator = null;
+  }
+
+  /// Replaces the platform adapter with a deterministic test implementation.
+  @visibleForTesting
+  void setBrowserHistoryForTesting(NavigationBrowserHistory browserHistory) {
+    _browserHistoryInstance = browserHistory;
+    _browserHasInitialEntry = false;
+  }
+}
+
+class _EnsembleNavigationObserver extends NavigatorObserver {
+  _EnsembleNavigationObserver(this.manager);
+
+  final EnsembleNavigationManager manager;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    manager._didPush(route);
+    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    manager._didPop(route);
+    super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    manager._didRemove(route);
+    super.didRemove(route, previousRoute);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    manager._didReplace(newRoute, oldRoute);
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+  }
+
+  @override
+  void didStartUserGesture(
+      Route<dynamic> route, Route<dynamic>? previousRoute) {
+    // Interactive iOS back gestures expose the previous route before didPopNext
+    // is delivered. Materialize it under the still-visible current route.
+    if (previousRoute is LazyEnsemblePageRouteBuilder<dynamic>) {
+      previousRoute.materialize();
+    }
+    super.didStartUserGesture(route, previousRoute);
+  }
+}
+
+class _StartedNavigationCommit {
+  const _StartedNavigationCommit(this.destinationRoute, this.completion);
+
+  /// Route returned to the action as soon as Navigator accepts the push.
+  final PageRouteBuilder<dynamic> destinationRoute;
+
+  /// Deferred transition cleanup that keeps subsequent transactions FIFO.
+  final Future<void> completion;
+}

--- a/modules/ensemble/lib/navigation/ensemble_navigation_manager.dart
+++ b/modules/ensemble/lib/navigation/ensemble_navigation_manager.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:ensemble/layout/ensemble_page_route.dart';
 import 'package:ensemble/navigation/browser/navigation_browser_history.dart';
 import 'package:ensemble/navigation/navigation_models.dart';
@@ -26,8 +28,12 @@ class EnsembleNavigationManager {
   final Expando<EnsembleRouteExitReason> _exitReasons =
       Expando<EnsembleRouteExitReason>('ensembleRouteExitReason');
   final NavigationReconciler _reconciler = const NavigationReconciler();
-  final Map<String, Future<PageRouteBuilder<dynamic>>> _pendingTransactions =
-      {};
+  final Map<List<Object?>, Future<PageRouteBuilder<dynamic>>>
+      _pendingTransactions =
+      HashMap<List<Object?>, Future<PageRouteBuilder<dynamic>>>(
+    equals: const DeepCollectionEquality().equals,
+    hashCode: const DeepCollectionEquality().hash,
+  );
   Future<void> _transactionTail = Future<void>.value();
   int _transactionSequence = 0;
   bool _isCommitting = false;
@@ -185,7 +191,7 @@ class EnsembleNavigationManager {
       return;
     }
 
-    final completer = Completer<void>();
+    final transitionCompleted = Completer<void>();
     var transitionStarted = animation.status != AnimationStatus.dismissed;
     void listener(AnimationStatus status) {
       if (status == AnimationStatus.forward ||
@@ -198,11 +204,22 @@ class EnsembleNavigationManager {
         return;
       }
       animation.removeStatusListener(listener);
-      if (!completer.isCompleted) completer.complete();
+      if (!transitionCompleted.isCompleted) transitionCompleted.complete();
     }
 
     animation.addStatusListener(listener);
-    await completer.future;
+    try {
+      // A legacy navigation can remove this route while it is animating. In
+      // that case Flutter disposes the animation and clears its listeners, but
+      // still completes Route.popped. Racing both lifecycle signals prevents
+      // a removed destination from permanently blocking the FIFO queue.
+      await Future.any<void>(<Future<void>>[
+        transitionCompleted.future,
+        route.popped.then<void>((_) {}),
+      ]);
+    } finally {
+      animation.removeStatusListener(listener);
+    }
   }
 
   Future<void> _restoreFromBrowser(
@@ -256,14 +273,25 @@ class EnsembleNavigationManager {
     return true;
   }
 
-  String _transactionKey(
+  List<Object?> _transactionKey(
     List<EnsembleRouteDescriptor> history,
     EnsembleRouteDescriptor destination,
   ) {
-    String descriptorKey(EnsembleRouteDescriptor descriptor) =>
-        '${descriptor.screenId}|${descriptor.screenName}|'
-        '${descriptor.isExternal}|${descriptor.inputs}';
-    return [...history, destination].map(descriptorKey).join('>');
+    List<Object?> descriptorKey(EnsembleRouteDescriptor descriptor) =>
+        <Object?>[
+          descriptor.screenId,
+          descriptor.screenName,
+          descriptor.isExternal,
+          descriptor.pageType,
+          descriptor.inputs,
+        ];
+    return <Object?>[
+      for (final descriptor in <EnsembleRouteDescriptor>[
+        ...history,
+        destination,
+      ])
+        descriptorKey(descriptor),
+    ];
   }
 
   void _didPush(Route<dynamic> route) {

--- a/modules/ensemble/lib/navigation/ensemble_route_factory.dart
+++ b/modules/ensemble/lib/navigation/ensemble_route_factory.dart
@@ -1,0 +1,61 @@
+import 'package:ensemble/framework/theme/theme_loader.dart';
+import 'package:ensemble/layout/ensemble_page_route.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
+import 'package:ensemble/util/utils.dart';
+import 'package:flutter/material.dart';
+
+/// Builds an Ensemble screen when a route is ready to materialize it.
+typedef EnsembleScreenFactory = Widget Function(
+    EnsembleRouteDescriptor descriptor);
+
+/// Canonical route-construction path shared by regular and stack navigation.
+class EnsembleRouteFactory {
+  const EnsembleRouteFactory(this.screenFactory);
+
+  /// Screen builder shared by eager destinations and lazy history entries.
+  final EnsembleScreenFactory screenFactory;
+
+  /// Creates an eager animated destination or a dormant historical route.
+  PageRouteBuilder<dynamic> create(
+    BuildContext context,
+    EnsembleRouteDescriptor descriptor, {
+    Map<String, dynamic>? transition,
+    bool animate = true,
+  }) {
+    final settings = EnsembleRouteSettings(
+      descriptor: descriptor,
+      payload: descriptor.toPayload(),
+    );
+    if (!animate) {
+      // Historical entries need to exist in Navigator for native Back behavior,
+      // but constructing their Ensemble screens here would run lifecycle work
+      // for screens the user has not visited.
+      return LazyEnsemblePageRouteBuilder<dynamic>(
+        screenBuilder: (_) => screenFactory(descriptor),
+        settings: settings,
+      );
+    }
+
+    final defaults =
+        Theme.of(context).extension<EnsembleThemeExtension>()?.transitions ??
+            const <String, dynamic>{};
+    final transitionType = PageTransitionTypeX.fromString(
+        transition?['type'] ?? defaults['page']?['type']);
+    final alignment = Utils.getAlignment(
+        transition?['alignment'] ?? defaults['page']?['alignment']);
+    final duration = Utils.getInt(
+      transition?['duration'] ?? defaults['page']?['duration'],
+      fallback: 250,
+    );
+
+    final screen = screenFactory(descriptor);
+
+    return EnsemblePageRouteBuilder(
+      child: screen,
+      transitionType: transitionType ?? PageTransitionType.fade,
+      alignment: alignment ?? Alignment.center,
+      duration: Duration(milliseconds: duration),
+      settings: settings,
+    );
+  }
+}

--- a/modules/ensemble/lib/navigation/navigation_models.dart
+++ b/modules/ensemble/lib/navigation/navigation_models.dart
@@ -1,0 +1,143 @@
+import 'package:collection/collection.dart';
+import 'package:ensemble/framework/error_handling.dart';
+import 'package:ensemble/page_model.dart';
+import 'package:flutter/widgets.dart';
+
+/// Unevaluated EDL representation of an entry in `navigateScreen.stack`.
+class NavigationStackEntry {
+  const NavigationStackEntry({required this.name, this.inputs});
+
+  /// A literal screen name or expression evaluated in the initiating context.
+  final dynamic name;
+
+  /// Unevaluated inputs; nested values are evaluated immediately before use.
+  final Map<String, dynamic>? inputs;
+
+  /// Parses the object-only stack entry syntax and reports its indexed path.
+  factory NavigationStackEntry.from(dynamic value, int index) {
+    if (value is! Map) {
+      throw LanguageError(
+          'navigateScreen.stack[$index] must be an object with a name.');
+    }
+    if (!value.containsKey('name') || value['name'] == null) {
+      throw LanguageError(
+          'navigateScreen.stack[$index] requires the name of a screen.');
+    }
+    final rawInputs = value['inputs'];
+    if (rawInputs != null && rawInputs is! Map) {
+      throw LanguageError(
+          'navigateScreen.stack[$index].inputs must be an object.');
+    }
+    return NavigationStackEntry(
+      name: value['name'],
+      inputs: rawInputs == null
+          ? null
+          : Map<String, dynamic>.from(rawInputs as Map),
+    );
+  }
+}
+
+/// Evaluated identity and reconstruction data for an Ensemble route.
+class EnsembleRouteDescriptor {
+  EnsembleRouteDescriptor({
+    this.screenId,
+    this.screenName,
+    Map<String, dynamic>? inputs,
+    this.isExternal = false,
+    String? routeId,
+  })  : inputs =
+            inputs == null ? null : Map<String, dynamic>.unmodifiable(inputs),
+        routeId = routeId ?? _nextRouteId();
+
+  static int _routeSequence = 0;
+
+  static String _nextRouteId() =>
+      'ensemble_route_${DateTime.now().microsecondsSinceEpoch}_${_routeSequence++}';
+
+  /// Definition ID when navigation addressed the screen by ID.
+  final String? screenId;
+
+  /// Definition name when navigation addressed the screen by name.
+  final String? screenName;
+
+  /// Evaluated inputs used both for reconstruction and route identity.
+  final Map<String, dynamic>? inputs;
+
+  /// Whether the descriptor targets a registered external Ensemble screen.
+  final bool isExternal;
+
+  /// Unique identity for this descriptor instance.
+  final String routeId;
+
+  /// Human-readable identifier used by diagnostics.
+  String get identifier => screenName ?? screenId ?? '';
+
+  /// Converts typed metadata to the legacy route argument format.
+  ScreenPayload toPayload({PageType pageType = PageType.regular}) =>
+      ScreenPayload(
+        screenId: screenId,
+        screenName: screenName,
+        arguments: inputs,
+        pageType: pageType,
+        isExternal: isExternal,
+      );
+
+  /// Performs exact descriptor equality for snapshots and browser restoration.
+  bool isEquivalentTo(EnsembleRouteDescriptor other) =>
+      screenId == other.screenId &&
+      screenName == other.screenName &&
+      isExternal == other.isExternal &&
+      const DeepCollectionEquality().equals(inputs, other.inputs);
+
+  /// Whether this existing route can satisfy a requested history entry.
+  ///
+  /// Inputs are directional here: omitted or empty requested inputs mean
+  /// "retain the existing route with its current inputs". Once the request
+  /// supplies inputs, they must match exactly.
+  bool satisfiesHistoryRequest(EnsembleRouteDescriptor requested) {
+    if (screenId != requested.screenId ||
+        screenName != requested.screenName ||
+        isExternal != requested.isExternal) {
+      return false;
+    }
+    if (requested.inputs == null || requested.inputs!.isEmpty) return true;
+    return const DeepCollectionEquality().equals(inputs, requested.inputs);
+  }
+
+  @override
+  String toString() => identifier;
+}
+
+/// Route settings used by every route created by Ensemble navigation.
+class EnsembleRouteSettings extends RouteSettings {
+  EnsembleRouteSettings({
+    required this.descriptor,
+    required ScreenPayload payload,
+  }) : super(arguments: payload);
+
+  /// Typed metadata retained alongside the legacy [ScreenPayload] arguments.
+  final EnsembleRouteDescriptor descriptor;
+}
+
+/// Why an Ensemble route stopped being active.
+enum EnsembleRouteExitReason {
+  /// The user or platform performed a real back navigation.
+  back,
+
+  /// A normal navigation replaced the current route.
+  replaced,
+
+  /// Declarative reconciliation removed an obsolete history suffix.
+  historyReconciled,
+
+  /// Navigation intentionally cleared every prior route.
+  rootCleared,
+}
+
+/// Associates a live Flutter route with its reconstructable descriptor.
+class ManagedEnsembleRoute {
+  ManagedEnsembleRoute({required this.route, required this.descriptor});
+
+  final Route<dynamic> route;
+  final EnsembleRouteDescriptor descriptor;
+}

--- a/modules/ensemble/lib/navigation/navigation_models.dart
+++ b/modules/ensemble/lib/navigation/navigation_models.dart
@@ -44,6 +44,7 @@ class EnsembleRouteDescriptor {
     this.screenName,
     Map<String, dynamic>? inputs,
     this.isExternal = false,
+    this.pageType = PageType.regular,
     String? routeId,
   })  : inputs =
             inputs == null ? null : Map<String, dynamic>.unmodifiable(inputs),
@@ -66,6 +67,12 @@ class EnsembleRouteDescriptor {
   /// Whether the descriptor targets a registered external Ensemble screen.
   final bool isExternal;
 
+  /// Whether this route is a regular screen or a modal screen.
+  ///
+  /// Route type participates in identity so a modal can never be retained as
+  /// a regular declarative history entry with the same screen name.
+  final PageType pageType;
+
   /// Unique identity for this descriptor instance.
   final String routeId;
 
@@ -73,12 +80,12 @@ class EnsembleRouteDescriptor {
   String get identifier => screenName ?? screenId ?? '';
 
   /// Converts typed metadata to the legacy route argument format.
-  ScreenPayload toPayload({PageType pageType = PageType.regular}) =>
+  ScreenPayload toPayload({PageType? pageType}) =>
       ScreenPayload(
         screenId: screenId,
         screenName: screenName,
         arguments: inputs,
-        pageType: pageType,
+        pageType: pageType ?? this.pageType,
         isExternal: isExternal,
       );
 
@@ -87,6 +94,7 @@ class EnsembleRouteDescriptor {
       screenId == other.screenId &&
       screenName == other.screenName &&
       isExternal == other.isExternal &&
+      pageType == other.pageType &&
       const DeepCollectionEquality().equals(inputs, other.inputs);
 
   /// Whether this existing route can satisfy a requested history entry.
@@ -95,9 +103,12 @@ class EnsembleRouteDescriptor {
   /// "retain the existing route with its current inputs". Once the request
   /// supplies inputs, they must match exactly.
   bool satisfiesHistoryRequest(EnsembleRouteDescriptor requested) {
-    if (screenId != requested.screenId ||
-        screenName != requested.screenName ||
-        isExternal != requested.isExternal) {
+    final identifierMatches = requested.screenName != null
+        ? screenName == requested.screenName
+        : requested.screenId != null && screenId == requested.screenId;
+    if (!identifierMatches ||
+        isExternal != requested.isExternal ||
+        pageType != requested.pageType) {
       return false;
     }
     if (requested.inputs == null || requested.inputs!.isEmpty) return true;

--- a/modules/ensemble/lib/navigation/navigation_reconciler.dart
+++ b/modules/ensemble/lib/navigation/navigation_reconciler.dart
@@ -1,0 +1,50 @@
+import 'package:ensemble/navigation/navigation_models.dart';
+
+/// Immutable result of comparing live and requested histories.
+class NavigationReconciliation {
+  const NavigationReconciliation({
+    required this.prefixLength,
+    required this.retained,
+    required this.obsolete,
+    required this.missing,
+  });
+
+  /// Number of compatible routes at the start of both histories.
+  final int prefixLength;
+
+  /// Existing routes whose widgets and state can be preserved.
+  final List<ManagedEnsembleRoute> retained;
+
+  /// Existing suffix that must be removed after destination navigation.
+  final List<ManagedEnsembleRoute> obsolete;
+
+  /// Requested suffix inserted as lazy historical routes.
+  final List<EnsembleRouteDescriptor> missing;
+}
+
+/// Calculates the longest reusable prefix without mutating Navigator state.
+class NavigationReconciler {
+  const NavigationReconciler();
+
+  /// Reconciles in order and never reuses a matching route after a mismatch.
+  NavigationReconciliation reconcile(
+    List<ManagedEnsembleRoute> current,
+    List<EnsembleRouteDescriptor> desired,
+  ) {
+    var prefixLength = 0;
+    final limit =
+        current.length < desired.length ? current.length : desired.length;
+    while (prefixLength < limit &&
+        current[prefixLength]
+            .descriptor
+            .satisfiesHistoryRequest(desired[prefixLength])) {
+      prefixLength++;
+    }
+    return NavigationReconciliation(
+      prefixLength: prefixLength,
+      retained: List.unmodifiable(current.take(prefixLength)),
+      obsolete: List.unmodifiable(current.skip(prefixLength)),
+      missing: List.unmodifiable(desired.skip(prefixLength)),
+    );
+  }
+}

--- a/modules/ensemble/lib/screen_controller.dart
+++ b/modules/ensemble/lib/screen_controller.dart
@@ -786,6 +786,7 @@ class ScreenController {
       screenName: screenName,
       inputs: pageArgs,
       isExternal: isExternal,
+      pageType: pageType,
     );
     final routeSettings = EnsembleRouteSettings(
       descriptor: descriptor,

--- a/modules/ensemble/lib/screen_controller.dart
+++ b/modules/ensemble/lib/screen_controller.dart
@@ -26,6 +26,9 @@ import 'package:ensemble/framework/widget/modal_screen.dart';
 import 'package:ensemble/framework/widget/screen.dart';
 import 'package:ensemble/framework/widget/toast.dart';
 import 'package:ensemble/layout/ensemble_page_route.dart';
+import 'package:ensemble/navigation/ensemble_navigation_manager.dart';
+import 'package:ensemble/navigation/ensemble_route_factory.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
 import 'package:ensemble/page_model.dart';
 import 'package:ensemble/util/ensemble_utils.dart';
 import 'package:ensemble/util/notification_utils.dart';
@@ -212,11 +215,54 @@ class ScreenController {
       });
 
       RouteOption? routeOption;
+      // A null stack preserves legacy Navigator behavior. An explicit empty
+      // stack is meaningful and makes the destination the new root.
+      final usesCustomStack =
+          action is NavigateScreenAction && action.stack != null;
+      List<EnsembleRouteDescriptor>? desiredHistory;
+      EnsembleRouteDescriptor? destinationDescriptor;
       if (action is NavigateScreenAction) {
         if (action.options?['clearAllScreens'] == true) {
           routeOption = RouteOption.clearAllScreens;
         } else if (action.options?['replaceCurrentScreen'] == true) {
           routeOption = RouteOption.replaceCurrentScreen;
+        }
+        if (usesCustomStack) {
+          if (routeOption != null) {
+            throw LanguageError(
+                'navigateScreen.stack cannot be combined with options.clearAllScreens or options.replaceCurrentScreen.');
+          }
+          if (action.asExternal) {
+            throw LanguageError(
+                'navigateScreen.stack cannot be used with asExternal.');
+          }
+          final destinationName = _requiredEvaluatedScreenName(
+            action.screenName,
+            scopeManager,
+            'navigateScreen.name',
+          );
+          desiredHistory = <EnsembleRouteDescriptor>[];
+          for (var index = 0; index < action.stack!.length; index++) {
+            final entry = action.stack![index];
+            final screenName = _requiredEvaluatedScreenName(
+              entry.name,
+              scopeManager,
+              'navigateScreen.stack[$index].name',
+            );
+            desiredHistory.add(EnsembleRouteDescriptor(
+              screenName: screenName,
+              inputs: _evaluateNavigationInputs(entry.inputs, scopeManager),
+            ));
+          }
+          destinationDescriptor = EnsembleRouteDescriptor(
+            screenName: destinationName,
+            inputs: nextArgs,
+            isExternal: action.isExternal,
+          );
+          await _validateNavigationDescriptors(
+            desiredHistory,
+            destinationDescriptor,
+          );
         }
       }
 
@@ -240,19 +286,44 @@ class ScreenController {
         context = scopeManager.dataContext.buildContext;
       }
 
-      PageRouteBuilder routeBuilder = await navigateToScreen(
-        context,
-        screenName: scopeManager.dataContext.eval(action.screenName),
-        asModal: action.asModal,
-        routeOption: routeOption,
-        pageArgs: nextArgs,
-        transition: action.transition,
-        isExternal: action.isExternal,
-        asExternal: action.asExternal,
-      );
+      PageRouteBuilder routeBuilder;
+      if (usesCustomStack) {
+        final navigator = Utils.globalAppKey.currentState;
+        if (navigator == null) {
+          throw RuntimeError(
+              'navigateScreen.stack could not find the Ensemble navigator.');
+        }
+        routeBuilder =
+            await EnsembleNavigationManager.instance.navigateWithHistory(
+          navigator: navigator,
+          history: desiredHistory!,
+          destination: destinationDescriptor!,
+          createRoute: (descriptor, {required animate}) => createEnsembleRoute(
+            navigator.context,
+            descriptor,
+            transition: action.transition,
+            animate: animate,
+          ),
+        );
+      } else {
+        routeBuilder = await navigateToScreen(
+          context,
+          screenName: scopeManager.dataContext.eval(action.screenName),
+          asModal: action.asModal,
+          routeOption: routeOption,
+          pageArgs: nextArgs,
+          transition: action.transition,
+          isExternal: action.isExternal,
+          asExternal: action.asExternal,
+        );
+      }
 
       if (action is NavigateScreenAction && action.onNavigateBack != null) {
         routeBuilder.popped.then((data) {
+          if (EnsembleNavigationManager.instance.exitReasonFor(routeBuilder) !=
+              EnsembleRouteExitReason.back) {
+            return;
+          }
           // animating transition while executing this Action causes stutter
           // if we do some heaviy processing. Delay it
           Future.delayed(
@@ -268,6 +339,12 @@ class ScreenController {
         routeBuilder.popped.whenComplete(() {
           executeActionWithScope(context, scopeManager, action.onModalDismiss!);
         });
+      }
+      if (usesCustomStack) {
+        // Legacy navigateScreen completes when its pushed route is popped.
+        // Keep that action timing separate from the manager's transaction
+        // completion, which finishes after the destination push is accepted.
+        await routeBuilder.popped;
       }
     } else if (action is ShowCameraAction) {
       GetIt.I<CameraManager>().openCamera(context, action, scopeManager);
@@ -550,6 +627,118 @@ class ScreenController {
         SystemStorageBindingSource(key, storagePrefix: storagePrefix), value));
   }
 
+  String _requiredEvaluatedScreenName(
+    dynamic rawName,
+    ScopeManager scopeManager,
+    String path,
+  ) {
+    final evaluated = scopeManager.dataContext.eval(rawName);
+    final screenName = Utils.optionalString(evaluated)?.trim();
+    if (screenName == null || screenName.isEmpty) {
+      throw LanguageError('$path must resolve to a non-empty screen name.');
+    }
+    return screenName;
+  }
+
+  Map<String, dynamic>? _evaluateNavigationInputs(
+    Map<String, dynamic>? inputs,
+    ScopeManager scopeManager,
+  ) {
+    if (inputs == null) return null;
+    return inputs.map((key, value) =>
+        MapEntry(key, _evaluateNavigationValue(value, scopeManager)));
+  }
+
+  dynamic _evaluateNavigationValue(dynamic value, ScopeManager scopeManager) {
+    if (value is Map) {
+      return value.map((key, nestedValue) => MapEntry(
+          key.toString(), _evaluateNavigationValue(nestedValue, scopeManager)));
+    }
+    if (value is List) {
+      return value
+          .map((entry) => _evaluateNavigationValue(entry, scopeManager))
+          .toList(growable: false);
+    }
+    return scopeManager.dataContext.eval(value);
+  }
+
+  Future<void> _validateNavigationDescriptors(
+    List<EnsembleRouteDescriptor> history,
+    EnsembleRouteDescriptor destination,
+  ) async {
+    final definitionProvider = Ensemble().getConfig()?.definitionProvider;
+    if (definitionProvider == null) {
+      throw RuntimeError(
+          'navigateScreen.stack cannot resolve screens before the app is initialized.');
+    }
+
+    Future<Object?> validate(EnsembleRouteDescriptor descriptor) async {
+      try {
+        await definitionProvider.getDefinition(
+            screenName: descriptor.screenName);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    }
+
+    // These lookups are independent. Running them together prevents the delay
+    // of a large declarative history from growing by one network/cache round
+    // trip per entry. Errors are inspected in declaration order below so the
+    // public indexed diagnostics remain deterministic.
+    final validations = await Future.wait<Object?>(<Future<Object?>>[
+      ...history.map(validate),
+      if (!destination.isExternal) validate(destination),
+    ]);
+
+    for (var index = 0; index < history.length; index++) {
+      final error = validations[index];
+      if (error != null) {
+        throw LanguageError(
+          'navigateScreen.stack[$index] references unknown screen "${history[index].screenName}".',
+          detailedError: error.toString(),
+        );
+      }
+    }
+
+    if (destination.isExternal) {
+      if (!Ensemble()
+          .externalScreenWidgets
+          .containsKey(destination.screenName)) {
+        throw LanguageError(
+            'navigateScreen references unknown external screen "${destination.screenName}".');
+      }
+      return;
+    }
+    final destinationError = validations.last;
+    if (destinationError != null) {
+      throw LanguageError(
+        'navigateScreen references unknown screen "${destination.screenName}".',
+        detailedError: destinationError.toString(),
+      );
+    }
+  }
+
+  PageRouteBuilder<dynamic> createEnsembleRoute(
+    BuildContext context,
+    EnsembleRouteDescriptor descriptor, {
+    Map<String, dynamic>? transition,
+    bool animate = true,
+  }) {
+    final factory = EnsembleRouteFactory((routeDescriptor) => getScreen(
+          screenId: routeDescriptor.screenId,
+          screenName: routeDescriptor.screenName,
+          pageArgs: routeDescriptor.inputs,
+          isExternal: routeDescriptor.isExternal,
+        ));
+    return factory.create(
+      context,
+      descriptor,
+      transition: transition,
+      animate: animate,
+    );
+  }
+
   /// Navigate to another
   /// [screenName] - navigate to the screen if specified, otherwise to appHome
   /// [asModal] - shows the App in a regular or modal screen
@@ -592,14 +781,15 @@ class ScreenController {
             defaultTransitionOptions[_pageType]?['duration'],
         fallback: 250);
 
-    final routeSettings = RouteSettings(
-      arguments: ScreenPayload(
-        screenId: screenId,
-        screenName: screenName,
-        pageType: pageType,
-        arguments: pageArgs,
-        isExternal: isExternal,
-      ),
+    final descriptor = EnsembleRouteDescriptor(
+      screenId: screenId,
+      screenName: screenName,
+      inputs: pageArgs,
+      isExternal: isExternal,
+    );
+    final routeSettings = EnsembleRouteSettings(
+      descriptor: descriptor,
+      payload: descriptor.toPayload(pageType: pageType),
     );
 
     PageRouteBuilder route = getScreenBuilder(
@@ -616,12 +806,16 @@ class ScreenController {
         externalAppNavigateKey?.currentState
             ?.pushAndRemoveUntil(route, (route) => false);
       } else {
+        EnsembleNavigationManager.instance
+            .markAllRoutes(EnsembleRouteExitReason.rootCleared);
         await Navigator.pushAndRemoveUntil(context, route, (route) => false);
       }
     } else if (routeOption == RouteOption.replaceCurrentScreen) {
       if (asExternal) {
         externalAppNavigateKey?.currentState?.pushReplacement(route);
       } else {
+        EnsembleNavigationManager.instance
+            .markCurrentRoute(EnsembleRouteExitReason.replaced);
         await Navigator.pushReplacement(context, route);
       }
     } else {

--- a/modules/ensemble/test/action_test.dart
+++ b/modules/ensemble/test/action_test.dart
@@ -1,6 +1,7 @@
 import 'package:ensemble/action/dialog_actions.dart';
 import 'package:ensemble/action/navigation_action.dart';
 import 'package:ensemble/framework/action.dart';
+import 'package:ensemble/framework/error_handling.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yaml/yaml.dart';
 
@@ -17,5 +18,90 @@ void main() {
     expect(EnsembleAction.from('closeAllDialogs'), closeAllDialogsMatcher);
     expect(EnsembleAction.from(YamlMap.wrap({'closeAllDialogs': {}})),
         closeAllDialogsMatcher);
+  });
+
+  group('navigateScreen stack parsing', () {
+    test('distinguishes omitted and empty stacks', () {
+      final omitted = NavigateScreenAction.fromMap(
+          payload: <String, dynamic>{'name': 'System'});
+      final empty = NavigateScreenAction.fromMap(
+          payload: <String, dynamic>{'name': 'System', 'stack': <dynamic>[]});
+
+      expect(omitted.stack, isNull);
+      expect(empty.stack, isEmpty);
+    });
+
+    test('parses object entries with unevaluated names and inputs', () {
+      final action = NavigateScreenAction.fromMap(payload: <String, dynamic>{
+        'name': 'System',
+        'stack': <dynamic>[
+          <String, dynamic>{'name': 'Home'},
+          <String, dynamic>{
+            'name': r'${parentScreen}',
+            'inputs': <String, dynamic>{'section': r'${section}'}
+          },
+        ],
+      });
+
+      expect(action.stack, hasLength(2));
+      expect(action.stack![1].name, r'${parentScreen}');
+      expect(action.stack![1].inputs!['section'], r'${section}');
+    });
+
+    test('rejects the ticket string-only format', () {
+      expect(
+        () => NavigateScreenAction.fromMap(payload: <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>['Home']
+        }),
+        throwsA(isA<LanguageError>()),
+      );
+    });
+
+    test('rejects missing names and non-map inputs', () {
+      expect(
+        () => NavigateScreenAction.fromMap(payload: <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>[
+            <String, dynamic>{'inputs': <String, dynamic>{}}
+          ]
+        }),
+        throwsA(isA<LanguageError>()),
+      );
+      expect(
+        () => NavigateScreenAction.fromMap(payload: <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>[
+            <String, dynamic>{'name': 'Home', 'inputs': 'invalid'}
+          ]
+        }),
+        throwsA(isA<LanguageError>()),
+      );
+    });
+
+    test('rejects imperative stack options and external navigator', () {
+      for (final payload in <Map<String, dynamic>>[
+        <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>[],
+          'options': <String, dynamic>{'clearAllScreens': true},
+        },
+        <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>[],
+          'options': <String, dynamic>{'replaceCurrentScreen': true},
+        },
+        <String, dynamic>{
+          'name': 'System',
+          'stack': <dynamic>[],
+          'asExternal': true,
+        },
+      ]) {
+        expect(
+          () => NavigateScreenAction.fromMap(payload: payload),
+          throwsA(isA<LanguageError>()),
+        );
+      }
+    });
   });
 }

--- a/modules/ensemble/test/ensemble_navigation_manager_test.dart
+++ b/modules/ensemble/test/ensemble_navigation_manager_test.dart
@@ -1,0 +1,378 @@
+import 'package:ensemble/framework/screen_tracker.dart';
+import 'package:ensemble/navigation/browser/navigation_browser_history.dart';
+import 'package:ensemble/navigation/ensemble_navigation_manager.dart';
+import 'package:ensemble/navigation/ensemble_route_factory.dart';
+import 'package:ensemble/navigation/navigation_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final manager = EnsembleNavigationManager.instance;
+
+  EnsembleRouteDescriptor descriptor(String name,
+          {Map<String, dynamic>? inputs}) =>
+      EnsembleRouteDescriptor(screenName: name, inputs: inputs);
+
+  PageRouteBuilder<dynamic> routeFor(EnsembleRouteDescriptor descriptor,
+      {Widget? child}) {
+    return PageRouteBuilder<dynamic>(
+      settings: EnsembleRouteSettings(
+        descriptor: descriptor,
+        payload: descriptor.toPayload(),
+      ),
+      transitionDuration: Duration.zero,
+      reverseTransitionDuration: Duration.zero,
+      pageBuilder: (_, __, ___) =>
+          child ?? Scaffold(body: Text(descriptor.identifier)),
+    );
+  }
+
+  Future<GlobalKey<NavigatorState>> pumpApp(
+    WidgetTester tester, {
+    NavigationBrowserHistory? browserHistory,
+    Map<String, dynamic>? homeInputs,
+    bool trackScreens = false,
+  }) async {
+    manager.reset();
+    ScreenTracker().clearAll();
+    manager
+        .setBrowserHistoryForTesting(browserHistory ?? _TestBrowserHistory());
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final home = descriptor('Home', inputs: homeInputs);
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navigatorKey,
+      navigatorObservers: <NavigatorObserver>[
+        if (trackScreens) ScreenTrackingNavigatorObserver(),
+        manager.observer,
+      ],
+      onGenerateInitialRoutes: (_) => <Route<dynamic>>[routeFor(home)],
+      onGenerateRoute: (_) => null,
+    ));
+    await tester.pump();
+    return navigatorKey;
+  }
+
+  testWidgets('reconciles a partial prefix and removes obsolete routes',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    final settings = descriptor('Settings');
+    final account = descriptor('Account');
+    final profile = descriptor('Profile');
+    final profileRoute = routeFor(profile);
+
+    navigatorKey.currentState!.push(routeFor(settings));
+    navigatorKey.currentState!.push(routeFor(account));
+    navigatorKey.currentState!.push(profileRoute);
+    await tester.pumpAndSettle();
+
+    final destinationRoute = await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home'), settings],
+      destination: descriptor('System'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    await tester.pumpAndSettle();
+
+    expect(manager.history.map((entry) => entry.descriptor.identifier),
+        <String>['Home', 'Settings', 'System']);
+    expect(manager.exitReasonFor(profileRoute),
+        EnsembleRouteExitReason.historyReconciled);
+
+    navigatorKey.currentState!.pop('back-payload');
+    await tester.pumpAndSettle();
+    expect(await destinationRoute.popped, 'back-payload');
+    expect(
+        manager.exitReasonFor(destinationRoute), EnsembleRouteExitReason.back);
+    expect(find.text('Settings'), findsOneWidget);
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('empty history makes destination the new root', (tester) async {
+    final navigatorKey = await pumpApp(tester);
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[],
+      destination: descriptor('Login'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    await tester.pumpAndSettle();
+
+    expect(manager.history.single.descriptor.identifier, 'Login');
+    expect(navigatorKey.currentState!.canPop(), isFalse);
+  });
+
+  testWidgets('retained route preserves widget state', (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    final settings = descriptor('Settings');
+    navigatorKey.currentState!
+        .push(routeFor(settings, child: const _RetainedCounter()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('0'));
+    await tester.pump();
+    expect(find.text('1'), findsOneWidget);
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home'), settings],
+      destination: descriptor('System'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    await tester.pumpAndSettle();
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsOneWidget);
+  });
+
+  testWidgets(
+      'missing history stays lazy until it is revealed by navigation back',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    Animation<double>? outgoingSecondaryAnimation;
+    final overview = descriptor('Overview');
+    final overviewRoute = PageRouteBuilder<dynamic>(
+      settings: EnsembleRouteSettings(
+        descriptor: overview,
+        payload: overview.toPayload(),
+      ),
+      transitionDuration: Duration.zero,
+      reverseTransitionDuration: Duration.zero,
+      pageBuilder: (_, __, ___) => const Scaffold(body: Text('Overview')),
+      transitionsBuilder: (_, __, secondaryAnimation, child) {
+        outgoingSecondaryAnimation = secondaryAnimation;
+        return child;
+      },
+    );
+    navigatorKey.currentState!.push(overviewRoute);
+    await tester.pumpAndSettle();
+
+    final constructed = <String>[];
+    final factory = EnsembleRouteFactory((entry) {
+      constructed.add(entry.identifier);
+      return Scaffold(body: Text(entry.identifier));
+    });
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[
+        descriptor('Home'),
+        descriptor('Wifi'),
+      ],
+      destination: descriptor('SetRoomName'),
+      createRoute: (entry, {required animate}) => factory.create(
+        navigatorKey.currentContext!,
+        entry,
+        transition: const <String, dynamic>{'duration': 100},
+        animate: animate,
+      ),
+    );
+
+    expect(constructed, <String>['SetRoomName']);
+    expect(overviewRoute.isActive, isTrue,
+        reason:
+            'the outgoing route must cover the lazy entry during animation');
+    await tester.pump();
+    expect(outgoingSecondaryAnimation?.value, 0,
+        reason: 'lazy history must not animate the outgoing screen away');
+    await tester.pumpAndSettle();
+    expect(constructed, <String>['SetRoomName']);
+    expect(overviewRoute.isActive, isFalse);
+
+    navigatorKey.currentState!.pop();
+    await tester.pump();
+
+    expect(constructed, <String>['SetRoomName', 'Wifi']);
+    await tester.pumpAndSettle();
+    expect(find.text('Wifi'), findsOneWidget);
+  });
+
+  testWidgets('screen tracker ignores lazy history until Back reveals it',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester, trackScreens: true);
+    navigatorKey.currentState!.push(routeFor(descriptor('Overview')));
+    await tester.pumpAndSettle();
+
+    final factory = EnsembleRouteFactory((entry) {
+      if (entry.identifier == 'Wifi') {
+        ScreenTracker().trackScreenFromPayload(entry.toPayload());
+      }
+      return Scaffold(body: Text(entry.identifier));
+    });
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[
+        descriptor('Home'),
+        descriptor('Wifi'),
+      ],
+      destination: descriptor('SetRoomName'),
+      createRoute: (entry, {required animate}) => factory.create(
+        navigatorKey.currentContext!,
+        entry,
+        transition: const <String, dynamic>{'duration': 100},
+        animate: animate,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(ScreenTracker().getCurrentScreenIdentifier(), 'SetRoomName');
+    expect(
+      ScreenTracker().screenHistory.map((screen) => screen.screenName),
+      <String?>['Home', 'SetRoomName'],
+    );
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+
+    expect(ScreenTracker().getCurrentScreenIdentifier(), 'Wifi');
+    expect(
+      ScreenTracker().screenHistory.map((screen) => screen.screenName),
+      <String?>['Home', 'Wifi'],
+    );
+  });
+
+  testWidgets('coalesces identical transactions while one is pending',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    final home = descriptor('Home');
+    final system = descriptor('System');
+
+    final first = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[home],
+      destination: system,
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    final second = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[home],
+      destination: system,
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+
+    expect(identical(first, second), isTrue);
+    await first;
+    await tester.pumpAndSettle();
+    expect(manager.history.map((entry) => entry.descriptor.identifier),
+        <String>['Home', 'System']);
+  });
+
+  testWidgets('publishes a single reconciled snapshot to browser history',
+      (tester) async {
+    final browserHistory = _RecordingBrowserHistory();
+    final navigatorKey = await pumpApp(
+      tester,
+      browserHistory: browserHistory,
+    );
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('System'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    await tester.pumpAndSettle();
+
+    expect(browserHistory.reconciliations, hasLength(1));
+    expect(browserHistory.reconciliations.single.currentDepth, 1);
+    expect(browserHistory.reconciliations.single.prefixLength, 1);
+    expect(
+      browserHistory.reconciliations.single.finalHistory
+          .map((entry) => entry.identifier),
+      <String>['Home', 'System'],
+    );
+  });
+
+  testWidgets('browser snapshot preserves inputs of a wildcard-retained route',
+      (tester) async {
+    final browserHistory = _RecordingBrowserHistory();
+    final navigatorKey = await pumpApp(
+      tester,
+      browserHistory: browserHistory,
+      homeInputs: <String, dynamic>{'userId': 42},
+    );
+
+    await manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('System'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      browserHistory.reconciliations.single.finalHistory.first.inputs,
+      <String, dynamic>{'userId': 42},
+    );
+  });
+}
+
+class _TestBrowserHistory implements NavigationBrowserHistory {
+  @override
+  bool get isHandlingPopState => false;
+
+  @override
+  void recordPop() {}
+
+  @override
+  void recordPush(List<EnsembleRouteDescriptor> snapshot) {}
+
+  @override
+  Future<void> reconcile({
+    required int currentDepth,
+    required int prefixLength,
+    required List<EnsembleRouteDescriptor> finalHistory,
+  }) async {}
+
+  @override
+  void replaceInitial(List<EnsembleRouteDescriptor> snapshot) {}
+}
+
+class _RecordingBrowserHistory extends _TestBrowserHistory {
+  final List<_RecordedReconciliation> reconciliations = [];
+
+  @override
+  Future<void> reconcile({
+    required int currentDepth,
+    required int prefixLength,
+    required List<EnsembleRouteDescriptor> finalHistory,
+  }) async {
+    reconciliations.add(_RecordedReconciliation(
+      currentDepth,
+      prefixLength,
+      finalHistory,
+    ));
+  }
+}
+
+class _RecordedReconciliation {
+  const _RecordedReconciliation(
+      this.currentDepth, this.prefixLength, this.finalHistory);
+
+  final int currentDepth;
+  final int prefixLength;
+  final List<EnsembleRouteDescriptor> finalHistory;
+}
+
+class _RetainedCounter extends StatefulWidget {
+  const _RetainedCounter();
+
+  @override
+  State<_RetainedCounter> createState() => _RetainedCounterState();
+}
+
+class _RetainedCounterState extends State<_RetainedCounter> {
+  var count = 0;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: TextButton(
+          onPressed: () => setState(() => count++),
+          child: Text('$count'),
+        ),
+      );
+}

--- a/modules/ensemble/test/ensemble_navigation_manager_test.dart
+++ b/modules/ensemble/test/ensemble_navigation_manager_test.dart
@@ -1,4 +1,5 @@
 import 'package:ensemble/framework/screen_tracker.dart';
+import 'package:ensemble/layout/ensemble_page_route.dart';
 import 'package:ensemble/navigation/browser/navigation_browser_history.dart';
 import 'package:ensemble/navigation/ensemble_navigation_manager.dart';
 import 'package:ensemble/navigation/ensemble_route_factory.dart';
@@ -14,14 +15,14 @@ void main() {
       EnsembleRouteDescriptor(screenName: name, inputs: inputs);
 
   PageRouteBuilder<dynamic> routeFor(EnsembleRouteDescriptor descriptor,
-      {Widget? child}) {
+      {Widget? child, Duration transitionDuration = Duration.zero}) {
     return PageRouteBuilder<dynamic>(
       settings: EnsembleRouteSettings(
         descriptor: descriptor,
         payload: descriptor.toPayload(),
       ),
-      transitionDuration: Duration.zero,
-      reverseTransitionDuration: Duration.zero,
+      transitionDuration: transitionDuration,
+      reverseTransitionDuration: transitionDuration,
       pageBuilder: (_, __, ___) =>
           child ?? Scaffold(body: Text(descriptor.identifier)),
     );
@@ -259,6 +260,106 @@ void main() {
     await tester.pumpAndSettle();
     expect(manager.history.map((entry) => entry.descriptor.identifier),
         <String>['Home', 'System']);
+  });
+
+  testWidgets('coalesces equivalent inputs with different map insertion order',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    final firstInputs = <String, dynamic>{
+      'filter': <String, dynamic>{'active': true, 'sort': 'name'},
+      'page': 1,
+    };
+    final secondInputs = <String, dynamic>{
+      'page': 1,
+      'filter': <String, dynamic>{'sort': 'name', 'active': true},
+    };
+
+    final first = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('System', inputs: firstInputs),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+    final second = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('System', inputs: secondInputs),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+
+    expect(identical(first, second), isTrue);
+    await first;
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('removed destination does not block the transaction queue',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    final first = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('First'),
+      createRoute: (entry, {required animate}) => routeFor(
+        entry,
+        transitionDuration:
+            animate ? const Duration(seconds: 10) : Duration.zero,
+      ),
+    );
+    await tester.pump();
+    final firstRoute = await first;
+
+    navigatorKey.currentState!
+        .pushReplacement(routeFor(descriptor('LegacyReplacement')));
+    final second = manager.navigateWithHistory(
+      navigator: navigatorKey.currentState!,
+      history: <EnsembleRouteDescriptor>[descriptor('Home')],
+      destination: descriptor('Second'),
+      createRoute: (entry, {required animate}) => routeFor(entry),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    final secondRoute = await second;
+    expect(firstRoute.isActive, isFalse);
+    expect(secondRoute.isActive, isTrue);
+    expect(manager.history.map((entry) => entry.descriptor.identifier),
+        <String>['Home', 'Second']);
+  });
+
+  testWidgets('lazy route reports reveal only after reverse transition',
+      (tester) async {
+    final navigatorKey = await pumpApp(tester);
+    var constructed = false;
+    final lazyDescriptor = descriptor('History');
+    final lazyRoute = LazyEnsemblePageRouteBuilder<dynamic>(
+      screenBuilder: (_) {
+        constructed = true;
+        return const Scaffold(body: Text('History'));
+      },
+      settings: EnsembleRouteSettings(
+        descriptor: lazyDescriptor,
+        payload: lazyDescriptor.toPayload(),
+      ),
+    );
+    navigatorKey.currentState!.push(lazyRoute);
+    final destination = routeFor(
+      descriptor('Destination'),
+      transitionDuration: const Duration(milliseconds: 200),
+    );
+    navigatorKey.currentState!.push(destination);
+    await tester.pumpAndSettle();
+
+    var revealed = false;
+    lazyRoute.revealed.then((_) => revealed = true);
+    navigatorKey.currentState!.pop();
+    await tester.pump();
+
+    expect(constructed, isTrue);
+    expect(revealed, isFalse);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(revealed, isFalse);
+    await tester.pumpAndSettle();
+    expect(revealed, isTrue);
   });
 
   testWidgets('publishes a single reconciled snapshot to browser history',

--- a/modules/ensemble/test/navigation_reconciler_test.dart
+++ b/modules/ensemble/test/navigation_reconciler_test.dart
@@ -1,14 +1,24 @@
 import 'package:ensemble/navigation/navigation_models.dart';
 import 'package:ensemble/navigation/navigation_reconciler.dart';
+import 'package:ensemble/page_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   const reconciler = NavigationReconciler();
 
-  ManagedEnsembleRoute managed(String name, {Map<String, dynamic>? inputs}) {
-    final descriptor =
-        EnsembleRouteDescriptor(screenName: name, inputs: inputs);
+  ManagedEnsembleRoute managed(
+    String? name, {
+    String? screenId,
+    Map<String, dynamic>? inputs,
+    PageType pageType = PageType.regular,
+  }) {
+    final descriptor = EnsembleRouteDescriptor(
+      screenId: screenId,
+      screenName: name,
+      inputs: inputs,
+      pageType: pageType,
+    );
     return ManagedEnsembleRoute(
       descriptor: descriptor,
       route: PageRouteBuilder<void>(
@@ -119,6 +129,39 @@ void main() {
     ];
 
     expect(reconciler.reconcile(current, requested).prefixLength, 3);
+  });
+
+  test('name request retains a route that also has a screen ID', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed('Details', screenId: 'screen-123'),
+      ],
+      <EnsembleRouteDescriptor>[desired('Details')],
+    );
+
+    expect(result.prefixLength, 1);
+  });
+
+  test('ID-only route does not guess equivalence with a screen name', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed(null, screenId: 'Details'),
+      ],
+      <EnsembleRouteDescriptor>[desired('Details')],
+    );
+
+    expect(result.prefixLength, 0);
+  });
+
+  test('regular request never retains a modal with the same name', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed('Details', pageType: PageType.modal),
+      ],
+      <EnsembleRouteDescriptor>[desired('Details')],
+    );
+
+    expect(result.prefixLength, 0);
   });
 
   test('handles empty and unrelated histories', () {

--- a/modules/ensemble/test/navigation_reconciler_test.dart
+++ b/modules/ensemble/test/navigation_reconciler_test.dart
@@ -1,0 +1,140 @@
+import 'package:ensemble/navigation/navigation_models.dart';
+import 'package:ensemble/navigation/navigation_reconciler.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const reconciler = NavigationReconciler();
+
+  ManagedEnsembleRoute managed(String name, {Map<String, dynamic>? inputs}) {
+    final descriptor =
+        EnsembleRouteDescriptor(screenName: name, inputs: inputs);
+    return ManagedEnsembleRoute(
+      descriptor: descriptor,
+      route: PageRouteBuilder<void>(
+        settings: EnsembleRouteSettings(
+          descriptor: descriptor,
+          payload: descriptor.toPayload(),
+        ),
+        pageBuilder: (_, __, ___) => const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  EnsembleRouteDescriptor desired(String name,
+          {Map<String, dynamic>? inputs}) =>
+      EnsembleRouteDescriptor(screenName: name, inputs: inputs);
+
+  test('retains the longest compatible prefix', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed('Home'),
+        managed('Settings'),
+        managed('Account'),
+        managed('Profile'),
+      ],
+      <EnsembleRouteDescriptor>[desired('Home'), desired('Settings')],
+    );
+
+    expect(result.prefixLength, 2);
+    expect(result.retained.map((route) => route.descriptor.identifier),
+        <String>['Home', 'Settings']);
+    expect(result.obsolete.map((route) => route.descriptor.identifier),
+        <String>['Account', 'Profile']);
+    expect(result.missing, isEmpty);
+  });
+
+  test('stops matching when inputs differ deeply', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed('Home'),
+        managed('Product', inputs: <String, dynamic>{
+          'product': <String, dynamic>{'id': 1}
+        }),
+      ],
+      <EnsembleRouteDescriptor>[
+        desired('Home'),
+        desired('Product', inputs: <String, dynamic>{
+          'product': <String, dynamic>{'id': 2}
+        }),
+      ],
+    );
+
+    expect(result.prefixLength, 1);
+    expect(result.obsolete.single.descriptor.identifier, 'Product');
+    expect(result.missing.single.identifier, 'Product');
+  });
+
+  test('omitted requested inputs retain the existing route and its inputs', () {
+    final currentHome = managed('Home', inputs: <String, dynamic>{
+      'userId': 42,
+      'filters': <String, dynamic>{'active': true},
+    });
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[currentHome],
+      <EnsembleRouteDescriptor>[desired('Home')],
+    );
+
+    expect(result.prefixLength, 1);
+    expect(result.retained.single, same(currentHome));
+    expect(result.obsolete, isEmpty);
+    expect(result.missing, isEmpty);
+  });
+
+  test('empty requested inputs retain a route with existing inputs', () {
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[
+        managed('Home', inputs: <String, dynamic>{'userId': 42}),
+      ],
+      <EnsembleRouteDescriptor>[
+        desired('Home', inputs: <String, dynamic>{}),
+      ],
+    );
+
+    expect(result.prefixLength, 1);
+  });
+
+  test('supplied equal inputs retain the existing route', () {
+    final inputs = <String, dynamic>{
+      'user': <String, dynamic>{'id': 42},
+    };
+    final result = reconciler.reconcile(
+      <ManagedEnsembleRoute>[managed('Home', inputs: inputs)],
+      <EnsembleRouteDescriptor>[desired('Home', inputs: inputs)],
+    );
+
+    expect(result.prefixLength, 1);
+  });
+
+  test('supports duplicate screens with different inputs', () {
+    final current = <ManagedEnsembleRoute>[
+      managed('Home'),
+      managed('Product', inputs: <String, dynamic>{'id': 1}),
+      managed('Product', inputs: <String, dynamic>{'id': 2}),
+    ];
+    final requested = <EnsembleRouteDescriptor>[
+      desired('Home'),
+      desired('Product', inputs: <String, dynamic>{'id': 1}),
+      desired('Product', inputs: <String, dynamic>{'id': 2}),
+    ];
+
+    expect(reconciler.reconcile(current, requested).prefixLength, 3);
+  });
+
+  test('handles empty and unrelated histories', () {
+    expect(
+      reconciler.reconcile(
+        <ManagedEnsembleRoute>[managed('A')],
+        <EnsembleRouteDescriptor>[],
+      ).obsolete,
+      hasLength(1),
+    );
+    expect(
+      reconciler.reconcile(
+        <ManagedEnsembleRoute>[managed('A')],
+        <EnsembleRouteDescriptor>[desired('X'), desired('Y')],
+      ).prefixLength,
+      0,
+    );
+  });
+}


### PR DESCRIPTION
## Description

Adds declarative navigation stack support to `navigateScreen`, allowing applications to define the history that should precede the destination screen.

The implementation preserves compatible existing routes, lazily inserts missing historical routes, and avoids constructing or tracking screens until they become visible. It also provides Flutter Web Back/Forward synchronization while keeping URLs unchanged.

## Related Issue

Fixes #2346

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Added object-based `navigateScreen.stack` support with evaluated screen names and nested inputs.
- Added validation for malformed entries, unknown screens, empty names, and conflicting navigation options.
- Distinguished an omitted stack from `stack: []`, which makes the destination the new root.
- Added longest-compatible-prefix reconciliation for preserving existing routes and widget state.
- Added directional input matching:
  - omitted or empty requested inputs retain the existing route and its inputs;
  - supplied equal inputs retain the route;
  - supplied different inputs reconstruct the route.
- Added lazy historical routes so rewritten history does not initialize, render, or track screens before they become visible.
- Prevented lazy routes from affecting destination transitions or exposing blank/black frames.
- Added FIFO transaction handling and coalescing for rapid identical navigation requests.
- Added route exit reasons so `onNavigateBack` only runs for real Back navigation.
- Updated screen tracking to ignore structural lazy-route insertion and publish the route only when Back reveals it.
- Added typed route metadata while retaining `ScreenPayload` route arguments for compatibility.
- Added session-level Flutter Web Back/Forward synchronization using opaque browser-history tokens without changing URLs.
- Added parser, reconciler, navigation manager, tracking, transition, concurrency, and browser-history tests.
- Added developer architecture documentation under `modules/ensemble/doc/navigation-architecture.md`.
- Updated the Ensemble schema with the new stack format and matching semantics.

## How to Test

1. Configure navigation with a declarative stack:

   ```yaml
   navigateScreen:
     name: ScreenC
     stack:
       - name: Home
       - name: ScreenB
   ```

2. Navigate from `Home → ScreenA` and verify the resulting history is:

   ```text
   Home → ScreenB → ScreenC
   ```

3. Verify the transaction reports:

   ```text
   KEEP: Home
   DROP: ScreenA
   INSERT: ScreenB
   PUSH: ScreenC
   ```

4. Verify only `ScreenC` is rendered and tracked during forward navigation.

5. Navigate Back and verify `ScreenB` is materialized and tracked at that point.

6. Verify a retained route preserves its widget, scroll, and PageGroup state.

7. Verify omitted or empty stack-entry inputs retain the existing route inputs.

8. Verify supplying different inputs reconstructs the route from the first mismatch.

9. Verify `stack: []` makes the destination the root.

10. Verify stack-less, modal, replacement, clear-all, external, and deep-link navigation continue to behave as before.

11. Run the focused tests:

    ```bash
    cd modules/ensemble
    flutter test \
      test/action_test.dart \
      test/navigation_reconciler_test.dart \
      test/ensemble_navigation_manager_test.dart
    ```

## Screenshots / Videos

Not applicable.

## Checklist

- [x] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [x] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors