### PR TITLE
Fix/id focus state

### DIFF
--- a/modules/ensemble/lib/framework/widget/view_util.dart
+++ b/modules/ensemble/lib/framework/widget/view_util.dart
@@ -379,7 +379,12 @@ class ViewUtil {
     }
 
     // Preserve ID-bound TV focus styles while a focused widget is rebuilt.
-    if (previousContext is HasController && w is HasController) {
+    // Only carry focus from a widget registered in THIS scope — an ancestor
+    // scope hit with the same id is a collision, not the widget being rebuilt.
+    if (widgetId != null &&
+        scopeNode.scope.dataContext.contextMap.containsKey(widgetId) &&
+        previousContext is HasController &&
+        w is HasController) {
       final previousController = previousContext.controller;
       final nextController = w.controller;
       if (previousController is WidgetController &&

--- a/modules/ensemble/lib/framework/widget/view_util.dart
+++ b/modules/ensemble/lib/framework/widget/view_util.dart
@@ -348,6 +348,21 @@ class ViewUtil {
         child: customWidget);
   }
 
+  /// Returns the [WidgetController] behind [value] (a controller or a widget
+  /// that owns one via [HasController]).
+  static WidgetController? _focusControllerOf(dynamic value) {
+    if (value is WidgetController) {
+      return value;
+    }
+    if (value is HasController) {
+      final controller = value.controller;
+      if (controller is WidgetController) {
+        return controller;
+      }
+    }
+    return null;
+  }
+
   static Widget buildBareWidget(ScopeNode scopeNode, WidgetModel model,
       Map<WidgetModel, ModelPayload> modelMap) {
     if (model is CustomWidgetModel) {
@@ -356,14 +371,17 @@ class ViewUtil {
 
     Widget? w;
     Function? widgetInstance = WidgetRegistry().widgetMap[model.type];
+    // A rebuild swaps the controller while the TV focus wrapper's State/node
+    // persists. Carry `hasFocus` over so `${id.hasFocus}` doesn't read the new
+    // controller's default `false` and flash unfocused for a frame.
+    final String? widgetId = model.props['id']?.toString();
+    final dynamic previousContext = widgetId != null
+        ? scopeNode.scope.dataContext.getContextById(widgetId)
+        : null;
     if (widgetInstance != null) {
       EnsembleController? previousController;
-      String? id = model.props['id']?.toString();
-      if (id != null) {
-        dynamic controller = scopeNode.scope.dataContext.getContextById(id);
-        if (controller is EnsembleController) {
-          previousController = controller;
-        }
+      if (previousContext is EnsembleController) {
+        previousController = previousContext;
       }
       w = Function.apply(widgetInstance, [previousController]);
     } else {
@@ -375,6 +393,18 @@ class ViewUtil {
         if (widgetInstance != null) {
           w = widgetInstance.call();
         }
+      }
+    }
+
+    // Copy focus state onto the rebuilt controller before bindings are
+    // evaluated, so the first frame after a rebuild renders correctly.
+    if (previousContext != null && w != null) {
+      final previousFocusController = _focusControllerOf(previousContext);
+      final nextFocusController = _focusControllerOf(w);
+      if (previousFocusController != null &&
+          nextFocusController != null &&
+          previousFocusController.hasFocus) {
+        nextFocusController.hasFocus = true;
       }
     }
 

--- a/modules/ensemble/lib/framework/widget/view_util.dart
+++ b/modules/ensemble/lib/framework/widget/view_util.dart
@@ -348,21 +348,6 @@ class ViewUtil {
         child: customWidget);
   }
 
-  /// Returns the [WidgetController] behind [value] (a controller or a widget
-  /// that owns one via [HasController]).
-  static WidgetController? _focusControllerOf(dynamic value) {
-    if (value is WidgetController) {
-      return value;
-    }
-    if (value is HasController) {
-      final controller = value.controller;
-      if (controller is WidgetController) {
-        return controller;
-      }
-    }
-    return null;
-  }
-
   static Widget buildBareWidget(ScopeNode scopeNode, WidgetModel model,
       Map<WidgetModel, ModelPayload> modelMap) {
     if (model is CustomWidgetModel) {
@@ -371,9 +356,6 @@ class ViewUtil {
 
     Widget? w;
     Function? widgetInstance = WidgetRegistry().widgetMap[model.type];
-    // A rebuild swaps the controller while the TV focus wrapper's State/node
-    // persists. Carry `hasFocus` over so `${id.hasFocus}` doesn't read the new
-    // controller's default `false` and flash unfocused for a frame.
     final String? widgetId = model.props['id']?.toString();
     final dynamic previousContext = widgetId != null
         ? scopeNode.scope.dataContext.getContextById(widgetId)
@@ -396,15 +378,14 @@ class ViewUtil {
       }
     }
 
-    // Copy focus state onto the rebuilt controller before bindings are
-    // evaluated, so the first frame after a rebuild renders correctly.
-    if (previousContext != null && w != null) {
-      final previousFocusController = _focusControllerOf(previousContext);
-      final nextFocusController = _focusControllerOf(w);
-      if (previousFocusController != null &&
-          nextFocusController != null &&
-          previousFocusController.hasFocus) {
-        nextFocusController.hasFocus = true;
+    // Preserve ID-bound TV focus styles while a focused widget is rebuilt.
+    if (previousContext is HasController && w is HasController) {
+      final previousController = previousContext.controller;
+      final nextController = w.controller;
+      if (previousController is WidgetController &&
+          nextController is WidgetController &&
+          previousController.hasFocus) {
+        nextController.hasFocus = true;
       }
     }
 

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -524,25 +524,6 @@ void _saveTVRowPositionOnFocus(
   }
 }
 
-/// Re-asserts the live focus state on a controller swapped during a rebuild
-/// (the focus node persists, so `${id.hasFocus}` would otherwise stay stale).
-/// Dispatch is deferred to avoid `setState` during build. No-op when in sync.
-void _resyncControllerHasFocus(
-    BuildContext context, BoxController boxController, bool hasFocus) {
-  if (boxController.hasFocus == hasFocus) return;
-  boxController.hasFocus = hasFocus;
-  final widgetId = boxController.id;
-  if (widgetId == null) return;
-  final scopeManager = DataScopeWidget.getScope(context);
-  WidgetsBinding.instance.addPostFrameCallback((_) {
-    scopeManager?.dispatch(ModelChangeEvent(
-      WidgetBindingSource(widgetId, property: 'hasFocus'),
-      hasFocus,
-      bindingScope: scopeManager,
-    ));
-  });
-}
-
 /// Maps a curve name (from `tvOptions.scrollAnimationCurve`) to a [Curve].
 /// Supported: easeIn, easeOut, easeInOut, linear, decelerate, ease,
 /// fastOutSlowIn, bounceOut, elasticOut.
@@ -563,26 +544,6 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
     _instanceId = ++_instanceCounter;
     _focusNode = FocusNode(debugLabel: 'TapEnabledWrapper_$_instanceId');
     _focusNode.addListener(_onFocusChange);
-    // A new element may have inherited hasFocus from a widget with the same id.
-    // Correct it after mount (getScope() can't run in initState).
-    if (widget.boxController.hasFocus) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _resyncControllerHasFocus(
-              context, widget.boxController, _focusNode.hasFocus);
-        }
-      });
-    }
-  }
-
-  @override
-  void didUpdateWidget(covariant _TapEnabledWrapper oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // Rebuilt with a fresh BoxController: re-assert the live focus state.
-    if (!identical(oldWidget.boxController, widget.boxController)) {
-      _resyncControllerHasFocus(
-          context, widget.boxController, _focusNode.hasFocus);
-    }
   }
 
   @override
@@ -1109,31 +1070,6 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
   // Buttons then showed no focus ring or highlight.
   final FocusScopeNode _scopeNode =
       FocusScopeNode(debugLabel: 'TVFocusOnlyWrapper');
-
-  @override
-  void initState() {
-    super.initState();
-    // A new element may have inherited hasFocus from a widget with the same id.
-    // Correct it after mount (getScope() can't run in initState).
-    if (widget.boxController.hasFocus) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _resyncControllerHasFocus(
-              context, widget.boxController, _scopeNode.hasFocus);
-        }
-      });
-    }
-  }
-
-  @override
-  void didUpdateWidget(covariant _TVFocusOnlyWrapper oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // Rebuilt with a fresh BoxController: re-assert the live focus state.
-    if (!identical(oldWidget.boxController, widget.boxController)) {
-      _resyncControllerHasFocus(
-          context, widget.boxController, _scopeNode.hasFocus);
-    }
-  }
 
   @override
   void dispose() {

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -524,6 +524,25 @@ void _saveTVRowPositionOnFocus(
   }
 }
 
