### PR TITLE
feat(wifi): enhance error handling for Wi-Fi connection failures

### DIFF
--- a/modules/ensemble/lib/action/wifi_action.dart
+++ b/modules/ensemble/lib/action/wifi_action.dart
@@ -47,12 +47,13 @@ Future<dynamic> _handleWifiError(
   BuildContext context,
   Invokable? initiator,
   EnsembleAction? onError,
-  Object error,
-) {
+  Object error, {
+  String status = 'error',
+}) {
   if (onError != null) {
     return ScreenController().executeAction(context, onError,
         event: EnsembleEvent(initiator,
-            error: error.toString(), data: {'status': 'error'}));
+            error: error.toString(), data: {'status': status}));
   }
   return Future.value(null);
 }
@@ -79,8 +80,12 @@ class ConnectToWifiAction extends EnsembleAction {
   final bool isHidden;
   /// Action executed when the operation succeeds.
   final EnsembleAction? onSuccess;
-  /// Action executed when the operation fails.
+  /// Action executed when the operation fails for a non-permission reason.
   final EnsembleAction? onError;
+  /// Action executed when location permission is denied.
+  final EnsembleAction? onPermissionDenied;
+  /// Action executed when device location services are disabled.
+  final EnsembleAction? onLocationDisabled;
 
   /// Creates a [ConnectToWifiAction] action.
   ConnectToWifiAction({
@@ -96,6 +101,8 @@ class ConnectToWifiAction extends EnsembleAction {
     required this.isHidden,
     this.onSuccess,
     this.onError,
+    this.onPermissionDenied,
+    this.onLocationDisabled,
   });
 
   /// Creates a [ConnectToWifiAction] from a YAML or map action payload.
@@ -126,6 +133,10 @@ class ConnectToWifiAction extends EnsembleAction {
       onSuccess:
           EnsembleAction.from(payload?['onSuccess'], initiator: initiator),
       onError: EnsembleAction.from(payload?['onError'], initiator: initiator),
+      onPermissionDenied: EnsembleAction.from(payload?['onPermissionDenied'],
+          initiator: initiator),
+      onLocationDisabled: EnsembleAction.from(payload?['onLocationDisabled'],
+          initiator: initiator),
     );
   }
 
@@ -145,8 +156,26 @@ class ConnectToWifiAction extends EnsembleAction {
           return _handleWifiResult(
               context, initiator, onSuccess, onError, result);
         case WifiOperation.connect:
-          return _connect(context, scopeManager);
+          // Must await so errors are caught below
+          // and routed to the matching callbacks.
+          return await _connect(context, scopeManager);
       }
+    } on WifiLocationDisabledException catch (e) {
+      return _handleWifiError(
+        context,
+        initiator,
+        onLocationDisabled ?? onError,
+        e.message,
+        status: 'locationDisabled',
+      );
+    } on WifiPermissionDeniedException catch (e) {
+      return _handleWifiError(
+        context,
+        initiator,
+        onPermissionDenied ?? onError,
+        e.message,
+        status: 'permissionDenied',
+      );
     } on PlatformException catch (e) {
       final message = e.message?.isNotEmpty == true ? e.message! : e.code;
       return _handleWifiError(

--- a/modules/ensemble/lib/framework/stub/wifi_manager.dart
+++ b/modules/ensemble/lib/framework/stub/wifi_manager.dart
@@ -1,6 +1,36 @@
 import 'package:ensemble/framework/error_handling.dart';
 import 'package:flutter/foundation.dart';
 
+/// Thrown when device location services are off and Wi-Fi connect cannot proceed.
+class WifiLocationDisabledException implements Exception {
+  /// Human-readable explanation for the developer / onError fallback.
+  final String message;
+
+  /// Creates a [WifiLocationDisabledException].
+  WifiLocationDisabledException([
+    this.message =
+        'Location services are disabled. Enable location to connect to WiFi.',
+  ]);
+
+  @override
+  String toString() => message;
+}
+
+/// Thrown when location permission is denied and Wi-Fi connect cannot proceed.
+class WifiPermissionDeniedException implements Exception {
+  /// Human-readable explanation for the developer / onError fallback.
+  final String message;
+
+  /// Creates a [WifiPermissionDeniedException].
+  WifiPermissionDeniedException([
+    this.message =
+        'Location permission is required to connect to WiFi on this device.',
+  ]);
+
+  @override
+  String toString() => message;
+}
+
 abstract class WifiManager {
   Future<bool?> connect(String ssid, {bool saveNetwork = false});
 

--- a/modules/ensemble_wifi/README.md
+++ b/modules/ensemble_wifi/README.md
@@ -221,10 +221,14 @@ sequenceDiagram
   else Mobile
     Action->>Impl: connectToSecureNetwork(…)
     Impl->>Geo: check / request location permission
-    alt Permission denied
+    alt Location services disabled
+      Geo-->>Impl: disabled
+      Impl-->>Action: WifiLocationDisabledException
+      Action-->>User: onLocationDisabled (falls back to onError)
+    else Permission denied
       Geo-->>Impl: denied
-      Impl-->>Action: StateError
-      Action-->>User: onError
+      Impl-->>Action: WifiPermissionDeniedException
+      Action-->>User: onPermissionDenied (falls back to onError)
     else Permission granted
       Geo-->>Impl: granted
       Impl->>Plugin: connectToSecureNetwork(…)
@@ -245,18 +249,20 @@ sequenceDiagram
 ### Parameters
 
 
-| Parameter     | Required                                     | Default   | Description                                                   |
-| ------------- | -------------------------------------------- | --------- | ------------------------------------------------------------- |
-| `operation`   | No                                           | `connect` | `connect` or `disconnect` |
-| `ssid`        | One of `ssid` or `ssidPrefix` (connect only) | —         | Exact network name                                            |
-| `ssidPrefix`  | One of `ssid` or `ssidPrefix` (connect only) | —         | Match nearest network by SSID prefix (common for IoT devices) |
-| `password`    | No                                           | —         | If set, uses secured connect                                  |
-| `saveNetwork` | No                                           | `false`   | Remember the network on the device after connecting           |
-| `isWep`       | No                                           | `false`   | WEP encryption (not supported on Android)                     |
-| `isWpa3`      | No                                           | `false`   | WPA3 network                                                  |
-| `isHidden`    | No                                           | `false`   | Hidden SSID (exact `ssid` connect only)                       |
-| `onSuccess`   | No                                           | —         | Action run when the operation succeeds                        |
-| `onError`     | No                                           | —         | Action run when the operation fails                           |
+| Parameter             | Required                                     | Default   | Description                                                   |
+| --------------------- | -------------------------------------------- | --------- | ------------------------------------------------------------- |
+| `operation`           | No                                           | `connect` | `connect` or `disconnect` |
+| `ssid`                | One of `ssid` or `ssidPrefix` (connect only) | —         | Exact network name                                            |
+| `ssidPrefix`          | One of `ssid` or `ssidPrefix` (connect only) | —         | Match nearest network by SSID prefix (common for IoT devices) |
+| `password`            | No                                           | —         | If set, uses secured connect                                  |
+| `saveNetwork`         | No                                           | `false`   | Remember the network on the device after connecting           |
+| `isWep`               | No                                           | `false`   | WEP encryption (not supported on Android)                     |
+| `isWpa3`              | No                                           | `false`   | WPA3 network                                                  |
+| `isHidden`            | No                                           | `false`   | Hidden SSID (exact `ssid` connect only)                       |
+| `onSuccess`           | No                                           | —         | Action run when the operation succeeds                        |
+| `onError`             | No                                           | —         | Action run for connection / other failures                    |
+| `onPermissionDenied`  | No                                           | —         | Action run when location permission is denied (falls back to `onError`) |
+| `onLocationDisabled`  | No                                           | —         | Action run when location services are off (falls back to `onError`) |
 
 
 All string parameters support Ensemble expressions (e.g. `${devicePassword}`).
@@ -279,7 +285,23 @@ data:
   connected: false   # or null, when connect verification failed
 ```
 
-Use `${event.error}` and `${event.data.connected}` in nested actions (e.g. `showToast`).
+**`onPermissionDenied`**
+
+```yaml
+error: "Location permission is required to connect to WiFi on this device."
+data:
+  status: permissionDenied
+```
+
+**`onLocationDisabled`**
+
+```yaml
+error: "Location services are disabled. Enable location to connect to WiFi."
+data:
+  status: locationDisabled
+```
+
+Use `${event.error}` and `${event.data.status}` in nested actions (e.g. `showToast`).
 
 ### JavaScript
 
@@ -290,6 +312,8 @@ ensemble.connectToWifi({
   ssid: 'MyNetwork',
   password: myPassword,
   onSuccess: { showToast: { message: 'Connected' } },
+  onPermissionDenied: { showToast: { message: 'Please grant location permission' } },
+  onLocationDisabled: { showToast: { message: 'Please enable location services' } },
   onError: { showToast: { message: event.error } }
 });
 ```
@@ -325,6 +349,12 @@ onTap:
     onSuccess:
       showToast:
         message: Connected
+    onPermissionDenied:
+      showToast:
+        message: Please grant location permission to connect to WiFi
+    onLocationDisabled:
+      showToast:
+        message: Please enable location services
     onError:
       showToast:
         message: ${event.error}

--- a/modules/ensemble_wifi/lib/wifi_manager_impl.dart
+++ b/modules/ensemble_wifi/lib/wifi_manager_impl.dart
@@ -16,8 +16,7 @@ class WifiManagerImpl implements WifiManager {
     }
 
     if (!await Geolocator.isLocationServiceEnabled()) {
-      throw StateError(
-          'Location services are disabled. Enable location to connect to WiFi.');
+      throw WifiLocationDisabledException();
     }
 
     var permission = await Geolocator.checkPermission();
@@ -27,8 +26,7 @@ class WifiManagerImpl implements WifiManager {
 
     if (permission == LocationPermission.denied ||
         permission == LocationPermission.deniedForever) {
-      throw StateError(
-          'Location permission is required to connect to WiFi on this device.');
+      throw WifiPermissionDeniedException();
     }
   }
 


### PR DESCRIPTION
- Introduced `WifiLocationDisabledException` and `WifiPermissionDeniedException` to handle specific error cases when location services are disabled or permission is denied.
- Updated `_handleWifiError` to accept a status parameter for more informative error handling.
- Added new callback parameters `onPermissionDenied` and `onLocationDisabled` to `ConnectToWifiAction` for improved user feedback.
- Updated documentation to reflect new error handling mechanisms and callback parameters.