### PR TITLE
feat(tab-bar): add customizable divider thickness

### DIFF
--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -70,9 +70,15 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         TabAlignment.values.from(widget.controller.tabAlignment) ??
             TabAlignment.start;
 
+    final dividerColor = widget.controller.dividerColor ?? Colors.transparent;
+    final dividerThickness =
+        widget.controller.dividerThickness?.toDouble() ?? 1;
+    final dividerPadding = widget.controller.dividerPadding;
+
     Widget tabBar = TabBar(
         labelPadding: labelPadding,
-        dividerColor: widget.controller.dividerColor ?? Colors.transparent,
+        dividerColor: dividerPadding == null ? dividerColor : Colors.transparent,
+        dividerHeight: dividerPadding == null ? dividerThickness : 0,
         indicator: indicatorThickness == 0
             ? BoxDecoration(
                 color: widget.controller.activeTabBackgroundColor ??
@@ -95,6 +101,42 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
             widget.controller.inactiveTabColor ?? Colors.black87,
         tabs: _buildTabs(widget.controller.items),
         onTap: onTabChanged);
+
+    if (dividerPadding != null) {
+      final divider = Padding(
+        padding: EdgeInsets.only(
+          left: dividerPadding.left,
+          right: dividerPadding.right,
+        ),
+        child: SizedBox(
+          height: dividerThickness,
+          child: ColoredBox(color: dividerColor),
+        ),
+      );
+
+      tabBar = dividerPadding.top > 0 || dividerPadding.bottom > 0
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                tabBar,
+                SizedBox(height: dividerPadding.top),
+                divider,
+                SizedBox(height: dividerPadding.bottom),
+              ],
+            )
+          : Stack(
+              children: [
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  height: dividerThickness,
+                  child: divider,
+                ),
+                tabBar,
+              ],
+            );
+    }
 
     if (widget.controller.tabBackgroundColor != null) {
       tabBar = ColoredBox(
@@ -135,6 +177,10 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
     final focusIndicatorColor = widget.controller.focusIndicatorColor;
     final focusTabColor = widget.controller.focusTabColor;
     final backgroundColor = widget.controller.tabBackgroundColor;
+    final dividerColor = widget.controller.dividerColor ?? Colors.transparent;
+    final dividerThickness =
+        widget.controller.dividerThickness?.toDouble() ?? 1;
+    final dividerPadding = widget.controller.dividerPadding;
     final indicatorThickness =
         widget.controller.indicatorThickness?.toDouble() ?? 2;
 
@@ -168,6 +214,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
                 focusIndicatorColor: focusIndicatorColor,
                 focusTabColor: focusTabColor,
                 indicatorThickness: indicatorThickness,
+                indicatorGap: dividerPadding?.top ?? 0,
                 tabFontSize: widget.controller.tabFontSize?.toDouble(),
                 tabFontWeight: widget.controller.tabFontWeight,
                 tabPadding: widget.controller.tabPadding,
@@ -188,7 +235,29 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
           );
         }
 
-        return tabRow;
+        final divider = Padding(
+          padding: EdgeInsets.only(
+            left: dividerPadding?.left ?? 0,
+            right: dividerPadding?.right ?? 0,
+          ),
+          child: SizedBox(
+            height: dividerThickness,
+            child: ColoredBox(color: dividerColor),
+          ),
+        );
+
+        return Stack(
+          children: [
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: dividerThickness,
+              child: divider,
+            ),
+            tabRow,
+          ],
+        );
       },
     );
 
