### PR TITLE
feat(border): support decimal border widths and radii

### DIFF
--- a/modules/bracket/lib/src/bracket.dart
+++ b/modules/bracket/lib/src/bracket.dart
@@ -1261,7 +1261,7 @@ class _BracketsColumnPageState extends State<BracketsColumnPage> {
                 lineColor: widget.controller.lineColor ?? Colors.black,
                 borderColor: widget.controller.borderColor ?? Colors.black,
                 lineWidth: widget.controller.lineWidth ?? 2.0,
-                borderWidth: widget.controller.borderWidth?.toDouble() ?? 2.0,
+                borderWidth: widget.controller.borderWidth ?? 2.0,
                 connectorLength: widget.controller.connectorLength,
                 columnIndex: widget.columnIndex,
                 prevColumnIndex: layout.toColumnIndex,

--- a/modules/ensemble/assets/schema/ensemble_schema.json
+++ b/modules/ensemble/assets/schema/ensemble_schema.json
@@ -2057,7 +2057,7 @@
                 "$ref": "#/$defs/type-color"
               },
               "dropdownBorderWidth": {
-                "type": "integer",
+                "type": "number",
                 "minimum": 0,
                 "description": "The thickness of the dropdown border"
               },
@@ -3598,12 +3598,19 @@
                   "description": "The fill color for this input fields. This property can be defined in the theme to apply to all Input widgets."
                 },
                 "borderRadius": {
-                  "type": "integer",
-                  "minimum": 0,
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  ],
                   "description": "The border radius for this Input widget. This property can be defined in the theme to apply to all Input widgets."
                 },
                 "borderWidth": {
-                  "type": "integer",
+                  "type": "number",
                   "minimum": 0,
                   "description": "The border width for this Input widget. This property can be defined in the theme to apply to all Input widgets."
                 },
@@ -5573,7 +5580,7 @@
                   "$ref": "#/$defs/type-color"
                 },
                 "borderWidth": {
-                  "type": "integer"
+                  "type": "number"
                 },
                 "itemDisplay": {
                   "type": "string",
@@ -7324,12 +7331,12 @@
               "type": "string"
             },
             {
-              "title": "integer",
-              "type": "integer"
+              "title": "number",
+              "type": "number"
             }
           ],
           "minimum": 0,
-          "description": "Border Radius with CSS-like notation (1 to 4 integers)"
+          "description": "Border Radius with CSS-like notation (1 to 4 numbers)"
         }
       }
     },
@@ -7849,7 +7856,7 @@
               "description": "Border color, starting with '0xFF' for full opacity"
             },
             "borderWidth": {
-              "type": "integer",
+              "type": "number",
               "minimum": 0,
               "description": "The thickness of the border"
             }

--- a/modules/ensemble/assets/schema/theme_schema.json
+++ b/modules/ensemble/assets/schema/theme_schema.json
@@ -199,12 +199,11 @@
           "description": "The fill color for applicable input fields (TextInput, Dropdown, ...)"
         },
         "borderRadius": {
-          "type": "integer",
-          "minimum": 0,
+          "$ref": "#/$defs/BorderRadius",
           "description": "The border radius for applicable Input widgets."
         },
         "borderWidth": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "description": "The border width for applicable Input widgets."
         },
@@ -237,11 +236,10 @@
       "type": "object",
       "properties": {
         "borderRadius": {
-          "type": "integer",
-          "minimum": 0
+          "$ref": "#/$defs/BorderRadius"
         },
         "borderWidth": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "description": "The border thickness of the button"
         },
@@ -275,7 +273,7 @@
           "description": "The border radius for this Input widget. This property can be defined in the theme to apply to all Input widgets."
         },
         "borderWidth": {
-          "type": "integer",
+          "type": "number",
           "description": "The border width for this Input widget. This property can be defined in the theme to apply to all Input widgets.",
           "minimum": 0
         },
@@ -414,11 +412,11 @@
           "type": "string"
         }
       ],
-      "description": "Border Radius with CSS-like notation (1 to 4 integers)",
+      "description": "Border Radius with CSS-like notation (1 to 4 numbers)",
       "uiType": "borderRadius"
     },
     "positiveInteger": {
-      "type": "integer",
+      "type": "number",
       "minimum": 0
     },
     "type-fontWeight": {

--- a/modules/ensemble/integration_test/local/themedApp/Widgets.yaml
+++ b/modules/ensemble/integration_test/local/themedApp/Widgets.yaml
@@ -10,8 +10,8 @@ View:
         - TextInput:
             value: updated style
             styles:
-              borderRadius: 10
-              borderWidth: 2
+              borderRadius: 10.5
+              borderWidth: 2.5
               borderColor: 0xFFCFA17B
               focusedBorderColor: 0xFF86BAA6
 
@@ -19,4 +19,5 @@ View:
             value: box style
             styles:
               variant: box
-              borderRadius: 99
+              borderRadius: 99.5
+              borderWidth: 0.5

--- a/modules/ensemble/integration_test/local/themedApp/theme.ensemble
+++ b/modules/ensemble/integration_test/local/themedApp/theme.ensemble
@@ -1,6 +1,7 @@
 Widgets:
   Input:
     # default variant is Underline
-    borderRadius: 5
+    borderRadius: 5.5
+    borderWidth: 1.5
     borderColor: 0xFF404040
     focusedBorderColor: 0xFF49DEFF

--- a/modules/ensemble/integration_test/local/themedApp_test.dart
+++ b/modules/ensemble/integration_test/local/themedApp_test.dart
@@ -27,10 +27,10 @@ void main() {
       expect(
           (originalText.decoration?.border as UnderlineInputBorder)
               .borderRadius,
-          BorderRadius.circular(5));
+          BorderRadius.circular(5.5));
       expect(originalText.decoration?.border?.borderSide.color,
           const Color(0xFF404040));
-      expect(originalText.decoration?.border?.borderSide.width, 1.0);
+      expect(originalText.decoration?.border?.borderSide.width, 1.5);
       expect(originalText.decoration?.focusedBorder?.borderSide.color,
           const Color(0xFF49DEFF));
 
@@ -48,8 +48,8 @@ void main() {
       expect(
           (updatedStyleText.decoration?.border as UnderlineInputBorder)
               .borderRadius,
-          BorderRadius.circular(10));
-      expect(updatedStyleText.decoration?.border?.borderSide.width, 2.0);
+          BorderRadius.circular(10.5));
+      expect(updatedStyleText.decoration?.border?.borderSide.width, 2.5);
       expect(updatedStyleText.decoration?.border?.borderSide.color,
           const Color(0xFFCFA17B));
       expect(updatedStyleText.decoration?.focusedBorder?.borderSide.color,
@@ -63,8 +63,8 @@ void main() {
       expect(boxStyleText.decoration?.border is OutlineInputBorder, true);
       expect(
           (boxStyleText.decoration?.border as OutlineInputBorder).borderRadius,
-          BorderRadius.circular(99));
-      expect(boxStyleText.decoration?.border?.borderSide.width, 1.0);
+          BorderRadius.circular(99.5));
+      expect(boxStyleText.decoration?.border?.borderSide.width, 0.5);
     });
   });
 }