+/// Re-asserts the live focus state on a controller swapped during a rebuild
+/// (the focus node persists, so `${id.hasFocus}` would otherwise stay stale).
+/// Dispatch is deferred to avoid `setState` during build. No-op when in sync.
+void _resyncControllerHasFocus(
+    BuildContext context, BoxController boxController, bool hasFocus) {
+  if (boxController.hasFocus == hasFocus) return;
+  boxController.hasFocus = hasFocus;
+  final widgetId = boxController.id;
+  if (widgetId == null) return;
+  final scopeManager = DataScopeWidget.getScope(context);
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    scopeManager?.dispatch(ModelChangeEvent(
+      WidgetBindingSource(widgetId, property: 'hasFocus'),
+      hasFocus,
+      bindingScope: scopeManager,
+    ));
+  });
+}
+
 /// Maps a curve name (from `tvOptions.scrollAnimationCurve`) to a [Curve].
 /// Supported: easeIn, easeOut, easeInOut, linear, decelerate, ease,
 /// fastOutSlowIn, bounceOut, elasticOut.
@@ -544,6 +563,26 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
     _instanceId = ++_instanceCounter;
     _focusNode = FocusNode(debugLabel: 'TapEnabledWrapper_$_instanceId');
     _focusNode.addListener(_onFocusChange);