@@ -273,6 +342,7 @@ class _TVTabButton extends StatefulWidget {
     this.focusIndicatorColor,
     this.focusTabColor,
     required this.indicatorThickness,
+    required this.indicatorGap,
     required this.onTap,
     this.autofocus = false,
     this.tabFontSize,
@@ -291,6 +361,7 @@ class _TVTabButton extends StatefulWidget {
   final Color? focusIndicatorColor;
   final Color? focusTabColor;
   final double indicatorThickness;
+  final double indicatorGap;
   final VoidCallback onTap;
   final double? tabFontSize;
   final FontWeight? tabFontWeight;
@@ -371,7 +442,7 @@ class _TVTabButtonState extends State<_TVTabButton> {
               children: [
                 // Tab content (icon + label)
                 _buildTabContent(context, hasFocus),
-                const SizedBox(height: 4),
+                SizedBox(height: 4 + widget.indicatorGap),
                 // Indicator line (shows when selected or focused)
                 AnimatedContainer(
                   duration: const Duration(milliseconds: 150),

--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -75,10 +75,16 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         widget.controller.dividerThickness?.toDouble() ?? 1;
     final dividerPadding = widget.controller.dividerPadding;
 
+    // dividerHeight reserves no height -- Material paints the divider inside
+    // the tab row (tabs.dart:2049) -- so lay our own out below the tabs.
+    final wantsCustomDivider = widget.controller.dividerColor != null &&
+        (dividerPadding != null || widget.controller.dividerThickness != null);
+
     Widget tabBar = TabBar(
         labelPadding: labelPadding,
-        dividerColor: dividerPadding == null ? dividerColor : Colors.transparent,
-        dividerHeight: dividerPadding == null ? dividerThickness : 0,
+        dividerColor: wantsCustomDivider ? Colors.transparent : dividerColor,
+        // null keeps TabBarThemeData.dividerHeight resolving for older apps.
+        dividerHeight: wantsCustomDivider ? 0 : null,
         indicator: indicatorThickness == 0
             ? BoxDecoration(
                 color: widget.controller.activeTabBackgroundColor ??
@@ -102,11 +108,11 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         tabs: _buildTabs(widget.controller.items),
         onTap: onTabChanged);
 
-    if (dividerPadding != null) {
+    if (wantsCustomDivider) {
       final divider = Padding(
         padding: EdgeInsets.only(
-          left: dividerPadding.left,
-          right: dividerPadding.right,
+          left: dividerPadding?.left ?? 0,
+          right: dividerPadding?.right ?? 0,
         ),
         child: SizedBox(
           height: dividerThickness,
@@ -114,28 +120,19 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         ),
       );
 
-      tabBar = dividerPadding.top > 0 || dividerPadding.bottom > 0
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                tabBar,
-                SizedBox(height: dividerPadding.top),
-                divider,
-                SizedBox(height: dividerPadding.bottom),
-              ],
-            )
-          : Stack(
-              children: [
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  height: dividerThickness,
-                  child: divider,
-                ),
-                tabBar,
-              ],
-            );
+      // Column, not a Stack overlay: keeps the divider off the indicator, and
+      // keeps the TabBar's width tight -- under a Stack's loose constraints
+      // dividerHeight 0 makes Flutter shrink-wrap the tabs (tabs.dart:2044).
+      tabBar = Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          tabBar,
+          SizedBox(height: dividerPadding?.top ?? 0),
+          divider,
+          SizedBox(height: dividerPadding?.bottom ?? 0),
+        ],
+      );
     }
 
     if (widget.controller.tabBackgroundColor != null) {
@@ -148,15 +145,14 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
       tabBar = Container(
         decoration: BoxDecoration(
           border: Border.all(
-            color: widget.controller.borderColor ?? Colors.transparent, // Customize as needed
+            color: widget.controller.borderColor ??
+                Colors.transparent, // Customize as needed
             width: (widget.controller.borderWidth ?? 0.0).toDouble(),
           ),
           borderRadius: borderRadius ?? BorderRadius.zero,
         ),
         child: ClipRRect(
-            borderRadius: borderRadius ?? BorderRadius.zero,
-            child: tabBar
-        ),
+            borderRadius: borderRadius ?? BorderRadius.zero, child: tabBar),
       );
     }
 
@@ -194,11 +190,11 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
     Widget tabBar = AnimatedBuilder(
       animation: tabController,
       builder: (context, child) {
-        Widget tabRow = SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: List.generate(items.length, (index) {
+        final tvTabAlignment =
+            TabAlignment.values.from(widget.controller.tabAlignment) ??
+                TabAlignment.start;
+
+        List<Widget> buildButtons() => List.generate(items.length, (index) {
               final tabItem = items[index];
 
               return _TVTabButton(
@@ -214,7 +210,6 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
                 focusIndicatorColor: focusIndicatorColor,
                 focusTabColor: focusTabColor,
                 indicatorThickness: indicatorThickness,
-                indicatorGap: dividerPadding?.top ?? 0,
                 tabFontSize: widget.controller.tabFontSize?.toDouble(),
                 tabFontWeight: widget.controller.tabFontWeight,
                 tabPadding: widget.controller.tabPadding,
@@ -223,9 +218,43 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
                   onTabChanged(index);
                 },
               );
-            }),
-          ),
-        );
+            });
+
+        // `fill` needs bounded constraints and Expanded children, which can't
+        // live in a scroll view; every other alignment keeps scrolling.
+        Widget tabRow;
+        if (tvTabAlignment == TabAlignment.fill) {
+          tabRow = Row(
+            children: [
+              for (final button in buildButtons()) Expanded(child: button),
+            ],
+          );
+        } else {
+          tabRow = LayoutBuilder(builder: (context, constraints) {
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: ConstrainedBox(
+                // Viewport-width minimum so non-start alignment has room;
+                // still scrolls on overflow.
+                constraints: constraints.hasBoundedWidth
+                    ? BoxConstraints(minWidth: constraints.maxWidth)
+                    : const BoxConstraints(),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: tvTabAlignment == TabAlignment.center
+                      ? MainAxisAlignment.center
+                      : MainAxisAlignment.start,
+                  children: [
+                    // 52px: the same offset Flutter uses on mobile.
+                    if (tvTabAlignment == TabAlignment.startOffset)
+                      const SizedBox(width: 52.0),
+                    ...buildButtons(),
+                  ],
+                ),
+              ),
+            );
+          });
+        }
 
         // Apply tabBarPadding to the tabs row only (not content area)
         if (widget.controller.tabBarPadding != null) {
@@ -233,6 +262,14 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
             padding: widget.controller.tabBarPadding!,
             child: tabRow,
           );