--- a/modules/ensemble/lib/controller/controller_mixins.dart
+++ b/modules/ensemble/lib/controller/controller_mixins.dart
@@ -16,7 +16,7 @@ mixin HasPassThrough on EnsembleWidgetController {
 mixin HasBorderController on EnsembleWidgetController {
   LinearGradient? borderGradient;
   Color? borderColor;
-  int? borderWidth;
+  double? borderWidth;
   EBorderRadius? borderRadius;
   BorderStyleComposite? borderStyle;
 
@@ -24,7 +24,7 @@ mixin HasBorderController on EnsembleWidgetController {
         'borderGradient': (value) =>
             borderGradient = Utils.getBackgroundGradient(value),
         'borderColor': (value) => borderColor = Utils.getColor(value),
-        'borderWidth': (value) => borderWidth = Utils.optionalInt(value),
+        'borderWidth': (value) => borderWidth = Utils.optionalDouble(value),
         'borderRadius': (value) => borderRadius = Utils.getBorderRadius(value),
         'borderStyle': (value) =>
             borderStyle = BorderStyleComposite.from(this, value),

--- a/modules/ensemble/lib/framework/model.dart
+++ b/modules/ensemble/lib/framework/model.dart
@@ -97,37 +97,37 @@ class BackgroundImage {
 
 class EBorderRadius {
   EBorderRadius._(
-      int _topLeft, int _topRight, int _bottomRight, int _bottomLeft)
+      double _topLeft, double _topRight, double _bottomRight, double _bottomLeft)
       : topLeft =
-            _topLeft == 0 ? Radius.zero : Radius.circular(_topLeft.toDouble()),
+            _topLeft == 0 ? Radius.zero : Radius.circular(_topLeft),
         topRight = _topRight == 0
             ? Radius.zero
-            : Radius.circular(_topRight.toDouble()),
+            : Radius.circular(_topRight),
         bottomRight = _bottomRight == 0
             ? Radius.zero
-            : Radius.circular(_bottomRight.toDouble()),
+            : Radius.circular(_bottomRight),
         bottomLeft = _bottomLeft == 0
             ? Radius.zero
-            : Radius.circular(_bottomLeft.toDouble());
+            : Radius.circular(_bottomLeft);
 
   Radius topLeft, topRight, bottomRight, bottomLeft;
 
-  factory EBorderRadius.all(int val) {
+  factory EBorderRadius.all(double val) {
     return EBorderRadius._(val, val, val, val);
   }
   // first value: top-left & bottom-right
   // second value: top-right & bottom-left
-  factory EBorderRadius.two(int first, int second) {
+  factory EBorderRadius.two(double first, double second) {
     return EBorderRadius._(first, second, first, second);
   }
   // first value: top-left
   // second value: top-right & bottom-left
   // third value: bottom-right
-  factory EBorderRadius.three(int first, int second, int third) {
+  factory EBorderRadius.three(double first, double second, double third) {
     return EBorderRadius._(first, second, third, second);
   }
   factory EBorderRadius.only(
-      int topLeft, int topRight, int bottomRight, int bottomLeft) {
+      double topLeft, double topRight, double bottomRight, double bottomLeft) {
     return EBorderRadius._(topLeft, topRight, bottomRight, bottomLeft);
   }
 

--- a/modules/ensemble/lib/framework/theme/theme_loader.dart
+++ b/modules/ensemble/lib/framework/theme/theme_loader.dart
@@ -11,7 +11,7 @@ import 'package:yaml/yaml.dart';
 mixin ThemeLoader {
   final EdgeInsets _buttonPadding =
   const EdgeInsets.only(left: 15, top: 5, right: 15, bottom: 5);
-  final int _buttonBorderRadius = 3;
+  final double _buttonBorderRadius = 3;
   final Color _buttonBorderOutlineColor = Colors.black12;
   bool hasLegacyCustomAppTheme(YamlMap? overrides) {
     return overrides?['App'] != null
@@ -389,12 +389,12 @@ mixin ThemeLoader {
         borderRadius: input['borderRadius'] == 0
             ? BorderRadius.zero
             : Utils.getBorderRadius(input['borderRadius'])?.getValue() ??
-                BorderRadius.circular(_buttonBorderRadius.toDouble()),
+                BorderRadius.circular(_buttonBorderRadius),
         side: borderColor == null
             ? BorderSide.none
             : BorderSide(
             color: borderColor,
-            width: Utils.optionalDouble(input['borderWidth']) ?? 1));
+            width: Utils.getDouble(input['borderWidth'], fallback: 1)));
 
     return getButtonStyle(
         isOutline: isOutline,

--- a/modules/ensemble/lib/framework/theme/theme_loader.dart
+++ b/modules/ensemble/lib/framework/theme/theme_loader.dart
@@ -286,7 +286,7 @@ mixin ThemeLoader {
     BorderRadius borderRadius =
         Utils.getBorderRadius(input['borderRadius'])?.getValue() ??
             getInputDefaultBorderRadius(variant);
-    int borderWidth = Utils.optionalInt(input['borderWidth']) ?? 1;
+    double borderWidth = Utils.optionalDouble(input['borderWidth']) ?? 1;
 
     Color? borderColor = Utils.getColor(input['borderColor']);
     Color? disabledBorderColor = Utils.getColor(input['disabledBorderColor']);
@@ -305,7 +305,7 @@ mixin ThemeLoader {
                   (colorScheme.brightness == Brightness.light
                       ? Colors.black54
                       : Colors.white70),
-              width: borderWidth.toDouble()));
+              width: borderWidth));
 
       return baseInputDecoration.copyWith(
         contentPadding: contentPadding ??
@@ -341,7 +341,7 @@ mixin ThemeLoader {
                   (colorScheme.brightness == Brightness.light
                       ? Colors.black87
                       : Colors.white70),
-              width: borderWidth.toDouble()));
+              width: borderWidth));
       return baseInputDecoration.copyWith(
         contentPadding: contentPadding ??
             const EdgeInsets.symmetric(vertical: 15, horizontal: 3),
@@ -386,15 +386,13 @@ mixin ThemeLoader {
     isOutline ? null : Utils.getColor(input['backgroundColor']);
 
     RoundedRectangleBorder border = RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(
-            Utils.getInt(input['borderRadius'], fallback: _buttonBorderRadius)
-                .toDouble()),
+        borderRadius: Utils.getBorderRadius(input['borderRadius'])?.getValue() ??
+            BorderRadius.circular(_buttonBorderRadius.toDouble()),
         side: borderColor == null
             ? BorderSide.none
             : BorderSide(
             color: borderColor,
-            width: Utils.getInt(input['borderWidth'], fallback: 1)
-                .toDouble()));
+            width: Utils.optionalDouble(input['borderWidth']) ?? 1));
 
     return getButtonStyle(
         isOutline: isOutline,
@@ -407,20 +405,20 @@ mixin ThemeLoader {
   InputBorder? getInputBorder(
       {InputVariant? variant,
         Color? borderColor,
-        required int borderWidth,
+        required double borderWidth,
         required BorderRadius borderRadius}) {
     if (borderColor != null) {
       if (variant == InputVariant.box) {
         return OutlineInputBorder(
             borderRadius: borderRadius,
             borderSide:
-            BorderSide(color: borderColor, width: borderWidth.toDouble()));
+            BorderSide(color: borderColor, width: borderWidth));
       }
       // default is underline
       return UnderlineInputBorder(
           borderRadius: borderRadius,
           borderSide:
-          BorderSide(color: borderColor, width: borderWidth.toDouble()));
+          BorderSide(color: borderColor, width: borderWidth));
     }
     return null;
   }
@@ -463,21 +461,20 @@ mixin ThemeLoader {
     Color? fillColor = Utils.getColor(input?["fillColor"]);
     Color? activeColor = Utils.getColor(input?["activeColor"]);
     Color? checkColor = Utils.getColor(input?["checkColor"]);
-    int borderWidth = Utils.optionalInt(input?['borderWidth'], min: 0) ?? 2;
+    double borderWidth = Utils.optionalDouble(input?['borderWidth'], min: 0) ?? 2;
 
     var checkboxTheme = CheckboxThemeData(
       side: WidgetStateBorderSide.resolveWith((states) {
         if (states.contains(WidgetState.disabled)) {
           return BorderSide(
-              width: borderWidth.toDouble(), color: DesignSystem.disableColor);
+              width: borderWidth, color: DesignSystem.disableColor);
         }
         if (states.contains(WidgetState.error)) {
           return BorderSide(
-              width: borderWidth.toDouble(),
-              color: DesignSystem.inputErrorColor);
+              width: borderWidth, color: DesignSystem.inputErrorColor);
         }
         if (!states.contains(WidgetState.selected)) {
-          return BorderSide(width: borderWidth.toDouble(), color: borderColor);
+          return BorderSide(width: borderWidth, color: borderColor);
         }
         // use default
         return null;

--- a/modules/ensemble/lib/framework/theme/theme_loader.dart
+++ b/modules/ensemble/lib/framework/theme/theme_loader.dart
@@ -386,8 +386,10 @@ mixin ThemeLoader {
     isOutline ? null : Utils.getColor(input['backgroundColor']);
 
     RoundedRectangleBorder border = RoundedRectangleBorder(
-        borderRadius: Utils.getBorderRadius(input['borderRadius'])?.getValue() ??
-            BorderRadius.circular(_buttonBorderRadius.toDouble()),
+        borderRadius: input['borderRadius'] == 0
+            ? BorderRadius.zero
+            : Utils.getBorderRadius(input['borderRadius'])?.getValue() ??
+                BorderRadius.circular(_buttonBorderRadius.toDouble()),
         side: borderColor == null
             ? BorderSide.none
             : BorderSide(
@@ -471,7 +473,8 @@ mixin ThemeLoader {
         }
         if (states.contains(WidgetState.error)) {
           return BorderSide(
-              width: borderWidth, color: DesignSystem.inputErrorColor);
+              width: borderWidth,
+              color: DesignSystem.inputErrorColor);
         }
         if (!states.contains(WidgetState.selected)) {
           return BorderSide(width: borderWidth, color: borderColor);

--- a/modules/ensemble/lib/framework/view/page.dart
+++ b/modules/ensemble/lib/framework/view/page.dart
@@ -972,12 +972,12 @@ class PageState extends State<Page>
       // show a divider between the NavigationRail and the content
       Color? borderColor =
           Utils.getColor(widget._pageModel.menu!.runtimeStyles?['borderColor']);
-      int? borderWidth = Utils.optionalInt(
+      double? borderWidth = Utils.optionalDouble(
           widget._pageModel.menu!.runtimeStyles?['borderWidth']);
       if (borderColor != null || borderWidth != null) {
         content.add(VerticalDivider(
-            thickness: (borderWidth ?? 1).toDouble(),
-            width: (borderWidth ?? 1).toDouble(),
+            thickness: borderWidth ?? 1,
+            width: borderWidth ?? 1,
             color: borderColor));
       }
 

--- a/modules/ensemble/lib/framework/view/page_group.dart
+++ b/modules/ensemble/lib/framework/view/page_group.dart
@@ -513,11 +513,12 @@ class PageGroupState extends State<PageGroup>
 
   Widget? _buildSidebarSeparator(Menu menu) {
     Color? borderColor = Utils.getColor(menu.runtimeStyles?['borderColor']);
-    int? borderWidth = Utils.optionalInt(menu.runtimeStyles?['borderWidth']);
+    double? borderWidth =
+        Utils.optionalDouble(menu.runtimeStyles?['borderWidth']);
     if (borderColor != null || borderWidth != null) {
       return VerticalDivider(
-          thickness: (borderWidth ?? 1).toDouble(),
-          width: (borderWidth ?? 1).toDouble(),
+          thickness: borderWidth ?? 1,
+          width: borderWidth ?? 1,
           color: borderColor);
     }
     return null;

--- a/modules/ensemble/lib/layout/data_grid.dart
+++ b/modules/ensemble/lib/layout/data_grid.dart
@@ -311,7 +311,7 @@ class DataGridState extends EWidgetState<DataGrid>
       dividerThickness: widget.controller.dividerThickness,
       border: TableBorder.all(
         color: widget.controller.borderColor ?? Colors.black,
-        width: widget.controller.borderWidth?.toDouble() ?? 1.0,
+        width: widget.controller.borderWidth ?? 1.0,
         borderRadius:
             widget.controller.borderRadius?.getValue() ?? BorderRadius.zero,
       ),

--- a/modules/ensemble/lib/util/utils.dart
+++ b/modules/ensemble/lib/util/utils.dart
@@ -863,39 +863,39 @@ class Utils {
   }
 
   static BorderRadiusGeometry? getBorderRadiusGeometry(dynamic value) {
-  if (value is int) {
+  if (value is num) {
     // Optimize: Ignore zero border radius as it causes unnecessary clipping
     if (value != 0) {
       return BorderRadius.all(Radius.circular(value.toDouble()));
     }
   } else if (value is String) {
-    // Convert the string to a list of integers
-    List<int> numbers = stringToIntegers(value, min: 0);
+    // Convert the string to a list of non-negative numbers
+    List<double> numbers = stringToDoubles(value, min: 0);
 
     // Handle 1 to 4 values for BorderRadius
     switch (numbers.length) {
       case 1:
-        return BorderRadius.all(Radius.circular(numbers[0].toDouble()));
+        return BorderRadius.all(Radius.circular(numbers[0]));
       case 2:
         return BorderRadius.vertical(
-          top: Radius.circular(numbers[0].toDouble()),
-          bottom: Radius.circular(numbers[1].toDouble()),
+          top: Radius.circular(numbers[0]),
+          bottom: Radius.circular(numbers[1]),
         );
       case 3:
         return BorderRadius.only(
-          topLeft: Radius.circular(numbers[0].toDouble()),
-          topRight: Radius.circular(numbers[1].toDouble()),
-          bottomLeft: Radius.circular(numbers[2].toDouble()),
+          topLeft: Radius.circular(numbers[0]),
+          topRight: Radius.circular(numbers[1]),
+          bottomLeft: Radius.circular(numbers[2]),
         );
       case 4:
         return BorderRadius.only(
-          topLeft: Radius.circular(numbers[0].toDouble()),
-          topRight: Radius.circular(numbers[1].toDouble()),
-          bottomRight: Radius.circular(numbers[2].toDouble()),
-          bottomLeft: Radius.circular(numbers[3].toDouble()),
+          topLeft: Radius.circular(numbers[0]),
+          topRight: Radius.circular(numbers[1]),
+          bottomRight: Radius.circular(numbers[2]),
+          bottomLeft: Radius.circular(numbers[3]),
         );
       default:
-        throw LanguageError('borderRadius requires 1 to 4 integers');
+        throw LanguageError('borderRadius requires 1 to 4 numbers');
     }
   }
 
@@ -975,13 +975,13 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
   }
 
   static EBorderRadius? getBorderRadius(dynamic value) {
-    if (value is int) {
+    if (value is num) {
       // optimize, ignore zero border radius as that causes extra processing for clipping
       if (value != 0) {
-        return EBorderRadius.all(value);
+        return EBorderRadius.all(value.toDouble());
       }
     } else if (value is String) {
-      List<int> numbers = stringToIntegers(value, min: 0);
+      List<double> numbers = stringToDoubles(value, min: 0);
       if (numbers.length == 1) {
         return EBorderRadius.all(numbers[0]);
       } else if (numbers.length == 2) {
@@ -992,7 +992,7 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
         return EBorderRadius.only(
             numbers[0], numbers[1], numbers[2], numbers[3]);
       } else {
-        throw LanguageError('borderRadius requires 1 to 4 integers');
+        throw LanguageError('borderRadius requires 1 to 4 numbers');
       }
     }
     return null;
@@ -1030,6 +1030,22 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
     List<String> values = value.split(' ');
     for (var val in values) {
       int? number = int.tryParse(val);
+      if (number != null &&
+          (min == null || number >= min) &&
+          (max == null || number <= max)) {
+        rtn.add(number);
+      }
+    }
+    return rtn;
+  }
+
+  /// Parse a whitespace-separated string into non-negative doubles.
+  static List<double> stringToDoubles(String value,
+      {double? min, double? max}) {
+    List<double> rtn = [];
+
+    for (var val in value.split(RegExp(r'\s+'))) {
+      double? number = double.tryParse(val);
       if (number != null &&
           (min == null || number >= min) &&
           (max == null || number <= max)) {

--- a/modules/ensemble/lib/util/utils.dart
+++ b/modules/ensemble/lib/util/utils.dart
@@ -612,9 +612,8 @@ class Utils {
             ? Border.all(
                 color: tooltip.styles?.borderColor ??
                     ThemeManager().getBorderColor(context),
-                width: (tooltip.styles?.borderWidth ??
-                        ThemeManager().getBorderThickness(context))
-                    .toDouble(),
+                width: tooltip.styles?.borderWidth ??
+                    ThemeManager().getBorderThickness(context),
               )
             : null,
       ),
@@ -1039,14 +1038,17 @@ static BoxDecoration? getBoxDecoration(dynamic style) {
     return rtn;
   }
 
-  /// Parse a whitespace-separated string into non-negative doubles.
+  /// parse a string and return a list of doubles
   static List<double> stringToDoubles(String value,
       {double? min, double? max}) {
     List<double> rtn = [];
 
     for (var val in value.split(RegExp(r'\s+'))) {
       double? number = double.tryParse(val);
+      // isFinite: double.tryParse accepts "Infinity"/"1e400", which would reach
+      // Radius.circular and blow up in painting.
       if (number != null &&
+          number.isFinite &&
           (min == null || number >= min) &&
           (max == null || number <= max)) {
         rtn.add(number);

--- a/modules/ensemble/lib/widget/button.dart
+++ b/modules/ensemble/lib/widget/button.dart
@@ -224,7 +224,7 @@ class ButtonState extends EWidgetState<Button> {
       } else {
         borderSide = BorderSide(
             color: widget._controller.borderColor ?? defaultShape.side.color,
-            width: widget._controller.borderWidth?.toDouble() ??
+            width: widget._controller.borderWidth ??
                 defaultShape.side.width);
       }
 

--- a/modules/ensemble/lib/widget/checkbox.dart
+++ b/modules/ensemble/lib/widget/checkbox.dart
@@ -148,8 +148,9 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
 
   Widget buildCheckbox(BuildContext context) {
     var theme = Theme.of(context);
-    double borderWidth =
-        widget._controller.borderWidth ?? theme.checkboxTheme.side?.width ?? 2;
+    double borderWidth = widget._controller.borderWidth ??
+        theme.checkboxTheme.side?.width ??
+        2;
     Color borderColor = widget._controller.borderColor ??
         theme.checkboxTheme.side?.color ??
         ThemeManager().getBorderColor(context);
@@ -160,7 +161,8 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
           if (!states.contains(WidgetState.selected) &&
               !states.contains(WidgetState.disabled) &&
               !states.contains(WidgetState.error)) {
-            return BorderSide(width: borderWidth, color: borderColor);
+            return BorderSide(
+                width: borderWidth, color: borderColor);
           }
           // fallback to theme, which fallback to default
           return null;
@@ -169,7 +171,8 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
             ? null
             : RoundedRectangleBorder(
                 borderRadius: widget._controller.borderRadius!.getValue(),
-                side: BorderSide(width: borderWidth, color: borderColor)),
+                side: BorderSide(
+                    width: borderWidth, color: borderColor)),
         activeColor: activeColor,
         checkColor: widget._controller.checkColor,
         fillColor:

--- a/modules/ensemble/lib/widget/checkbox.dart
+++ b/modules/ensemble/lib/widget/checkbox.dart
@@ -148,9 +148,8 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
 
   Widget buildCheckbox(BuildContext context) {
     var theme = Theme.of(context);
-    int borderWidth = widget._controller.borderWidth ??
-        theme.checkboxTheme.side?.width.toInt() ??
-        2;
+    double borderWidth =
+        widget._controller.borderWidth ?? theme.checkboxTheme.side?.width ?? 2;
     Color borderColor = widget._controller.borderColor ??
         theme.checkboxTheme.side?.color ??
         ThemeManager().getBorderColor(context);
@@ -161,8 +160,7 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
           if (!states.contains(WidgetState.selected) &&
               !states.contains(WidgetState.disabled) &&
               !states.contains(WidgetState.error)) {
-            return BorderSide(
-                width: borderWidth.toDouble(), color: borderColor);
+            return BorderSide(width: borderWidth, color: borderColor);
           }
           // fallback to theme, which fallback to default
           return null;
@@ -171,8 +169,7 @@ class CheckboxState extends FormFieldWidgetState<EnsembleCheckbox> {
             ? null
             : RoundedRectangleBorder(
                 borderRadius: widget._controller.borderRadius!.getValue(),
-                side: BorderSide(
-                    width: borderWidth.toDouble(), color: borderColor)),
+                side: BorderSide(width: borderWidth, color: borderColor)),
         activeColor: activeColor,
         checkColor: widget._controller.checkColor,
         fillColor:

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -66,7 +66,7 @@ class TVFocusStylingResolver {
     return tvOptions.focusBorderWidth ??
         tvFocusTheme.focusBorderWidth ??
         externalProvider?.focusBorderWidth ??
-        boxController.borderWidth?.toDouble() ??
+        boxController.borderWidth ??
         TVFocusTheme.defaultBorderWidth;
   }
 
@@ -96,14 +96,13 @@ BoxBorder? _resolveBoxBorder({
   required bool hasBorder,
   required LinearGradient? borderGradient,
   required Color? borderColor,
-  required int? borderWidth,
+  required double? borderWidth,
   required BorderStyleComposite? borderStyle,
   required BuildContext context,
 }) {
   if (!hasBorder) return null;
 
-  final width =
-      borderWidth?.toDouble() ?? ThemeManager().getBorderThickness(context);
+  final width = borderWidth ?? ThemeManager().getBorderThickness(context);
 
   if (borderGradient != null) {
     return GradientBoxBorder(gradient: borderGradient, width: width);

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -102,7 +102,8 @@ BoxBorder? _resolveBoxBorder({
 }) {
   if (!hasBorder) return null;
 
-  final width = borderWidth ?? ThemeManager().getBorderThickness(context);
+  final width =
+      borderWidth ?? ThemeManager().getBorderThickness(context);
 
   if (borderGradient != null) {
     return GradientBoxBorder(gradient: borderGradient, width: width);

--- a/modules/ensemble/lib/widget/helpers/controllers.dart
+++ b/modules/ensemble/lib/widget/helpers/controllers.dart
@@ -943,7 +943,7 @@ class BoxController extends WidgetController {
   LinearGradient? backgroundGradient;
 
   Color? borderColor;
-  int? borderWidth;
+  double? borderWidth;
   EBorderRadius? borderRadius;
   LinearGradient? borderGradient;
   BorderStyleComposite? borderStyle;
@@ -989,7 +989,7 @@ class BoxController extends WidgetController {
           borderGradient = Utils.getBackgroundGradient(value),
 
       'borderColor': (value) => borderColor = Utils.getColor(value),
-      'borderWidth': (value) => borderWidth = Utils.optionalInt(value),
+      'borderWidth': (value) => borderWidth = Utils.optionalDouble(value),
       'borderRadius': (value) => borderRadius = Utils.getBorderRadius(value),
       'borderStyle': (value) =>
           borderStyle = BorderStyleComposite.from(this, value),

--- a/modules/ensemble/lib/widget/helpers/form_helper.dart
+++ b/modules/ensemble/lib/widget/helpers/form_helper.dart
@@ -40,7 +40,7 @@ class FormFieldController extends WidgetController {
   Color? fillColor;
 
   EBorderRadius? borderRadius;
-  int? borderWidth;
+  double? borderWidth;
   Color? borderColor;
 
   Color? enabledBorderColor;
@@ -77,7 +77,7 @@ class FormFieldController extends WidgetController {
       'filled': (value) => filled = Utils.optionalBool(value),
       'fillColor': (value) => fillColor = Utils.getColor(value),
       'borderRadius': (value) => borderRadius = Utils.getBorderRadius(value),
-      'borderWidth': (value) => borderWidth = Utils.optionalInt(value, min: 0),
+      'borderWidth': (value) => borderWidth = Utils.optionalDouble(value, min: 0),
       'borderColor': (color) => borderColor = Utils.getColor(color),
       'enabledBorderColor': (color) =>
           enabledBorderColor = Utils.getColor(color),
@@ -169,12 +169,12 @@ abstract class FormFieldWidgetState<W extends HasController>
       InputVariant? variant = myController.variant ?? _themeVariant;
 
       // resolve borderWidth
-      int? _themeBorderWidth = themeDecoration.border?.borderSide.width.toInt();
+      double? _themeBorderWidth = themeDecoration.border?.borderSide.width;
       if (myController.borderWidth != null &&
           myController.borderWidth != _themeBorderWidth) {
         redrawAllBorders = true;
       }
-      int borderWidth = myController.borderWidth ?? _themeBorderWidth ?? 1;
+      double borderWidth = myController.borderWidth ?? _themeBorderWidth ?? 1;
 
       // resolve borderRadius
       BorderRadius? _themeBorderRadius =

--- a/modules/ensemble/lib/widget/helpers/tooltip_composite.dart
+++ b/modules/ensemble/lib/widget/helpers/tooltip_composite.dart
@@ -43,7 +43,7 @@ class TooltipStyleComposite extends WidgetCompositeProperty {
     padding = Utils.optionalInsets(inputs['padding']);
     margin = Utils.optionalInsets(inputs['margin']);
     borderColor = Utils.getColor(inputs['borderColor']);
-    borderWidth = Utils.optionalInt(inputs['borderWidth']);
+    borderWidth = Utils.optionalDouble(inputs['borderWidth']);
   }
 
   TextStyle? textStyle;
@@ -57,7 +57,7 @@ class TooltipStyleComposite extends WidgetCompositeProperty {
   EdgeInsets? padding;
   EdgeInsets? margin;
   Color? borderColor;
-  int? borderWidth;
+  double? borderWidth;
 
   @override
   Map<String, Function> setters() {
@@ -73,7 +73,7 @@ class TooltipStyleComposite extends WidgetCompositeProperty {
       'padding': (value) => padding = Utils.optionalInsets(value),
       'margin': (value) => margin = Utils.optionalInsets(value),
       'borderColor': (value) => borderColor = Utils.getColor(value),
-      'borderWidth': (value) => borderWidth = Utils.optionalInt(value),
+      'borderWidth': (value) => borderWidth = Utils.optionalDouble(value),
     };
   }
 

--- a/modules/ensemble/lib/widget/input/dropdown.dart
+++ b/modules/ensemble/lib/widget/input/dropdown.dart
@@ -771,7 +771,7 @@ class SelectOneState extends FormFieldWidgetState<SelectOne>
       return getCustomBorder(
         originalBorder: inputDecoration.enabledBorder ?? baseBorder,
         borderColor: widget._controller.borderColor,
-        borderWidth: widget._controller.borderWidth?.toDouble(),
+        borderWidth: widget._controller.borderWidth,
         borderRadius: widget._controller.borderRadius?.getValue(),
       );
     }
@@ -787,7 +787,7 @@ class SelectOneState extends FormFieldWidgetState<SelectOne>
     return getCustomBorder(
       originalBorder: inputDecoration.focusedBorder ?? baseBorder,
       borderColor: widget._controller.focusedBorderColor,
-      borderWidth: widget._controller.borderWidth?.toDouble(),
+      borderWidth: widget._controller.borderWidth,
       borderRadius: widget._controller.borderRadius?.getValue(),
     );
   }

--- a/modules/ensemble/lib/widget/input/dropdown.dart
+++ b/modules/ensemble/lib/widget/input/dropdown.dart
@@ -103,7 +103,7 @@ abstract class SelectOne extends StatefulWidget
       'dropdownBorderColor': (value) =>
           _controller.dropdownBorderColor = Utils.getColor(value),
       'dropdownBorderWidth': (value) =>
-          _controller.dropdownBorderWidth = Utils.optionalInt(value),
+          _controller.dropdownBorderWidth = Utils.optionalDouble(value),
       'dropdownMaxHeight': (value) =>
           _controller.dropdownMaxHeight = Utils.optionalInt(value, min: 0),
       'createNewItem': (value) => _setCreateNewItem(value),
@@ -263,7 +263,7 @@ class SelectOneController extends FormFieldController with HasTextPlaceholder {
   int? dropdownOffsetY;
   Color? dropdownBackgroundColor;
   EBorderRadius? dropdownBorderRadius;
-  int? dropdownBorderWidth;
+  double? dropdownBorderWidth;
   Color? dropdownBorderColor;
   int? dropdownMaxHeight;
   TextStyleComposite? _textStyle;
@@ -411,8 +411,7 @@ class SelectOneState extends FormFieldWidgetState<SelectOne>
                     ? Border.all(
                         color: widget._controller.dropdownBorderColor ??
                             ThemeManager().getBorderColor(context),
-                        width: widget._controller.dropdownBorderWidth
-                                ?.toDouble() ??
+                        width: widget._controller.dropdownBorderWidth ??
                             ThemeManager().getBorderThickness(context),
                       )
                     : null),

--- a/modules/ensemble/lib/widget/input/form_time.dart
+++ b/modules/ensemble/lib/widget/input/form_time.dart
@@ -227,7 +227,7 @@ class AndroidTimePickerStyle {
 }
 
 class _BorderStyle {
-  final int borderWidth;
+  final double borderWidth;
   final BorderRadius borderRadius;
   final Color borderColor;
 
@@ -328,8 +328,8 @@ class TimeState extends FormFieldWidgetState<Time> {
   _BorderStyle _resolveBorderStyle(BuildContext context, String? errorText) {
     final themeDecoration = Theme.of(context).inputDecorationTheme;
 
-    final borderWidth = widget._controller.borderWidth ??
-        (themeDecoration.border?.borderSide.width.toInt() ?? 1);
+    final double borderWidth = widget._controller.borderWidth ??
+        (themeDecoration.border?.borderSide.width ?? 1);
 
     BorderRadius? _themeBorderRadius;
     if (themeDecoration.border is OutlineInputBorder) {

--- a/modules/ensemble/lib/widget/input/form_time.dart
+++ b/modules/ensemble/lib/widget/input/form_time.dart
@@ -612,7 +612,7 @@ class TimeState extends FormFieldWidgetState<Time> {
           borderRadius: borderStyle.borderRadius,
           border: Border.all(
             color: borderStyle.borderColor,
-            width: borderStyle.borderWidth.toDouble(),
+            width: borderStyle.borderWidth,
           ),
         ),
         padding: widget._controller.contentPadding ??

--- a/modules/ensemble/lib/widget/input/form_time.dart
+++ b/modules/ensemble/lib/widget/input/form_time.dart
@@ -328,7 +328,7 @@ class TimeState extends FormFieldWidgetState<Time> {
   _BorderStyle _resolveBorderStyle(BuildContext context, String? errorText) {
     final themeDecoration = Theme.of(context).inputDecorationTheme;
 
-    final double borderWidth = widget._controller.borderWidth ??
+    final borderWidth = widget._controller.borderWidth ??
         (themeDecoration.border?.borderSide.width ?? 1);
 
     BorderRadius? _themeBorderRadius;

--- a/modules/ensemble/lib/widget/shape.dart
+++ b/modules/ensemble/lib/widget/shape.dart
@@ -151,10 +151,10 @@ class InternalShape extends StatelessWidget {
       : borderGradient != null
           ? GradientBoxBorder(
               gradient: borderGradient!,
-              width: borderWidth?.toDouble() ??
+              width: borderWidth ??
                   ThemeManager().getBorderThickness(context))
           : Border.all(
               color: borderColor ?? ThemeManager().getBorderColor(context),
-              width: borderWidth?.toDouble() ??
+              width: borderWidth ??
                   ThemeManager().getBorderThickness(context));
 }

--- a/modules/ensemble/lib/widget/shape.dart
+++ b/modules/ensemble/lib/widget/shape.dart
@@ -85,7 +85,7 @@ class InternalShape extends StatelessWidget {
 
   final LinearGradient? borderGradient;
   final Color? borderColor;
-  final int? borderWidth;
+  final double? borderWidth;
   final BorderRadius? borderRadius;
 
   @override

--- a/modules/ensemble/test/utils_test.dart
+++ b/modules/ensemble/test/utils_test.dart
@@ -9,6 +9,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('border radius parsing', () {
+    test('preserves decimal shorthand', () {
+      expect(Utils.stringToDoubles('1.5 2.5 3.5', min: 0),
+          [1.5, 2.5, 3.5]);
+
+      final borderRadius = Utils.getBorderRadius('1.5 2.5 3.5')!.getValue();
+
+      expect(borderRadius.topLeft.x, 1.5);
+      expect(borderRadius.topRight.x, 2.5);
+      expect(borderRadius.bottomRight.x, 3.5);
+      expect(borderRadius.bottomLeft.x, 2.5);
+    });
+
+  });
+
   test('get double', () {
     dynamic value = 2.3;
     expect(Utils.getDouble(value, fallback: 0), value);

--- a/modules/ensemble/test/widget/button_test.dart
+++ b/modules/ensemble/test/widget/button_test.dart
@@ -40,4 +40,17 @@ void main() {
     expect((children[0] as Icon).icon, Icons.star);
     expect((children[1] as Text).data, 'hello world');
   });
+
+  testWidgets('button preserves decimal border styles', (tester) async {
+    final widget = Button()
+      ..setProperty('label', 'decimal border')
+      ..setProperty('borderWidth', 1.5)
+      ..setProperty('borderRadius', 2.5);
+
+    await tester.pumpWidget(TestUtils.wrapTestWidget(widget));
+
+    expect(widget.controller.borderWidth, 1.5);
+    expect(widget.controller.borderRadius?.getValue(),
+        BorderRadius.circular(2.5));
+  });
 }

--- a/modules/ensemble/test/widget/checkbox_switch_test.dart
+++ b/modules/ensemble/test/widget/checkbox_switch_test.dart
@@ -33,6 +33,23 @@ void main() {
     expect(checkbox.value, true);
   });
 
+  testWidgets('checkbox preserves decimal border styles', (tester) async {
+    final widget = EnsembleCheckbox()
+      ..setProperty('borderWidth', 1.5)
+      ..setProperty('borderRadius', 2.5);
+
+    await tester.pumpWidget(TestUtils.wrapTestWidget(widget));
+
+    final checkbox = tester.firstWidget<Checkbox>(find.byType(Checkbox));
+    final side = WidgetStateProperty.resolveAs<BorderSide?>(
+      checkbox.side,
+      const <WidgetState>{},
+    );
+    expect(side?.width, 1.5);
+    expect((checkbox.shape! as RoundedRectangleBorder).borderRadius,
+        BorderRadius.circular(2.5));
+  });
+
   testWidgets("switch", (tester) async {
     EnsembleSwitch widget = EnsembleSwitch();
     widget.setProperty('value', true);

--- a/modules/ensemble/test/widget/dropdown_test.dart
+++ b/modules/ensemble/test/widget/dropdown_test.dart
@@ -1,4 +1,6 @@
+import 'package:ensemble_dropdown/ensemble_dropdown.dart';
 import 'package:ensemble/widget/input/dropdown.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';
@@ -22,5 +24,19 @@ void main() {
 
     // verified value is selected after dropdown has closed
     expect(find.text('two'), findsOneWidget);
+  });
+
+  testWidgets('dropdown popup renders a decimal border width', (tester) async {
+    final widget = Dropdown()
+      ..setProperty('items', ['one'])
+      ..setProperty('dropdownBorderColor', 0xFF102030)
+      ..setProperty('dropdownBorderWidth', 1.5);
+
+    await tester.pumpWidget(TestUtils.wrapTestWidget(widget));
+
+    final dropdown = tester.firstWidget<EnsembleDropdown<dynamic>>(
+        find.byType(EnsembleDropdown<dynamic>));
+    final decoration = dropdown.dropdownStyleData.decoration as BoxDecoration;
+    expect((decoration.border as Border).top.width, 1.5);
   });
 }


### PR DESCRIPTION
## Description

This PR adds support for decimal values in border widths and border radii across Ensemble widgets and themes.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

- Changed border width handling from `int` to `double`.
- Added decimal border width support for containers, forms, checkboxes, shapes, and themes.
- Added decimal border radius support.
- Added parsing for decimal border radius values from YAML strings.
- Added the `stringToDoubles` utility with minimum and maximum value validation.
- Preserved existing integer border values and behavior.

## How to Test

1. Run `flutter analyze` from `modules/ensemble`.
2. Run `flutter test` from `modules/ensemble`.
3. Test decimal border widths:

```yaml
Column:
  styles:
    borderWidth: 1.5
    borderColor: 0xff276ef1