+    // A new element may have inherited hasFocus from a widget with the same id.
+    // Correct it after mount (getScope() can't run in initState).
+    if (widget.boxController.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _resyncControllerHasFocus(
+              context, widget.boxController, _focusNode.hasFocus);
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _TapEnabledWrapper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Rebuilt with a fresh BoxController: re-assert the live focus state.
+    if (!identical(oldWidget.boxController, widget.boxController)) {
+      _resyncControllerHasFocus(
+          context, widget.boxController, _focusNode.hasFocus);
+    }
   }
 
   @override
@@ -1070,6 +1109,31 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
   // Buttons then showed no focus ring or highlight.
   final FocusScopeNode _scopeNode =
       FocusScopeNode(debugLabel: 'TVFocusOnlyWrapper');
+
+  @override
+  void initState() {
+    super.initState();
+    // A new element may have inherited hasFocus from a widget with the same id.
+    // Correct it after mount (getScope() can't run in initState).
+    if (widget.boxController.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _resyncControllerHasFocus(
+              context, widget.boxController, _scopeNode.hasFocus);
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _TVFocusOnlyWrapper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Rebuilt with a fresh BoxController: re-assert the live focus state.
+    if (!identical(oldWidget.boxController, widget.boxController)) {
+      _resyncControllerHasFocus(
+          context, widget.boxController, _scopeNode.hasFocus);
+    }
+  }
 
   @override
   void dispose() {

--- a/modules/ensemble/lib/widget/helpers/box_wrapper.dart
+++ b/modules/ensemble/lib/widget/helpers/box_wrapper.dart
@@ -524,6 +524,28 @@ void _saveTVRowPositionOnFocus(
   }
 }
 
+/// Re-asserts the live focus state on a controller swapped during a rebuild.
+/// view_util carries `hasFocus` over onto the rebuilt controller, but that copy
+/// is one-directional — when the rebuild produced a new element whose FocusNode
+/// is not actually focused, `${id.hasFocus}` would stay `true` forever. This
+/// re-asserts the controller against the live node (no-op when in sync).
+/// Dispatch is deferred to avoid `setState` during build.
+void _resyncControllerHasFocus(
+    BuildContext context, BoxController boxController, bool hasFocus) {
+  if (boxController.hasFocus == hasFocus) return;
+  boxController.hasFocus = hasFocus;
+  final widgetId = boxController.id;
+  if (widgetId == null) return;
+  final scopeManager = DataScopeWidget.getScope(context);
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    scopeManager?.dispatch(ModelChangeEvent(
+      WidgetBindingSource(widgetId, property: 'hasFocus'),
+      hasFocus,
+      bindingScope: scopeManager,
+    ));
+  });
+}
+
 /// Maps a curve name (from `tvOptions.scrollAnimationCurve`) to a [Curve].
 /// Supported: easeIn, easeOut, easeInOut, linear, decelerate, ease,
 /// fastOutSlowIn, bounceOut, elasticOut.