+        }
+
+        // Only draw when a divider property is set. dividerColor alone
+        // predates this feature and TV never drew a line for it.
+        if (widget.controller.dividerColor == null ||
+            (dividerPadding == null &&
+                widget.controller.dividerThickness == null)) {
+          return tabRow;
         }
 
         final divider = Padding(
@@ -246,23 +283,23 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
           ),
         );
 
-        return Stack(
+        // Same as mobile: divider below the tabs, not overlaid on it.
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: dividerThickness,
-              child: divider,
-            ),
             tabRow,
+            SizedBox(height: dividerPadding?.top ?? 0),
+            divider,
+            SizedBox(height: dividerPadding?.bottom ?? 0),
           ],
         );
       },
     );
 
-    // If tvRow is 0 (default), wrap tabs in their own FocusTraversalGroup
-    if (tvOptions?.row == null) {
+    // Isolate the tabs only when no focus row was given -- either property
+    // opts in to the shared page grid.
+    if (widget.controller.tvRow == null && tvOptions?.row == null) {
       tabBar = FocusTraversalGroup(
         policy: TVFocusOrderTraversalPolicy(),
         child: tabBar,
@@ -284,9 +321,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
           borderRadius: borderRadius ?? BorderRadius.zero,
         ),
         child: ClipRRect(
-            borderRadius: borderRadius ?? BorderRadius.zero,
-            child: tabBar
-        ),
+            borderRadius: borderRadius ?? BorderRadius.zero, child: tabBar),
       );
     }
 
