### PR TITLE
fix: remove unused image cache manager override

### DIFF
--- a/modules/ensemble/lib/framework/widget/image.dart
+++ b/modules/ensemble/lib/framework/widget/image.dart
@@ -23,7 +23,7 @@ class Image extends StatelessWidget {
       this.placeholderBuilder,
       this.loadingWidget,
       this.colorFilter,
-      this.networkCacheManager});
+      this.cacheManager});
 
   final String source;
   final double? width;
@@ -41,8 +41,8 @@ class Image extends StatelessWidget {
   // optional widget while the image is loading
   final Widget? loadingWidget;
 
-  // optional cache manager for network image
-  final BaseCacheManager? networkCacheManager;
+  // The cache policy selected by the calling Ensemble widget.
+  final BaseCacheManager? cacheManager;
 
   @override
   Widget build(BuildContext context) {
@@ -78,7 +78,7 @@ class Image extends StatelessWidget {
           errorWidget: errorBuilder != null
               ? (context, url, error) => errorBuilder!(error.toString())
               : null,
-          cacheManager: networkCacheManager,
+          cacheManager: cacheManager,
         );
       }
     } else {

--- a/modules/ensemble/lib/widget/avatar.dart
+++ b/modules/ensemble/lib/widget/avatar.dart
@@ -18,7 +18,6 @@ import 'package:ensemble/widget/helpers/box_wrapper.dart';
 import 'package:ensemble/widget/helpers/controllers.dart';
 import 'package:ensemble/widget/image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:yaml/yaml.dart';
 
 class Avatar extends EnsembleWidget<AvatarController> {
@@ -45,7 +44,6 @@ class AvatarController extends EnsembleBoxController {
   BoxFit? fit;
   Color? placeholderColor;
   dynamic loadingWidget;
-  BaseCacheManager? networkCacheManager;
   ColorFilterComposite? colorFilter;
   bool allowRedirect = true;
   int? resizedWidth;
@@ -77,8 +75,6 @@ class AvatarController extends EnsembleBoxController {
       'fit': (value) => fit = Utils.getBoxFit(value),
       'placeholderColor': (value) => placeholderColor = Utils.getColor(value),
       'loadingWidget': (value) => loadingWidget = value,
-      'networkCacheManager': (value) =>
-          networkCacheManager = value is BaseCacheManager ? value : null,
       'allowRedirect': (value) =>
           allowRedirect = Utils.getBool(value, fallback: true),
       'resizedWidth': (value) =>
@@ -316,12 +312,9 @@ class AvatarState extends EnsembleWidgetState<Avatar>
               ? getScopeManager()!
                   .buildWidgetFromDefinition(widget.controller.loadingWidget)
               : null,
-      networkCacheManager: widget.controller.allowRedirect
-          ? widget.controller.networkCacheManager ??
-              EnsembleImageCacheManager.instanceFor()
-          : EnsembleImageCacheManager.instanceFor(
-              allowRedirect: false,
-            ),
+      cacheManager: EnsembleImageCacheManager.instanceFor(
+        allowRedirect: widget.controller.allowRedirect,
+      ),
       placeholderBuilder: (_, __) =>
           ColoredBoxPlaceholder(color: widget.controller.placeholderColor),
       errorBuilder: (_) => _buildFallback());

--- a/modules/ensemble/lib/widget/image.dart
+++ b/modules/ensemble/lib/widget/image.dart
@@ -68,9 +68,6 @@ class EnsembleImage extends StatefulWidget
       'placeholderColor': (value) =>
           _controller.placeholderColor = Utils.getColor(value),
       'loadingWidget': (widget) => _controller.loadingWidget = widget,
-      'networkCacheManager': (value) =>
-          _controller.networkCacheManager =
-              value is BaseCacheManager ? value : null,
       'fallback': (widget) => _controller.fallback = widget,
       'onTap': (funcDefinition) => _controller.onTap =
           EnsembleAction.from(funcDefinition, initiator: this),
@@ -99,7 +96,6 @@ class ImageController extends BoxController {
   BoxFit? fit;
   Color? placeholderColor;
   dynamic loadingWidget;
-  BaseCacheManager? networkCacheManager;
   EnsembleAction? onTap;
   String? onTapHaptic;
   ColorFilterComposite? colorFilter;
@@ -299,12 +295,9 @@ class ImageState extends EWidgetState<EnsembleImage> {
           // gigantic images won't run out of memory
           memCacheWidth: cachedWidth,
           memCacheHeight: cachedHeight,
-          cacheManager: widget._controller.allowRedirect
-              ? widget._controller.networkCacheManager ??
-                  EnsembleImageCacheManager.instanceFor()
-              : EnsembleImageCacheManager.instanceFor(
-                  allowRedirect: false,
-                ),
+          cacheManager: EnsembleImageCacheManager.instanceFor(
+            allowRedirect: widget._controller.allowRedirect,
+          ),
           errorWidget: (context, error, stacktrace) => errorFallback(),
           placeholder: (context, url) => _buildLoadingPlaceholder(loadingWidget: loadingWidget),
           httpHeaders: _evaluateHeaders(),


### PR DESCRIPTION
This PR removes the unused `networkCacheManager` override from the `Image` and `Avatar` controllers.

The override accepted only a runtime `BaseCacheManager` instance, which cannot be supplied through Ensemble YAML and has no in-repository caller. Image and Avatar continue to use Ensemble's internal cache manager, preserving redirect handling and configured cache behavior.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## What Has Changed

- Removed the unused `networkCacheManager` fields and setters from `ImageController` and `AvatarController`.
- Kept `EnsembleImageCacheManager.instanceFor(allowRedirect: ...)` as the manager used by Image and Avatar network requests.
- Renamed the framework Image helper parameter from `networkCacheManager` to `cacheManager` to clarify that it forwards the internally selected cache policy.
- Preserved `allowRedirect: false` redirect blocking and `App.imageCache` configuration for both Image and Avatar.

## How to Test

1. Run the focused image widget tests:

   ```bash
   cd modules/ensemble
   flutter test test/widget/image_widget_test.dart
   ```

2. Verify an `Image` and `Avatar` with a network source still load normally.
3. Verify `allowRedirect: false` continues to reject redirected image requests.
4. Verify configured `App.imageCache` settings still apply to network images.

## Screenshots / Videos

N/A

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [x] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [ ] I have updated documentation if needed
- [ ] My changes do not introduce new warnings or errors