@@ -544,6 +566,26 @@ class _TapEnabledWrapperState extends State<_TapEnabledWrapper> {
     _instanceId = ++_instanceCounter;
     _focusNode = FocusNode(debugLabel: 'TapEnabledWrapper_$_instanceId');
     _focusNode.addListener(_onFocusChange);
+    // A new element may have inherited hasFocus from a widget with the same id.
+    // Correct it after mount (getScope() can't run in initState).
+    if (widget.boxController.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _resyncControllerHasFocus(
+              context, widget.boxController, _focusNode.hasFocus);
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _TapEnabledWrapper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Rebuilt with a fresh BoxController: re-assert the live focus state.
+    if (!identical(oldWidget.boxController, widget.boxController)) {
+      _resyncControllerHasFocus(
+          context, widget.boxController, _focusNode.hasFocus);
+    }
   }
 
   @override
@@ -1070,6 +1112,31 @@ class _TVFocusOnlyWrapperState extends State<_TVFocusOnlyWrapper> {
   // Buttons then showed no focus ring or highlight.
   final FocusScopeNode _scopeNode =
       FocusScopeNode(debugLabel: 'TVFocusOnlyWrapper');
+
+  @override
+  void initState() {
+    super.initState();
+    // A new element may have inherited hasFocus from a widget with the same id.
+    // Correct it after mount (getScope() can't run in initState).
+    if (widget.boxController.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _resyncControllerHasFocus(
+              context, widget.boxController, _scopeNode.hasFocus);
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _TVFocusOnlyWrapper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Rebuilt with a fresh BoxController: re-assert the live focus state.
+    if (!identical(oldWidget.boxController, widget.boxController)) {
+      _resyncControllerHasFocus(
+          context, widget.boxController, _scopeNode.hasFocus);
+    }
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
## Description

This PR fixes `${id.hasFocus}` resetting to `false` when a focused TV widget is rebuilt after navigating back.

The previous widget controller is available through the widget ID context. The replacement controller now inherits its `hasFocus` value before bindings are evaluated, preventing ID-bound focus styles from rendering unfocused during the rebuild.

## Related Issue

<!-- Add the related issue or PR link here. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

### Preserve ID-bound focus state during rebuilds

- Look up the previous widget instance using its YAML `id`.
- When the previous controller has focus, copy `hasFocus` to the replacement controller before bindings run.
- Keep the existing TV focus node, navigation, scrolling, actions, and binding-dispatch behavior unchanged.

### Behavior Compatibility

- No changes to D-pad traversal, focus coordinates, navigation, actions, or scrolling.
- No expected mobile behavior change: `hasFocus` is set by the existing TV focus wrappers.
- The change applies only when an ID-bound widget is rebuilt and the previous controller is focused.

## How to Test

1. From `modules/ensemble`, run:

   ```bash
   flutter analyze lib/framework/widget/view_util.dart