### PR TITLE
feat(tab-bar): add overlay indicator option

### DIFF
--- a/modules/ensemble/assets/schema/ensemble_schema.json
+++ b/modules/ensemble/assets/schema/ensemble_schema.json
@@ -6786,6 +6786,10 @@
                   "$ref": "#/$defs/type-color",
                   "description": "The color of the tabbar divider color"
                 },
+                "overlayIndicator": {
+                  "type": "boolean",
+                  "description": "Whether the indicator overlaps the divider"
+                },
                 "inactiveTabColor": {
                   "$ref": "#/$defs/type-color",
                   "description": "The color of the un-selected tabs' text"

--- a/modules/ensemble/lib/layout/tab/base_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/base_tab_bar.dart
@@ -69,6 +69,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
     final tabAlignment =
         TabAlignment.values.from(widget.controller.tabAlignment) ??
             TabAlignment.start;
+    final overlayIndicator = widget.controller.overlayIndicator ?? false;
 
     final dividerColor = widget.controller.dividerColor ?? Colors.transparent;
     final dividerThickness =
@@ -78,7 +79,9 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
     // dividerHeight reserves no height -- Material paints the divider inside
     // the tab row (tabs.dart:2049) -- so lay our own out below the tabs.
     final wantsCustomDivider = widget.controller.dividerColor != null &&
-        (dividerPadding != null || widget.controller.dividerThickness != null);
+        (dividerPadding != null ||
+            widget.controller.dividerThickness != null ||
+            widget.controller.overlayIndicator != null);
 
     Widget tabBar = TabBar(
         labelPadding: labelPadding,
@@ -120,19 +123,31 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         ),
       );
 
-      // Column, not a Stack overlay: keeps the divider off the indicator, and
-      // keeps the TabBar's width tight -- under a Stack's loose constraints
-      // dividerHeight 0 makes Flutter shrink-wrap the tabs (tabs.dart:2044).
-      tabBar = Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          tabBar,
-          SizedBox(height: dividerPadding?.top ?? 0),
-          divider,
-          SizedBox(height: dividerPadding?.bottom ?? 0),
-        ],
-      );
+      if (overlayIndicator) {
+        tabBar = Stack(
+          children: [
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: dividerThickness,
+              child: divider,
+            ),
+            tabBar,
+          ],
+        );
+      } else {
+        tabBar = Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            tabBar,
+            SizedBox(height: dividerPadding?.top ?? 0),
+            divider,
+            SizedBox(height: dividerPadding?.bottom ?? 0),
+          ],
+        );
+      }
     }
 
     if (widget.controller.tabBackgroundColor != null) {
@@ -177,6 +192,7 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
     final dividerThickness =
         widget.controller.dividerThickness?.toDouble() ?? 1;
     final dividerPadding = widget.controller.dividerPadding;
+    final overlayIndicator = widget.controller.overlayIndicator ?? false;
     final indicatorThickness =
         widget.controller.indicatorThickness?.toDouble() ?? 2;
 
@@ -268,7 +284,8 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
         // predates this feature and TV never drew a line for it.
         if (widget.controller.dividerColor == null ||
             (dividerPadding == null &&
-                widget.controller.dividerThickness == null)) {
+                widget.controller.dividerThickness == null &&
+                widget.controller.overlayIndicator == null)) {
           return tabRow;
         }
 
@@ -283,7 +300,21 @@ abstract class BaseTabBarState extends EWidgetState<BaseTabBar>
           ),
         );
 
-        // Same as mobile: divider below the tabs, not overlaid on it.
+        if (overlayIndicator) {
+          return Stack(
+            children: [
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: dividerThickness,
+                child: divider,
+              ),
+              tabRow,
+            ],
+          );
+        }
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisSize: MainAxisSize.min,

--- a/modules/ensemble/lib/layout/tab/scrollable_tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab/scrollable_tab_bar.dart
@@ -80,6 +80,8 @@ class ScrollableTabBar extends BaseTabBar {
           _controller.dividerThickness = Utils.optionalInt(thickness, min: 0),
       'dividerPadding': (padding) =>
           _controller.dividerPadding = Utils.optionalInsets(padding),
+      'overlayIndicator': (overlay) =>
+          _controller.overlayIndicator = Utils.optionalBool(overlay),
       'selectedIndex': (index) =>
           _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
       'onTabSelection': (action) => _controller.onTabSelection =

--- a/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
+++ b/modules/ensemble/lib/layout/tab/tab_bar_controller.dart
@@ -29,6 +29,7 @@ class TabBarController extends BoxController {
   Color? dividerColor;
   int? dividerThickness;
   EdgeInsets? dividerPadding;
+  bool? overlayIndicator;
   Color? focusIndicatorColor; // TV D-pad: focus-state indicator color (fallback blue)
   Color? focusTabColor; // TV D-pad: focus-state tab text color (fallback white)
   int? indicatorThickness;

--- a/modules/ensemble/lib/layout/tab_bar.dart
+++ b/modules/ensemble/lib/layout/tab_bar.dart
@@ -100,6 +100,8 @@ abstract class BaseTabBar extends StatefulWidget
           _controller.dividerThickness = Utils.optionalInt(thickness, min: 0),
       'dividerPadding': (padding) =>
           _controller.dividerPadding = Utils.optionalInsets(padding),
+      'overlayIndicator': (overlay) =>
+          _controller.overlayIndicator = Utils.optionalBool(overlay),
       'selectedIndex': (index) =>
           _controller.selectedIndex = Utils.getInt(index, min: 0, fallback: 0),
       'onTabSelection': (action) => _controller.onTabSelection =


### PR DESCRIPTION
## Description

This PR adds an optional `overlayIndicator` property to the Ensemble `TabBar`. It allows the selected/focused indicator to overlap the divider, which is required for the Android TV TabBar layout.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## What Has Changed

### TabBar overlay indicator

- Added the nullable `overlayIndicator` boolean property.
- Added YAML support for both `TabBar` and `ScrollableTabBar`.
- Added schema metadata for the new property.
- Added overlay rendering for standard and TV TabBar implementations.
- Kept the existing divider and indicator behavior when the property is omitted or set to `false`.
- Preserved existing TV focus coordinates, navigation, scrolling, and tab selection behavior.

### Usage

```yaml
TabBar:
  styles:
    dividerColor: 0xFF232323
    dividerThickness: 3
    dividerPadding: 4 40 0 40
    overlayIndicator: true