@@ -342,7 +377,6 @@ class _TVTabButton extends StatefulWidget {
     this.focusIndicatorColor,
     this.focusTabColor,
     required this.indicatorThickness,
-    required this.indicatorGap,
     required this.onTap,
     this.autofocus = false,
     this.tabFontSize,
@@ -361,7 +395,6 @@ class _TVTabButton extends StatefulWidget {
   final Color? focusIndicatorColor;
   final Color? focusTabColor;
   final double indicatorThickness;
-  final double indicatorGap;
   final VoidCallback onTap;
   final double? tabFontSize;
   final FontWeight? tabFontWeight;
@@ -442,7 +475,7 @@ class _TVTabButtonState extends State<_TVTabButton> {
               children: [
                 // Tab content (icon + label)
                 _buildTabContent(context, hasFocus),
-                SizedBox(height: 4 + widget.indicatorGap),
+                const SizedBox(height: 4),
                 // Indicator line (shows when selected or focused)
                 AnimatedContainer(
                   duration: const Duration(milliseconds: 150),
@@ -454,7 +487,8 @@ class _TVTabButtonState extends State<_TVTabButton> {
                         : widget.isSelected
                             ? widget.indicatorColor
                             : Colors.transparent,
-                    borderRadius: BorderRadius.circular(widget.indicatorThickness / 2),
+                    borderRadius:
+                        BorderRadius.circular(widget.indicatorThickness / 2),
                   ),
                 ),
               ],
@@ -494,14 +528,16 @@ class _TVTabButtonState extends State<_TVTabButton> {
 
   Widget _buildTabContent(BuildContext context, bool isFocused) {
     final textColor = isFocused
-        ? (widget.focusTabColor ?? Colors.white)
+        // Not white: that's invisible on a light tab bar.
+        ? (widget.focusTabColor ?? widget.activeColor)
         : widget.isSelected
             ? widget.activeColor
             : widget.inactiveColor;
 
     final textStyle = TextStyle(
       fontSize: widget.tabFontSize ?? 14,
-      fontWeight: widget.tabFontWeight ?? (widget.isSelected ? FontWeight.w600 : FontWeight.normal),
+      fontWeight: widget.tabFontWeight ??
+          (widget.isSelected ? FontWeight.w600 : FontWeight.normal),
       color: textColor,
     );
 

--- a/modules/ensemble/lib/layout/tab/scrollable_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/scrollable_tab_bar.dart
@@ -76,6 +76,10 @@ class ScrollableTabBar extends BaseTabBar {
           _controller.focusTabColor = Utils.getColor(color),
       'indicatorThickness': (thickness) =>
           _controller.indicatorThickness = Utils.optionalInt(thickness),
+      'dividerThickness': (thickness) =>
+          _controller.dividerThickness = Utils.optionalInt(thickness, min: 0),
+      'dividerPadding': (padding) =>
+          _controller.dividerPadding = Utils.optionalInsets(padding),
       'selectedIndex': (index) =>
           _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
       'onTabSelection': (action) => _controller.onTabSelection =

--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -27,6 +27,8 @@ class TabBarController extends BoxController {
   Color? activeTabBackgroundColor;
   Color? indicatorColor;
   Color? dividerColor;
+  int? dividerThickness;
+  EdgeInsets? dividerPadding;
   Color? focusIndicatorColor; // TV D-pad: focus-state indicator color (fallback blue)
   Color? focusTabColor; // TV D-pad: focus-state tab text color (fallback white)
   int? indicatorThickness;

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -96,6 +96,10 @@ abstract class BaseTabBar extends StatefulWidget
           _controller.focusTabColor = Utils.getColor(color),
       'indicatorThickness': (thickness) =>
           _controller.indicatorThickness = Utils.optionalInt(thickness),
+      'dividerThickness': (thickness) =>
+          _controller.dividerThickness = Utils.optionalInt(thickness, min: 0),
+      'dividerPadding': (padding) =>
+          _controller.dividerPadding = Utils.optionalInsets(padding),
       'selectedIndex': (index) =>
           _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
       'onTabSelection': (action) => _controller.onTabSelection =


### PR DESCRIPTION
## Description

This PR adds configurable divider thickness and padding to the Ensemble TabBar, including the TV TabBar implementation.

## Related Issue

<!-- Add the related issue or PR link here. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

### TabBar divider styling

- Added `dividerThickness` to configure the TabBar divider height, defaulting to `1`.
- Added `dividerPadding` to configure divider insets and vertical spacing.
- Applied divider styling consistently to standard and TV TabBar implementations, including spacing before the TV focus indicator.
- Added schema metadata for the new TabBar properties.

## How to Test

1. From `modules/ensemble`, run `flutter analyze`.
2. From `modules/ensemble`, run `flutter test`.
3. Verify TabBar styling with YAML similar to:

```yaml
TabBar:
  styles:
    dividerColor: 0xFF666666
    dividerThickness: 3
    dividerPadding: [16, 4, 16, 8]
```

4. Confirm that existing TabBar layouts without the new properties retain the default divider behavior.

## Screenshots / Videos

Not included.

## Checklist

- [ ] I have run `flutter analyze` and addressed any new warnings
- [ ] I have run `flutter test` and all tests pass
- [ ] I have tested my changes on the relevant platform(s)
- [x] I have updated documentation where applicable
- [ ] My changes do not introduce new warnings or errors
